### PR TITLE
Add an ELB action to set SSL listener policy

### DIFF
--- a/docs/source/policy/resources/elb.rst
+++ b/docs/source/policy/resources/elb.rst
@@ -22,3 +22,6 @@ Actions
 
 ``delete``
   Delete ELB
+
+``set-ssl-listener-policy``
+  Set SSL listener policy

--- a/docs/source/usecases/usecases/elbsslwhitelist.rst
+++ b/docs/source/usecases/usecases/elbsslwhitelist.rst
@@ -15,9 +15,11 @@ ELB - SSL Whitelist
          - SetLoadBalancerPoliciesOfListener
      filters:
        - type: ssl-policy
-         whitelist:
+         whitelist: &POLICY
            - Protocol-TLSv1
            - Protocol-TLSv1.1
            - Protocol-TLSv1.2
      actions:
-       - delete
+       - type: set-ssl-listener-policy
+         name: CustodianEnforcedPolicy
+         attributes: *POLICY


### PR DESCRIPTION
* Add ELB 'set-ssl-listener-policy' action
* This action can be used in conjunction with the SSL whitelist filter