### PR TITLE
Notify improvements

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -142,6 +142,8 @@ class Notify(EventAction):
         'properties': {
             'type': {'enum': ['notify']},
             'to': {'type': 'array', 'items': {'type': 'string'}},
+            'cc_manager': {'type': 'boolean'},
+            'from': {'type': 'string'},
             'subject': {'type': 'string'},
             'template': {'type': 'string'},
             'transport': {
@@ -156,11 +158,12 @@ class Notify(EventAction):
     }
 
     def process(self, resources, event=None):
-        message = {'resources': resources,
-                   'event': event,
-                   'action': self.data,
-                   'policy': self.manager.data}
-        self.send_data_message(message)
+        for batch in utils.chunks(resources, 500):
+            message = {'resources': resources,
+                       'event': event,
+                       'action': self.data,
+                       'policy': self.manager.data}            
+            self.send_data_message(message)
 
     def send_data_message(self, message):
         if self.data['transport']['type'] == 'sqs':

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -131,6 +131,11 @@ def chunks(iterable, size=50):
         yield batch
 
 
+def get_account_id(session):
+    iam = session.client('iam')
+    return iam.list_roles(MaxItems=1)['Roles'][0]['Arn'].split(":")[4]
+
+
 def query_instances(session, client=None, **query):
     """Return a list of ec2 instances for the query.
     """


### PR DESCRIPTION
allow spec of 'from' address, 'cc_manager' booleans, and also automatically chunk resources into batches of 500 to stay under the 264k limit (in addition to zlib/b64 encode).