### PR TITLE
Update s3stat.py to properly deal with multi-region

### DIFF
--- a/tools/s3stat.py
+++ b/tools/s3stat.py
@@ -68,20 +68,35 @@ def main():
    logging.basicConfig(level=logging.INFO)
    
    bucket = os.environ.get('BUCKET')
-   s = boto3.Session()
-   cw = s.client('cloudwatch')
-   s3 = s.client('s3')
-   buckets = s3.list_buckets()['Buckets'] 
-
+   
    results = {'buckets':[]}
    size_count = obj_count = 0.0
+   regions = ['eu-west-1',
+              'ap-southeast-1',
+              'ap-southeast-2',
+              'eu-central-1',
+              'ap-northeast-2',
+              'ap-northeast-1',
+              'us-east-1',
+              'sa-east-1',
+              'us-west-1',
+              'us-west-2']
+   for region in regions:
 
-   for b in buckets:
-      i = bucket_info(cw, b['Name'])
-      results['buckets'].append(i)
-      obj_count += i['ObjectCount']
-      size_count += i['SizeGB']
- 
+        s = boto3.Session(region_name=region)
+        cw = s.client('cloudwatch')
+        s3 = s.client('s3')
+        buckets = s3.list_buckets()['Buckets']
+
+        for b in buckets:
+              i = bucket_info(cw, b['Name'])
+              bucket_region = s3.get_bucket_location(Bucket=b['Name'])['LocationConstraint']
+              # bucket_region is `None` when it is in us-east-1 (US Standard)
+              if bucket_region == region or bucket_region == None:
+                results['buckets'].append(i)
+                obj_count += i['ObjectCount']
+                size_count += i['SizeGB']
+
    results['TotalObjects'] = obj_count
    results['TotalSizeGB'] = size_count
 

--- a/tools/s3stat.py
+++ b/tools/s3stat.py
@@ -71,31 +71,20 @@ def main():
    
    results = {'buckets':[]}
    size_count = obj_count = 0.0
-   regions = ['eu-west-1',
-              'ap-southeast-1',
-              'ap-southeast-2',
-              'eu-central-1',
-              'ap-northeast-2',
-              'ap-northeast-1',
-              'us-east-1',
-              'sa-east-1',
-              'us-west-1',
-              'us-west-2']
-   for region in regions:
 
-        s = boto3.Session(region_name=region)
-        cw = s.client('cloudwatch')
-        s3 = s.client('s3')
-        buckets = s3.list_buckets()['Buckets']
+   s = boto3.Session()
+   s3 = s.client('s3')
+   buckets = s3.list_buckets()['Buckets']
 
-        for b in buckets:
-              i = bucket_info(cw, b['Name'])
-              bucket_region = s3.get_bucket_location(Bucket=b['Name'])['LocationConstraint']
-              # bucket_region is `None` when it is in us-east-1 (US Standard)
-              if bucket_region == region or bucket_region == None:
-                results['buckets'].append(i)
-                obj_count += i['ObjectCount']
-                size_count += i['SizeGB']
+   for b in buckets:
+      bucket_region = s3.get_bucket_location(Bucket=b['Name'])['LocationConstraint']
+      # get the cloudwatch session for the region the bucket is in
+      cw = s.client('cloudwatch', region_name=bucket_region)
+      i = bucket_info(cw, b['Name'])
+
+      results['buckets'].append(i)
+      obj_count += i['ObjectCount']
+      size_count += i['SizeGB']
 
    results['TotalObjects'] = obj_count
    results['TotalSizeGB'] = size_count


### PR DESCRIPTION
The results dict would show empty when the bucket was not in the same region that the boto3.Session() was established in. Not sure if it is a bug with cloudwatch or not, but this fix is working for my needs.