### PR TITLE
Add ability to copy RDS DB Instance tags to snapshots

### DIFF
--- a/docs/source/policy/resources/rds.rst
+++ b/docs/source/policy/resources/rds.rst
@@ -15,4 +15,12 @@ Actions
 -------
 
 ``delete``
-  Delete RDS resource and you can specify if you want to ``skip-snapshot``, default is False
+  Delete DB instance.
+  You can specify if you want to ``skip-snapshot``, default is False
+
+``snapshot``
+  Create a manual DB snapshot
+
+``retention``
+  Set the DB instance backup retention period to ``days``.
+  You can specify if you want to ``copy-tags`` from the DB instance to the snapshot, default is False

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -117,6 +117,18 @@ class RDSTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 6)
 
+    def test_rds_retention_copy_tags(self):
+        session_factory = self.replay_flight_data('test_rds_retention')
+        p = self.load_policy(
+            {'name': 'rds-snapshot',
+             'resource': 'rds',
+             'actions': [
+                 {'type': 'retention', 'days': 21, 'copy-tags': True}]},
+            config={'region': 'us-west-2'},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 6)
+
     def test_rds_delete(self):
         session_factory = self.replay_flight_data('test_rds_delete')
         p = self.load_policy(


### PR DESCRIPTION
* Add `copy-tags` attribute to the RDS `retention` action - Default is **false**
* Call `modify_db_instance()` if either the retention period increases or the copy tags flag changes
* Add unit test
* Enhance documentation

Fixes #213.