### PR TITLE
various enhancements to cwe, asg, elb, rds, offhours, and schema

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -14,15 +14,19 @@
 
 import argparse
 import logging
+import os
 
 from c7n import commands, resources
 
 
 def _default_options(p):
-    p.add_argument("-r", "--region", default="us-east-1",
-                   help="AWS Region to target (Default: us-east-1)")
-    p.add_argument("--profile", default=None,
-                   help="AWS Account Config File Profile to utilize")
+    p.add_argument(
+        "-r", "--region",
+        default=os.environ.get('AWS_DEFAULT_REGION', "us-east-1"),
+        help="AWS Region to target (Default: us-east-1)")
+    p.add_argument(
+        "--profile", default=os.environ.get('AWS_PROFILE'),
+        help="AWS Account Config File Profile to utilize")
     p.add_argument("--assume", default=None, dest="assume_role",
                    help="Role to assume")
     p.add_argument("-c", "--config", required=True,

--- a/c7n/offhours.py
+++ b/c7n/offhours.py
@@ -129,6 +129,8 @@ import logging
 
 from dateutil import zoneinfo
 
+from c7n.utils import type_schema
+
 DEFAULT_TAG = "maid_offhours"
 
 TZ_ALIASES = {
@@ -282,12 +284,20 @@ class Time(Filter):
 
 class OffHour(Time):
 
+    schema = type_schema(
+        'offhour', rinherit=Time.schema, required=['offhour', 'default_tz'],
+        offhour={'type': 'integer', 'minimum': 0, 'maximum': 24})
+
     def get_sentinel_time(self, tz):
         t = super(OffHour, self).get_sentinel_time(tz)
         return t.replace(hour=self.data.get('offhour', DEFAULT_OFFHOUR))
 
                          
 class OnHour(Time):
+
+    schema = type_schema(
+        'onhour', rinherit=Time.schema, required=['onhour', 'default_tz'],
+        onhour={'type': 'integer', 'minimum': 0, 'maximum': 24})
 
     def get_sentinel_time(self, tz):
         t = super(OnHour, self).get_sentinel_time(tz)

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -124,7 +124,7 @@ class Policy(object):
 
         resource_ids = CloudWatchEvents.get_ids(event, mode)
         if resource_ids is None:
-            raise ValueError("Invalid push event mode %s" % self.data)
+            raise ValueError("Unknown push event mode %s" % self.data)
 
         self.log.info('Found resource ids: %s' % resource_ids)
         if not resource_ids:

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -51,6 +51,15 @@ class ASG(ResourceManager):
     filter_registry = filters
     action_registry = actions
 
+    def get_resources(self, asg_names):
+        c = local_session(self.session_factory).client('autoscaling')
+        try:
+            return c.describe_auto_scaling_groups(
+                AutoScalingGroupNames=asg_names)['AutoScalingGroups']
+        except ClientError as e:
+            log.warning("event, cwe not found: %s" % (asg_names))
+            return []
+
     def resources(self):
         c = self.session_factory().client('autoscaling')
         if self._cache.load():

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -570,12 +570,12 @@ class ScanBucket(BucketActionBase):
     def _process_bucket(self, b, p, key_log, w):
         content_key = self.get_bucket_op(b, 'contents_key')
         count = 0
+
         for key_set in p:
             count += len(key_set.get(content_key, []))
 
             # Empty bucket check
-            if not content_key in key_set and not key_set['IsTruncated']:
-                # annotate bucket
+            if content_key not in key_set and not key_set['IsTruncated']:
                 b['KeyScanCount'] = count
                 b['KeyRemediated'] = key_log.count
                 return {'Bucket': b['Name'],
@@ -604,7 +604,10 @@ class ScanBucket(BucketActionBase):
                 log.info('Scan Complete bucket:%s keys:%d remediated:%d',
                          b['Name'], count, key_log.count)
 
-        return {'Bucket': b['Name'], 'Remediated': key_log.count, 'Count': count}
+        b['KeyScanCount'] = count
+        b['KeyRemediated'] = key_log.count
+        return {
+            'Bucket': b['Name'], 'Remediated': key_log.count, 'Count': count}
 
     def process_chunk(self, batch, bucket):
         raise NotImplementedError()

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -139,6 +139,7 @@ def generate(resource_types=()):
                 'comment': {'type': 'string'},
                 'comments': {'type': 'string'},                
                 'description': {'type': 'string'},
+                'tags': {'type': 'array', 'items': {'type': 'string'}},
                 'mode': {'$ref': '#/definitions/policy-mode'},
                 'actions': {
                     'type': 'array',
@@ -171,9 +172,16 @@ def generate(resource_types=()):
                         'asg-instance-state',
                         'periodic'
                     ]},
-                'events': {'type': 'array', 'items': {'type': 'string'}},
-                'sources': {'type': 'array', 'items': {'type': 'string'}},
-                'ids': {'type': 'string'}
+                'events': {'type': 'array', 'items': {
+                    'oneOf': [
+                        {'type': 'string'},
+                        {'type': 'object',
+                         'required': ['event', 'source', 'ids'],
+                         'properties': {
+                             'source': {'type': 'string'},
+                             'ids': {'type': 'string'},
+                             'event': {'type': 'string'}}}]
+                    }}
             },
         },    
     }
