### PR TITLE
Quick fix to ResourceManager's filter_resources function

### DIFF
--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -56,6 +56,8 @@ class ResourceManager(object):
         return []
     
     def filter_resources(self, resources, event=None):
+        if not resources:
+            return []
         original = len(resources)
         for f in self.filters:
             if event and event['debug']:

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -182,6 +182,8 @@ class InstanceImageBase(object):
 @filters.register('image-age')
 class ImageAge(AgeFilter, InstanceImageBase):
 
+    date_attribute = "CreationDate"
+
     schema = type_schema('image-age', days={'type': 'number'})
 
     def process(self, resources, event=None):


### PR DESCRIPTION
The filter_resources function in ResourceManager in manager.py would throw an error upon calling len(resources) if resources was a NoneType (which happened in certain instances where _cache.get() returns None). Added in a quick check to verify that resources was a list.