### PR TITLE
Ignore 'LoadBalancerNotFound' errors when getting ELB tags

### DIFF
--- a/c7n/resources/elb.py
+++ b/c7n/resources/elb.py
@@ -57,6 +57,8 @@ def _elb_tags(elbs, session_factory, executor_factory):
         try:
             results = client.describe_tags(LoadBalancerNames=elb_map.keys())
         except ClientError as e:
+            if e.response['Error']['Code'] == 'LoadBalancerNotFound':
+                return
             log.exception("Exception Processing ELB: %s", e)
             raise
         for tag_desc in results['TagDescriptions']:


### PR DESCRIPTION
* Fixes https://github.com/capitalone/cloud-custodian/issues/247