@@ -193,6 +201,7 @@ def generate(resource_types=()):
         'required': ['policies'],
         'additionalProperties': False,
         'properties': {
+            'vars': {'type': 'object'},
             'policies': {
                 'type': 'array',
                 'additionalItems': False,

--- a/c7n/version.py
+++ b/c7n/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = "0.8.10"
+version = "0.8.11"

--- a/setup.py
+++ b/setup.py
@@ -3,7 +3,7 @@ from setuptools import setup, find_packages
 
 setup(
     name="c7n",
-    version='0.8.10',
+    version='0.8.11',
     description="Cloud Custodian - Policy Rules Engine",
     long_description_markdown_filename='README.md',
     classifiers=[

--- a/tests/common.py
+++ b/tests/common.py
@@ -139,7 +139,7 @@ class Config(Bag):
     def empty(cls, **kw):
         d = {}
         d.update({
-            'region': "us-east-1",
+            'region': os.environ.get('AWS_DEFAULT_REGION', "us-east-1"),
             'cache': '',
             'profile': None,
             'assume_role': None,

--- a/tests/data/cwe/event-asg-instance-failed.json
+++ b/tests/data/cwe/event-asg-instance-failed.json
@@ -1,0 +1,28 @@
+{
+    "account": "619193117841",
+    "region": "us-west-2",
+    "detail": {
+	"EndTime": "2016-05-21T16:43:34.000Z",
+	"Description": "Launching a new EC2 instance.  Status Reason: snapshotId can only be modified on EBS devices. Launching EC2 instance failed.",
+	"AutoScalingGroupName": "CustodianTest",
+	"ActivityId": "0e9d8daa-1fb8-4d84-91e0-0c4e57800be4",
+	"EC2InstanceId": "",
+	"Details": {
+	    "Availability Zone": "us-west-2b",
+	    "Subnet ID": "subnet-3f9e3d54"
+	},
+	"StartTime": "2016-05-21T16:43:34.112Z",
+	"StatusCode": "Failed",
+	"Cause": "At 2016-05-21T16:43:20Z a user request created an AutoScalingGroup changing the desired capacity from 0 to 3.  At 2016-05-21T16:43:32Z an instance was started in response to a difference between desired and actual capacity, increasing the capacity from 0 to 3.",
+	"StatusMessage": "snapshotId can only be modified on EBS devices. Launching EC2 instance failed.",
+	"RequestId": "0e9d8daa-1fb8-4d84-91e0-0c4e57800be4"
+    },
+    "detail-type": "EC2 Instance Launch Unsuccessful",
+    "source": "aws.autoscaling",
+    "version": "0",
+    "time": "2016-05-21T16:43:34Z",
+    "id": "6318c183-0f23-41a5-84e1-a0106fbc4da1",
+    "resources": [
+	"arn:aws:autoscaling:us-west-2:619193117841:autoScalingGroup:d2323979-c12a-4509-a97b-4b0589c06325:autoScalingGroupName/CustodianTest"
+    ]
+}

--- a/tests/data/cwe/event-cloud-trail-run-instances.json
+++ b/tests/data/cwe/event-cloud-trail-run-instances.json
@@ -1,0 +1,275 @@
+{
+    "eventVersion": "1.03",
+    "userIdentity": {
+        "type": "Root",
+        "principalId": "619193117841",
+        "arn": "arn:aws:iam::619193117841:root",
+        "accountId": "619193117841",
+        "invokedBy": "autoscaling.amazonaws.com"
+    },
+    "eventTime": "2016-05-21T16:11:14Z",
+    "eventSource": "ec2.amazonaws.com",
+    "eventName": "RunInstances",
+    "awsRegion": "us-west-1",
+    "sourceIPAddress": "autoscaling.amazonaws.com",
+    "userAgent": "autoscaling.amazonaws.com",
+    "requestParameters": {
+        "instancesSet": {
+            "items": [
+                {
+                    "imageId": "ami-06116566",
+                    "minCount": 1,
+                    "maxCount": 2,
+                    "keyName": "PersonalWest"
+                }
+            ]
+        },
+        "groupSet": {
+            "items": [
+                {
+                    "groupId": "sg-bd2d87d9"
+                }
+            ]
+        },
+        "instanceType": "t2.micro",
+        "blockDeviceMapping": {
+            "items": [
+                {
+                    "deviceName": "/dev/sdb",
+                    "ebs": {
+                        "volumeSize": 8,
+                        "deleteOnTermination": true,
+                        "volumeType": "gp2",
+                        "encrypted": false
+                    }
+                },
+                {
+                    "deviceName": "/dev/sda1",
+                    "ebs": {
+                        "volumeSize": 8,
+                        "deleteOnTermination": true,
+                        "volumeType": "gp2"
+                    }
+                },
+                {
+                    "deviceName": "/dev/sdc",
+                    "noDevice": {}
+                }
+            ]
+        },
+        "availabilityZone": "us-west-1c",
+        "monitoring": {
+            "enabled": false
+        },
+        "subnetId": "subnet-5f7a3106",
+        "disableApiTermination": false,
+        "clientToken": "d4673c83-0aaf-4e52-b2a8-99bf7dfbe074_subnet-5f7a3106_2",
+        "iamInstanceProfile": {
+            "name": "BaseIAMRole"
+        }
+    },
+    "responseElements": {
+        "reservationId": "r-05b201b7",
+        "ownerId": "619193117841",
+        "groupSet": {},
+        "instancesSet": {
+            "items": [
+                {
+                    "instanceId": "i-784cdacd",
+                    "imageId": "ami-06116566",
+                    "instanceState": {
+                        "code": 0,
+                        "name": "pending"
+                    },
+                    "privateDnsName": "ip-172-30-2-156.us-west-1.compute.internal",
+                    "keyName": "PersonalWest",
+                    "amiLaunchIndex": 1,
+                    "productCodes": {},
+                    "instanceType": "t2.micro",
+                    "launchTime": 1463847074000,
+                    "placement": {
+                        "availabilityZone": "us-west-1c",
+                        "tenancy": "default"
+                    },
+                    "monitoring": {
+                        "state": "disabled"
+                    },
+                    "subnetId": "subnet-5f7a3106",
+                    "vpcId": "vpc-1b4a1b7e",
+                    "privateIpAddress": "172.30.2.156",
+                    "stateReason": {
+                        "code": "pending",
+                        "message": "pending"
+                    },
+                    "architecture": "x86_64",
+                    "rootDeviceType": "ebs",
+                    "rootDeviceName": "/dev/sda1",
+                    "blockDeviceMapping": {},
+                    "virtualizationType": "hvm",
+                    "hypervisor": "xen",
+                    "clientToken": "d4673c83-0aaf-4e52-b2a8-99bf7dfbe074_subnet-5f7a3106_2",
+                    "interfaceId": "interface-6a08d837",
+                    "groupSet": {
+                        "items": [
+                            {
+                                "groupId": "sg-bd2d87d9",
+                                "groupName": "default"
+                            }
+                        ]
+                    },
+                    "sourceDestCheck": true,
+                    "networkInterfaceSet": {
+                        "items": [
+                            {
+                                "networkInterfaceId": "eni-6a08d837",
+                                "internalInterfaceId": "interface-6a08d837",
+                                "subnetId": "subnet-5f7a3106",
+                                "vpcId": "vpc-1b4a1b7e",
+                                "availabilityZone": "us-west-1c",
+                                "ownerId": "619193117841",
+                                "requesterManaged": false,
+                                "status": "in-use",
+                                "macAddress": "06:e1:54:77:56:c3",
+                                "privateIpAddress": "172.30.2.156",
+                                "sourceDestCheck": true,
+                                "groupSet": {
+                                    "items": [
+                                        {
+                                            "groupId": "sg-bd2d87d9",
+                                            "groupName": "default"
+                                        }
+                                    ]
+                                },
+                                "attachment": {
+                                    "attachmentId": "eni-attach-1cabe8dc",
+                                    "instanceId": "i-784cdacd",
+                                    "instanceOwnerId": "619193117841",
+                                    "deviceIndex": 0,
+                                    "status": "attaching",
+                                    "attachTime": 1463847074000,
+                                    "deleteOnTermination": true
+                                },
+                                "attachableToInstanceBySet": {},
+                                "associableWithElasticIpBySet": {},
+                                "privateIpAddressesSet": {
+                                    "item": [
+                                        {
+                                            "privateIpAddress": "172.30.2.156",
+                                            "primary": true
+                                        }
+                                    ]
+                                },
+                                "tagSet": {}
+                            }
+                        ]
+                    },
+                    "iamInstanceProfile": {
+                        "arn": "arn:aws:iam::619193117841:instance-profile/BaseIAMRole",
+                        "id": "AIPAIRG6ZZNGYJQ3NRJ5W"
+                    },
+                    "ebsOptimized": false
+                },
+                {
+                    "instanceId": "i-7b4cdace",
+                    "imageId": "ami-06116566",
+                    "instanceState": {
+                        "code": 0,
+                        "name": "pending"
+                    },
+                    "privateDnsName": "ip-172-30-2-157.us-west-1.compute.internal",
+                    "keyName": "PersonalWest",
+                    "amiLaunchIndex": 0,
+                    "productCodes": {},
+                    "instanceType": "t2.micro",
+                    "launchTime": 1463847074000,
+                    "placement": {
+                        "availabilityZone": "us-west-1c",
+                        "tenancy": "default"
+                    },
+                    "monitoring": {
+                        "state": "disabled"
+                    },
+                    "subnetId": "subnet-5f7a3106",
+                    "vpcId": "vpc-1b4a1b7e",
+                    "privateIpAddress": "172.30.2.157",
+                    "stateReason": {
+                        "code": "pending",
+                        "message": "pending"
+                    },
+                    "architecture": "x86_64",
+                    "rootDeviceType": "ebs",
+                    "rootDeviceName": "/dev/sda1",
+                    "blockDeviceMapping": {},
+                    "virtualizationType": "hvm",
+                    "hypervisor": "xen",
+                    "clientToken": "d4673c83-0aaf-4e52-b2a8-99bf7dfbe074_subnet-5f7a3106_2",
+                    "interfaceId": "interface-6508d838",
+                    "groupSet": {
+                        "items": [
+                            {
+                                "groupId": "sg-bd2d87d9",
+                                "groupName": "default"
+                            }
+                        ]
+                    },
+                    "sourceDestCheck": true,
+                    "networkInterfaceSet": {
+                        "items": [
+                            {
+                                "networkInterfaceId": "eni-6508d838",
+                                "internalInterfaceId": "interface-6508d838",
+                                "subnetId": "subnet-5f7a3106",
+                                "vpcId": "vpc-1b4a1b7e",
+                                "availabilityZone": "us-west-1c",
+                                "ownerId": "619193117841",
+                                "requesterManaged": false,
+                                "status": "in-use",
+                                "macAddress": "06:bd:28:47:d3:45",
+                                "privateIpAddress": "172.30.2.157",
+                                "sourceDestCheck": true,
+                                "groupSet": {
+                                    "items": [
+                                        {
+                                            "groupId": "sg-bd2d87d9",
+                                            "groupName": "default"
+                                        }
+                                    ]
+                                },
+                                "attachment": {
+                                    "attachmentId": "eni-attach-09abe8c9",
+                                    "instanceId": "i-7b4cdace",
+                                    "instanceOwnerId": "619193117841",
+                                    "deviceIndex": 0,
+                                    "status": "attaching",
+                                    "attachTime": 1463847074000,
+                                    "deleteOnTermination": true
+                                },
+                                "attachableToInstanceBySet": {},
+                                "associableWithElasticIpBySet": {},
+                                "privateIpAddressesSet": {
+                                    "item": [
+                                        {
+                                            "privateIpAddress": "172.30.2.157",
+                                            "primary": true
+                                        }
+                                    ]
+                                },
+                                "tagSet": {}
+                            }
+                        ]
+                    },
+                    "iamInstanceProfile": {
+                        "arn": "arn:aws:iam::619193117841:instance-profile/BaseIAMRole",
+                        "id": "AIPAIRG6ZZNGYJQ3NRJ5W"
+                    },
+                    "ebsOptimized": false
+                }
+            ]
+        },
+        "requesterId": "226008221399"
+    },
+    "requestID": "0114b565-8354-410c-abe0-9a2196e70c9d",
+    "eventID": "6da8b953-741f-4273-be3f-289b92b4d1fc",
+    "eventType": "AwsApiCall",
+    "recipientAccountId": "619193117841"
+}

--- a/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.AddTags_1.json
+++ b/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.AddTags_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "549be7fd-201e-11e6-be72-7b04834bf93a"
+        }
+    }
+}

--- a/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeLoadBalancers_1.json
+++ b/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeLoadBalancers_1.json
@@ -1,0 +1,75 @@
+{
+    "status_code": 200, 
+    "data": {
+        "LoadBalancerDescriptions": [
+            {
+                "Subnets": [
+                    "subnet-389e3d53", 
+                    "subnet-3e9e3d55", 
+                    "subnet-3f9e3d54"
+                ], 
+                "CanonicalHostedZoneNameID": "Z33MTJ483KN6FU", 
+                "CanonicalHostedZoneName": "CloudCustodian-1762224948.us-west-2.elb.amazonaws.com", 
+                "ListenerDescriptions": [
+                    {
+                        "Listener": {
+                            "InstancePort": 80, 
+                            "LoadBalancerPort": 80, 
+                            "Protocol": "HTTP", 
+                            "InstanceProtocol": "HTTP"
+                        }, 
+                        "PolicyNames": []
+                    }
+                ], 
+                "HealthCheck": {
+                    "HealthyThreshold": 10, 
+                    "Interval": 30, 
+                    "Target": "HTTP:80/index.html", 
+                    "Timeout": 5, 
+                    "UnhealthyThreshold": 2
+                }, 
+                "VPCId": "vpc-399e3d52", 
+                "BackendServerDescriptions": [], 
+                "Instances": [
+                    {
+                        "InstanceId": "i-9432cb49"
+                    }
+                ], 
+                "DNSName": "CloudCustodian-1762224948.us-west-2.elb.amazonaws.com", 
+                "SecurityGroups": [
+                    "sg-0a08e365"
+                ], 
+                "Policies": {
+                    "LBCookieStickinessPolicies": [], 
+                    "AppCookieStickinessPolicies": [], 
+                    "OtherPolicies": []
+                }, 
+                "LoadBalancerName": "CloudCustodian", 
+                "CreatedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 17, 
+                    "microsecond": 610000, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 20
+                }, 
+                "AvailabilityZones": [
+                    "us-west-2a", 
+                    "us-west-2b", 
+                    "us-west-2c"
+                ], 
+                "Scheme": "internet-facing", 
+                "SourceSecurityGroup": {
+                    "OwnerAlias": "619193117841", 
+                    "GroupName": "default"
+                }
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "538ff653-201e-11e6-a63e-ab6d48bc31eb"
+        }
+    }
+}

--- a/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeLoadBalancers_2.json
+++ b/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeLoadBalancers_2.json
@@ -1,0 +1,75 @@
+{
+    "status_code": 200, 
+    "data": {
+        "LoadBalancerDescriptions": [
+            {
+                "Subnets": [
+                    "subnet-389e3d53", 
+                    "subnet-3e9e3d55", 
+                    "subnet-3f9e3d54"
+                ], 
+                "CanonicalHostedZoneNameID": "Z33MTJ483KN6FU", 
+                "CanonicalHostedZoneName": "CloudCustodian-1762224948.us-west-2.elb.amazonaws.com", 
+                "ListenerDescriptions": [
+                    {
+                        "Listener": {
+                            "InstancePort": 80, 
+                            "LoadBalancerPort": 80, 
+                            "Protocol": "HTTP", 
+                            "InstanceProtocol": "HTTP"
+                        }, 
+                        "PolicyNames": []
+                    }
+                ], 
+                "HealthCheck": {
+                    "HealthyThreshold": 10, 
+                    "Interval": 30, 
+                    "Target": "HTTP:80/index.html", 
+                    "Timeout": 5, 
+                    "UnhealthyThreshold": 2
+                }, 
+                "VPCId": "vpc-399e3d52", 
+                "BackendServerDescriptions": [], 
+                "Instances": [
+                    {
+                        "InstanceId": "i-9432cb49"
+                    }
+                ], 
+                "DNSName": "CloudCustodian-1762224948.us-west-2.elb.amazonaws.com", 
+                "SecurityGroups": [
+                    "sg-0a08e365"
+                ], 
+                "Policies": {
+                    "LBCookieStickinessPolicies": [], 
+                    "AppCookieStickinessPolicies": [], 
+                    "OtherPolicies": []
+                }, 
+                "LoadBalancerName": "CloudCustodian", 
+                "CreatedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 17, 
+                    "microsecond": 610000, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 20
+                }, 
+                "AvailabilityZones": [
+                    "us-west-2a", 
+                    "us-west-2b", 
+                    "us-west-2c"
+                ], 
+                "Scheme": "internet-facing", 
+                "SourceSecurityGroup": {
+                    "OwnerAlias": "619193117841", 
+                    "GroupName": "default"
+                }
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "55a456f2-201e-11e6-97eb-f7adfa187e50"
+        }
+    }
+}

--- a/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "5418877a-201e-11e6-a63e-ab6d48bc31eb"
+        }, 
+        "TagDescriptions": [
+            {
+                "Tags": [
+                    {
+                        "Value": "ubuntu", 
+                        "Key": "Platform"
+                    }
+                ], 
+                "LoadBalancerName": "CloudCustodian"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeTags_2.json
+++ b/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeTags_2.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "55269c1a-201e-11e6-9a00-4dbf4ea1869e"
+        }, 
+        "TagDescriptions": [
+            {
+                "Tags": [
+                    {
+                        "Value": "ubuntu", 
+                        "Key": "Platform"
+                    }, 
+                    {
+                        "Value": "Resource does not meet policy: delete@2016/05/21", 
+                        "Key": "custodian_next"
+                    }
+                ], 
+                "LoadBalancerName": "CloudCustodian"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeTags_3.json
+++ b/tests/data/placebo/test_elb_mark_and_match/elasticloadbalancing.DescribeTags_3.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "562c9a51-201e-11e6-96db-198531c49883"
+        }, 
+        "TagDescriptions": [
+            {
+                "Tags": [
+                    {
+                        "Value": "ubuntu", 
+                        "Key": "Platform"
+                    }, 
+                    {
+                        "Value": "Resource does not meet policy: delete@2016/05/21", 
+                        "Key": "custodian_next"
+                    }
+                ], 
+                "LoadBalancerName": "CloudCustodian"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elb_tags/elasticloadbalancing.DescribeLoadBalancers_1.json
+++ b/tests/data/placebo/test_elb_tags/elasticloadbalancing.DescribeLoadBalancers_1.json
@@ -1,0 +1,75 @@
+{
+    "status_code": 200, 
+    "data": {
+        "LoadBalancerDescriptions": [
+            {
+                "Subnets": [
+                    "subnet-389e3d53", 
+                    "subnet-3e9e3d55", 
+                    "subnet-3f9e3d54"
+                ], 
+                "CanonicalHostedZoneNameID": "Z33MTJ483KN6FU", 
+                "CanonicalHostedZoneName": "CloudCustodian-1762224948.us-west-2.elb.amazonaws.com", 
+                "ListenerDescriptions": [
+                    {
+                        "Listener": {
+                            "InstancePort": 80, 
+                            "LoadBalancerPort": 80, 
+                            "Protocol": "HTTP", 
+                            "InstanceProtocol": "HTTP"
+                        }, 
+                        "PolicyNames": []
+                    }
+                ], 
+                "HealthCheck": {
+                    "HealthyThreshold": 10, 
+                    "Interval": 30, 
+                    "Target": "HTTP:80/index.html", 
+                    "Timeout": 5, 
+                    "UnhealthyThreshold": 2
+                }, 
+                "VPCId": "vpc-399e3d52", 
+                "BackendServerDescriptions": [], 
+                "Instances": [
+                    {
+                        "InstanceId": "i-9432cb49"
+                    }
+                ], 
+                "DNSName": "CloudCustodian-1762224948.us-west-2.elb.amazonaws.com", 
+                "SecurityGroups": [
+                    "sg-0a08e365"
+                ], 
+                "Policies": {
+                    "LBCookieStickinessPolicies": [], 
+                    "AppCookieStickinessPolicies": [], 
+                    "OtherPolicies": []
+                }, 
+                "LoadBalancerName": "CloudCustodian", 
+                "CreatedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 17, 
+                    "microsecond": 610000, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 20
+                }, 
+                "AvailabilityZones": [
+                    "us-west-2a", 
+                    "us-west-2b", 
+                    "us-west-2c"
+                ], 
+                "Scheme": "internet-facing", 
+                "SourceSecurityGroup": {
+                    "OwnerAlias": "619193117841", 
+                    "GroupName": "default"
+                }
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "39bb9050-201e-11e6-96db-198531c49883"
+        }
+    }
+}

--- a/tests/data/placebo/test_elb_tags/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_elb_tags/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "3b2ab0e7-201e-11e6-be72-7b04834bf93a"
+        }, 
+        "TagDescriptions": [
+            {
+                "Tags": [
+                    {
+                        "Value": "ubuntu", 
+                        "Key": "Platform"
+                    }
+                ], 
+                "LoadBalancerName": "CloudCustodian"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_mark_and_match/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_rds_mark_and_match/iam.ListRoles_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AAqfcgNEOsYyuumcSiAtwUFQZuy3ovsdD92RTrHGoQ2yJWzCbQOWUJsxkx/XLtPb23K37Fzg7j3Eo/rFW64nHrDt", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAIBRFOWJZSGZJEZVAK", 
+                "CreateDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 55
+                }, 
+                "RoleName": "BaseIAMRole", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::619193117841:role/BaseIAMRole"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "c0c03788-2025-11e6-b2cb-474a6f2ec67c"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_mark_and_match/iam.ListRoles_2.json
+++ b/tests/data/placebo/test_rds_mark_and_match/iam.ListRoles_2.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "ACIko+qR28xNsbV/os3fvKTXjRXli4GBKGHUw8h+6cyuN/VGq/6lMIK9RKdWTYnOLWNqYGEmFoLYZrNR3XdPWAmb", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAIBRFOWJZSGZJEZVAK", 
+                "CreateDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 55
+                }, 
+                "RoleName": "BaseIAMRole", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::619193117841:role/BaseIAMRole"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "c1bebb8f-2025-11e6-a9b3-9347fe68fd42"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_mark_and_match/rds.AddTagsToResource_1.json
+++ b/tests/data/placebo/test_rds_mark_and_match/rds.AddTagsToResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "c145bad5-2025-11e6-b135-09009e8304b8"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_mark_and_match/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_mark_and_match/rds.DescribeDBInstances_1.json
@@ -1,0 +1,111 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBInstances": [
+            {
+                "PubliclyAccessible": false, 
+                "MasterUsername": "custodian", 
+                "MonitoringInterval": 0, 
+                "LicenseModel": "postgresql-license", 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-0a08e365"
+                    }
+                ], 
+                "InstanceCreateTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 22, 
+                    "microsecond": 993000, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 43
+                }, 
+                "CopyTagsToSnapshot": true, 
+                "OptionGroupMemberships": [
+                    {
+                        "Status": "in-sync", 
+                        "OptionGroupName": "default:postgres-9-4"
+                    }
+                ], 
+                "PendingModifiedValues": {}, 
+                "Engine": "postgres", 
+                "MultiAZ": false, 
+                "LatestRestorableTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 59
+                }, 
+                "DBSecurityGroups": [], 
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.postgres9.4", 
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ], 
+                "AutoMinorVersionUpgrade": true, 
+                "PreferredBackupWindow": "08:35-09:05", 
+                "DBSubnetGroup": {
+                    "Subnets": [
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-389e3d53", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2c"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3e9e3d55", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2a"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3f9e3d54", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2b"
+                            }
+                        }
+                    ], 
+                    "DBSubnetGroupName": "default", 
+                    "VpcId": "vpc-399e3d52", 
+                    "DBSubnetGroupDescription": "default", 
+                    "SubnetGroupStatus": "Complete"
+                }, 
+                "ReadReplicaDBInstanceIdentifiers": [], 
+                "AllocatedStorage": 5, 
+                "BackupRetentionPeriod": 7, 
+                "PreferredMaintenanceWindow": "thu:10:25-thu:10:55", 
+                "Endpoint": {
+                    "Port": 5432, 
+                    "Address": "custodiantest.cj9uic5xuiu0.us-west-2.rds.amazonaws.com"
+                }, 
+                "DBInstanceStatus": "available", 
+                "EngineVersion": "9.4.7", 
+                "AvailabilityZone": "us-west-2b", 
+                "DomainMemberships": [], 
+                "StorageType": "gp2", 
+                "DbiResourceId": "db-V57KXLXSG4MTCQYEUXJF3D4LLE", 
+                "CACertificateIdentifier": "rds-ca-2015", 
+                "KmsKeyId": "arn:aws:kms:us-west-2:619193117841:key/43811d5f-db1f-448d-b61d-04c5bf49b9d8", 
+                "StorageEncrypted": true, 
+                "DBInstanceClass": "db.m3.medium", 
+                "DbInstancePort": 0, 
+                "DBInstanceIdentifier": "custodiantest"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "c0915ef5-2025-11e6-8563-adebdc059922"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_mark_and_match/rds.DescribeDBInstances_2.json
+++ b/tests/data/placebo/test_rds_mark_and_match/rds.DescribeDBInstances_2.json
@@ -1,0 +1,111 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBInstances": [
+            {
+                "PubliclyAccessible": false, 
+                "MasterUsername": "custodian", 
+                "MonitoringInterval": 0, 
+                "LicenseModel": "postgresql-license", 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-0a08e365"
+                    }
+                ], 
+                "InstanceCreateTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 22, 
+                    "microsecond": 993000, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 43
+                }, 
+                "CopyTagsToSnapshot": true, 
+                "OptionGroupMemberships": [
+                    {
+                        "Status": "in-sync", 
+                        "OptionGroupName": "default:postgres-9-4"
+                    }
+                ], 
+                "PendingModifiedValues": {}, 
+                "Engine": "postgres", 
+                "MultiAZ": false, 
+                "LatestRestorableTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 59
+                }, 
+                "DBSecurityGroups": [], 
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.postgres9.4", 
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ], 
+                "AutoMinorVersionUpgrade": true, 
+                "PreferredBackupWindow": "08:35-09:05", 
+                "DBSubnetGroup": {
+                    "Subnets": [
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-389e3d53", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2c"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3e9e3d55", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2a"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3f9e3d54", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2b"
+                            }
+                        }
+                    ], 
+                    "DBSubnetGroupName": "default", 
+                    "VpcId": "vpc-399e3d52", 
+                    "DBSubnetGroupDescription": "default", 
+                    "SubnetGroupStatus": "Complete"
+                }, 
+                "ReadReplicaDBInstanceIdentifiers": [], 
+                "AllocatedStorage": 5, 
+                "BackupRetentionPeriod": 7, 
+                "PreferredMaintenanceWindow": "thu:10:25-thu:10:55", 
+                "Endpoint": {
+                    "Port": 5432, 
+                    "Address": "custodiantest.cj9uic5xuiu0.us-west-2.rds.amazonaws.com"
+                }, 
+                "DBInstanceStatus": "available", 
+                "EngineVersion": "9.4.7", 
+                "AvailabilityZone": "us-west-2b", 
+                "DomainMemberships": [], 
+                "StorageType": "gp2", 
+                "DbiResourceId": "db-V57KXLXSG4MTCQYEUXJF3D4LLE", 
+                "CACertificateIdentifier": "rds-ca-2015", 
+                "KmsKeyId": "arn:aws:kms:us-west-2:619193117841:key/43811d5f-db1f-448d-b61d-04c5bf49b9d8", 
+                "StorageEncrypted": true, 
+                "DBInstanceClass": "db.m3.medium", 
+                "DbInstancePort": 0, 
+                "DBInstanceIdentifier": "custodiantest"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "c195886a-2025-11e6-bc1e-2d79ecb68ebb"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_mark_and_match/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_rds_mark_and_match/rds.ListTagsForResource_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "c0fa5a42-2025-11e6-9342-395a4d8a9b80"
+        }, 
+        "TagList": [
+            {
+                "Value": "postgres", 
+                "Key": "Platform"
+            }, 
+            {
+                "Value": "other", 
+                "Key": "workload-type"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_mark_and_match/rds.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_rds_mark_and_match/rds.ListTagsForResource_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "c1f90542-2025-11e6-bd28-ffcae44aaf1f"
+        }, 
+        "TagList": [
+            {
+                "Value": "postgres", 
+                "Key": "Platform"
+            }, 
+            {
+                "Value": "Resource does not meet policy: delete@2016/05/21", 
+                "Key": "custodian_next"
+            }, 
+            {
+                "Value": "other", 
+                "Key": "workload-type"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_tags/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_rds_tags/iam.ListRoles_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AAKVUG6oouqUWrxlFukIbjuEpYbnFs07xCfDiKrqFwQXJ5FtAS+E41rwcx8anK0PS96pdOV2t4dX2nmpIR0+E7T7", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAIBRFOWJZSGZJEZVAK", 
+                "CreateDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 55
+                }, 
+                "RoleName": "BaseIAMRole", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::619193117841:role/BaseIAMRole"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "d4b5d85e-2023-11e6-964c-7b76c530a910"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_tags/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_tags/rds.DescribeDBInstances_1.json
@@ -1,0 +1,111 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBInstances": [
+            {
+                "PubliclyAccessible": false, 
+                "MasterUsername": "custodian", 
+                "MonitoringInterval": 0, 
+                "LicenseModel": "postgresql-license", 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-0a08e365"
+                    }
+                ], 
+                "InstanceCreateTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 22, 
+                    "microsecond": 993000, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 43
+                }, 
+                "CopyTagsToSnapshot": true, 
+                "OptionGroupMemberships": [
+                    {
+                        "Status": "in-sync", 
+                        "OptionGroupName": "default:postgres-9-4"
+                    }
+                ], 
+                "PendingModifiedValues": {}, 
+                "Engine": "postgres", 
+                "MultiAZ": false, 
+                "LatestRestorableTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 44
+                }, 
+                "DBSecurityGroups": [], 
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.postgres9.4", 
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ], 
+                "AutoMinorVersionUpgrade": true, 
+                "PreferredBackupWindow": "08:35-09:05", 
+                "DBSubnetGroup": {
+                    "Subnets": [
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-389e3d53", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2c"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3e9e3d55", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2a"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3f9e3d54", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2b"
+                            }
+                        }
+                    ], 
+                    "DBSubnetGroupName": "default", 
+                    "VpcId": "vpc-399e3d52", 
+                    "DBSubnetGroupDescription": "default", 
+                    "SubnetGroupStatus": "Complete"
+                }, 
+                "ReadReplicaDBInstanceIdentifiers": [], 
+                "AllocatedStorage": 5, 
+                "BackupRetentionPeriod": 7, 
+                "PreferredMaintenanceWindow": "thu:10:25-thu:10:55", 
+                "Endpoint": {
+                    "Port": 5432, 
+                    "Address": "custodiantest.cj9uic5xuiu0.us-west-2.rds.amazonaws.com"
+                }, 
+                "DBInstanceStatus": "available", 
+                "EngineVersion": "9.4.7", 
+                "AvailabilityZone": "us-west-2b", 
+                "DomainMemberships": [], 
+                "StorageType": "gp2", 
+                "DbiResourceId": "db-V57KXLXSG4MTCQYEUXJF3D4LLE", 
+                "CACertificateIdentifier": "rds-ca-2015", 
+                "KmsKeyId": "arn:aws:kms:us-west-2:619193117841:key/43811d5f-db1f-448d-b61d-04c5bf49b9d8", 
+                "StorageEncrypted": true, 
+                "DBInstanceClass": "db.m3.medium", 
+                "DbInstancePort": 0, 
+                "DBInstanceIdentifier": "custodiantest"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "d46cc0b1-2023-11e6-9541-0dacbe99b868"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_tags/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_rds_tags/rds.ListTagsForResource_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "d4ec0352-2023-11e6-bcfb-97d0579f549a"
+        }, 
+        "TagList": [
+            {
+                "Value": "postgres", 
+                "Key": "Platform"
+            }, 
+            {
+                "Value": "other", 
+                "Key": "workload-type"
+            }
+        ]
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -385,12 +385,13 @@ class S3Test(BaseTest):
             'filters': [{'Name': bname}],
             'actions': ['encrypt-keys']}, session_factory=session_factory)
         resources = p.run()
