### PR TITLE
create cache folder if nonexistant

### DIFF
--- a/c7n/cache.py
+++ b/c7n/cache.py
@@ -27,11 +27,11 @@ log = logging.getLogger('c7n.cache')
 def factory(config):
     if not config:
         return NullCache(None)
-    
+
     if not config.cache or not config.cache_period:
-        log.info("Disabling cache")    
+        log.info("Disabling cache")
         return NullCache(config)
-    
+
     return FileCacheManager(config)
 
 
@@ -45,11 +45,11 @@ class NullCache(object):
 
     def get(self, key):
         pass
-    
+
     def save(self, key, data):
         pass
-    
-    
+
+
 class FileCacheManager(object):
 
     def __init__(self, config):
@@ -64,7 +64,7 @@ class FileCacheManager(object):
     def get(self, key):
         k = cPickle.dumps(key)
         return self.data.get(k)
-        
+
     def load(self):
         if os.path.isfile(self.cache_path):
             if (time.time() - os.stat(self.cache_path).st_mtime >
@@ -74,7 +74,7 @@ class FileCacheManager(object):
                 self.data = cPickle.load(fh)
             log.info("Using cache file %s" % self.cache_path)
             return True
-        
+
     def save(self, key, data):
         try:
             with open(self.cache_path, 'w') as fh:
@@ -83,3 +83,11 @@ class FileCacheManager(object):
         except Exception as e:
             log.warning("Could not save cache %s err: %s" % (
                 self.cache_path, e))
+            if not os.path.exists(self.cache_path):
+                directory = os.path.dirname(self.cache_path)
+                log.info('Generating Cache directory: %s.' % directory)
+                try:
+                    os.makedirs(directory)
+                except Exception as e:
+                    log.warning("Could not create directory: %s err: %s" % (
+                        directory, e))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -15,3 +15,85 @@
 
 from unittest import TestCase
 from c7n import cache
+from argparse import Namespace
+import cPickle
+import tempfile
+import mock
+
+
+class FileCacheManagerTest(TestCase):
+    def setUp(self):
+        self.test_config = Namespace(cache_period=60, cache='test-cloud-custodian.cache')
+        self.test_cache = cache.FileCacheManager(self.test_config)
+        self.test_key = 'test'
+        self.bad_key = 'bad'
+        self.test_value = [1, 2, 3]
+
+
+    def test_get(self):
+        #mock the pick and set it to the data variable
+        test_pickle = cPickle.dumps({cPickle.dumps(self.test_key): self.test_value}, protocol=2)
+        self.test_cache.data = cPickle.loads(test_pickle)
+
+        #assert
+        self.assertEquals(self.test_cache.get(self.test_key), self.test_value)
+        self.assertEquals(self.test_cache.get(self.bad_key), None)
+
+
+
+    def test_load(self):
+        pass
+
+
+    @mock.patch.object(cache.os, 'makedirs')
+    @mock.patch.object(cache.os.path, 'exists')
+    @mock.patch.object(cache.cPickle, 'dump')
+    @mock.patch.object(cache.cPickle, 'dumps')
+    def test_save_exists(self, mock_dumps, mock_dump, mock_exists, mock_mkdir):
+        #path exists then we dont need to create the folder
+        mock_exists.return_value = True
+        #tempfile to hold the pickle
+        temp_cache_file = tempfile.NamedTemporaryFile()
+        self.test_cache.cache_path = temp_cache_file.name
+        #make the call
+        self.test_cache.save(self.test_key, self.test_value)
+
+        #assert if file already exists
+        self.assertFalse(mock_mkdir.called)
+        self.assertTrue(mock_dumps.called)
+        self.assertTrue(mock_dump.called)
+
+        #mkdir should NOT be called, but pickles should
+        self.assertEquals(mock_mkdir.call_count,0)
+        self.assertEquals(mock_dump.call_count,1)
+        self.assertEquals(mock_dumps.call_count,1)
+
+
+
+
+    @mock.patch.object(cache.os, 'makedirs')
+    @mock.patch.object(cache.os.path, 'exists')
+    @mock.patch.object(cache.cPickle, 'dump')
+    @mock.patch.object(cache.cPickle, 'dumps')
+    def test_save_doesnt_exists(self, mock_dumps, mock_dump, mock_exists, mock_mkdir):
+
+        temp_cache_file = tempfile.NamedTemporaryFile()
+        self.test_cache.cache_path = temp_cache_file.name
+
+        #path doesnt exists then we will create the folder
+        #raise some sort of exception in the try
+        mock_exists.return_value = False
+        mock_dump.side_effect = Exception('Error')
+
+        #make the call
+        self.test_cache.save(self.test_key, self.test_value)
+
+        #assert if file doesnt exists
+        self.assertTrue(mock_mkdir.called)
+        self.assertTrue(mock_dumps.called)
+        self.assertTrue(mock_dump.called)
+
+        #all 3 should be called once
+        self.assertEquals(mock_mkdir.call_count,1)
+        self.assertEquals(mock_dump.call_count,1)
+        self.assertEquals(mock_dumps.call_count,1)

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -41,10 +41,6 @@ class FileCacheManagerTest(TestCase):
 
 
 
-    def test_load(self):
-        pass
-
-
     @mock.patch.object(cache.os, 'makedirs')
     @mock.patch.object(cache.os.path, 'exists')
     @mock.patch.object(cache.cPickle, 'dump')


### PR DESCRIPTION
Was having some problems with rebasing the out of sync PR/Branch so I just figured it would be easier to submit a new PR:

Fix for #16 

* Adding some unittests for cache.py
* Logic to ensure if the folder path doesn't exist will create the folder before trying to save the cache file