### PR TITLE
ImageAge filter NotImplementedError fix

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -182,6 +182,8 @@ class InstanceImageBase(object):
 @filters.register('image-age')
 class ImageAge(AgeFilter, InstanceImageBase):
 
+    date_attribute = "CreationDate"
+
     schema = type_schema('image-age', days={'type': 'number'})
 
     def process(self, resources, event=None):


### PR DESCRIPTION
Adding a fix to the ImageAge filter. Custodian was raising a NotImplementedError on ImageAge because the date_attribute property wasn't defined in the filter. Setting date_attribute = 'CreationDate' resolved the error.