+
         self.assertTrue(
             'ServerSideEncryption' in client.head_object(
                 Bucket=bname, Key='home.txt'))
 
     def test_global_grants_filter_option(self):
-        self.patch(s3.S3, 'executor_factory', MainThreadExecutor)        
+        self.patch(s3.S3, 'executor_factory', MainThreadExecutor)
         self.patch(s3, 'S3_AUGMENT_TABLE', [
             ('get_bucket_acl', 'Acl', None, None)
             ])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -62,6 +62,15 @@ class SchemaTest(BaseTest):
         self.assertTrue(
             "'type': 'ebs'" in error.message)
 
+    def test_vars_and_tags(self):
+        data = {
+            'vars': {'alpha': 1, 'beta': 2},
+            'policies': [{
+                'name': 'test',
+                'resource': 'ec2',
+                'tags': ['controls']}]}
+        self.assertEqual(list(self.validator.iter_errors(data)), [])
+
     def test_semantic_error_on_value_derived(self):
         data = {
             'policies': [


### PR DESCRIPTION
- cli region and profile default to aws sdk standard env vars- policies can have tags, to allow for classification and grouping without renaming.
- add in cwe shortcuts for asgs
- change cwe long form to allow multiple sources, id selectors (closes #85)
- offhours and onhours explicitly require there respective time fields (closes #100 and refs #111)
- allow vars section in config file for yaml references on repeated values
- asg resource manager supports cwe/push policies
- simplify elb tag retrieval
- elb and rds support marked-for-op filter and mark-for-op action (closes #49)
- add tools/vocabulary.py to auto gen yaml file of valid policy language elements
- version incr 0.8.11