### PR TITLE
Rds elb tags

### DIFF
--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -14,6 +14,7 @@
 import logging
 
 from c7n import cache
+from c7n.executor import ThreadPoolExecutor
 from c7n.registry import PluginRegistry
 from c7n.utils import dumps
 
@@ -27,7 +28,9 @@ class ResourceManager(object):
     action_registry = None
 
     supports_dry_run = False
-    
+
+    executor_factory = ThreadPoolExecutor
+
     def __init__(self, ctx, data):
         self.ctx = ctx
         self.session_factory = ctx.session_factory

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -69,6 +69,8 @@ from c7n.filters import FilterRegistry, Filter
 from c7n.manager import ResourceManager, resources
 from c7n.utils import local_session, type_schema
 
+from functools import partial
+
 log = logging.getLogger('custodian.rds')
 
 
@@ -96,7 +98,7 @@ class RDS(ResourceManager):
         p = c.get_paginator('describe_db_instances')
         results = p.paginate(Filters=query)
         dbs = list(itertools.chain(
-            *[rp['DBInstances'] for rp in results]))
+            *[self.add_tags(c, rp['DBInstances']) for rp in results]))
         self._cache.save(
             {'region': self.config.region, 'resource': 'rds', 'q': query}, dbs)
         return self.filter_resources(dbs)
@@ -109,6 +111,46 @@ class RDS(ResourceManager):
                 c.describe_db_instances(
                     DBInstanceIdentifier=db_id)['DBInstances'])
         return results
+
+    def add_tags(self, client, dbs):
+        """
+        Adds the tags to the list of databases
+        """
+        account_id = self.get_account_id()
+        fn = partial(self.process_tags, account_id=account_id ,client=client)
+        with self.executor_factory(max_workers=3) as w:
+            return list(w.map(fn,dbs))
+
+    def process_tags(self, db, **kwargs):
+        region = self.get_region(db)
+        name = db['DBInstanceIdentifier']
+        arn = "arn:aws:rds:%s:%s:db:%s" % (region, kwargs['account_id'], name)
+        tag_list = (
+            kwargs['client'].list_tags_for_resource(ResourceName=arn)['TagList']
+        )
+        tags = []
+        if tag_list:
+            tags.extend(tag_list)
+        db['Tags'] = tags
+        return db
+
+    def get_account_id(self):
+        # TODO: This just gets a security group in the account
+        # and uses that as the ARN of the account. See notes
+        # at top of file for how else we can do this
+        client = self.session_factory().client('ec2')
+        account_id = (
+            client.describe_security_groups()['SecurityGroups'][0]['OwnerId']
+        )
+        return account_id
+
+    def get_region(self, db):
+        # get the region from the endpoint
+        endpoint_parts = db['Endpoint']['Address'].split('.')
+
+        # format is "<db-id>.<region>.rds.amazonaws.com"
+        region = endpoint_parts[-4]
+        return region
 
 
 @filters.register('default-vpc')

--- a/tests/data/placebo/test_healthcheck_protocol_mismatch/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_healthcheck_protocol_mismatch/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,63 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "00000000-0000-0000-0000-000000000000"
+        }, 
+        "TagDescriptions": [
+            {
+                "Tags": [
+                    {
+                        "Value": "value1", 
+                        "Key": "tag1"
+                    }, 
+                    {
+                        "Value": "value2", 
+                        "Key": "tag2"
+                    }
+                ], 
+                "LoadBalancerName": "test-elb-protocol-mismatch"
+            },
+            {
+                "Tags": [
+                    {
+                        "Value": "value1", 
+                        "Key": "tag1"
+                    }, 
+                    {
+                        "Value": "value2", 
+                        "Key": "tag2"
+                    }
+                ], 
+                "LoadBalancerName": "test-elb-protocol-matches"
+            },
+            {
+                "Tags": [
+                    {
+                        "Value": "value1", 
+                        "Key": "tag1"
+                    }, 
+                    {
+                        "Value": "value2", 
+                        "Key": "tag2"
+                    }
+                ], 
+                "LoadBalancerName": "test-elb-no-listeners"
+            },
+            {
+                "Tags": [
+                    {
+                        "Value": "value1", 
+                        "Key": "tag1"
+                    }, 
+                    {
+                        "Value": "value2", 
+                        "Key": "tag2"
+                    }
+                ], 
+                "LoadBalancerName": "test-elb-multiple-listeners"
+            }            
+        ]
+    }
+}

--- a/tests/data/placebo/test_ssl_ciphers/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_ssl_ciphers/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "00000000-0000-0000-0000-000000000000"
+        }, 
+        "TagDescriptions": [
+            {
+                "Tags": [
+                    {
+                        "Value": "value1", 
+                        "Key": "tag1"
+                    }, 
+                    {
+                        "Value": "value2", 
+                        "Key": "tag2"
+                    }
+                ], 
+                "LoadBalancerName": "test-elb-valid-policy"
+            },
+            {
+                "Tags": [
+                    {
+                        "Value": "value1", 
+                        "Key": "tag1"
+                    }, 
+                    {
+                        "Value": "value2", 
+                        "Key": "tag2"
+                    }
+                ], 
+                "LoadBalancerName": "test-elb-invalid-policy"
+            }              
+        ]
+    }
+}


### PR DESCRIPTION
Added tag support for RDS and ELB - #35 and #40. Did these together since they were pretty similar.

Approach to get RDS ARN was to just grab a security group from the account and get the ARN as suggested http://stackoverflow.com/questions/32634402/work-with-rds-tags-in-boto3-how-to-get-arn-in-boto3. This is a bit hacky. I saw your note on maybe using an attribute for account - that could be a next pass, but I think the SG way will work for a first pass.