### PR TITLE
Improvements to Invalid AutoScaling Group filter

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -79,3 +79,8 @@ class InternetGateway(QueryResourceManager):
         date = None
 
     resource_type = Meta
+
+@resources.register('key-pair')
+class KeyPair(QueryResourceManager):
+
+    resource_type = 'aws.ec2.key-pair'

--- a/tests/data/placebo/test_asg_invalid_filter_bad/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,0 +1,82 @@
+{
+    "status_code": 200,
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123:autoScalingGroup:f03353dd-fb08-4f12-912a-a72319cf47e4:autoScalingGroupName/abc",
+                "HealthCheckGracePeriod": 0,
+                "SuspendedProcesses": [],
+                "DesiredCapacity": 3,
+                "Tags": [
+                    {
+                        "ResourceType": "auto-scaling-group",
+                        "ResourceId": "abc",
+                        "PropagateAtLaunch": true,
+                        "Value": "abc",
+                        "Key": "Name"
+                    }
+                ],
+                "EnabledMetrics": [],
+                "LoadBalancerNames": [
+                    "abc-elb"
+                ],
+                "AutoScalingGroupName": "abc",
+                "DefaultCooldown": 300,
+                "MinSize": 3,
+                "Instances": [
+                    {
+                        "ProtectedFromScaleIn": false,
+                        "AvailabilityZone": "us-west-2a",
+                        "InstanceId": "i-1",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "abc-lc"
+                    },
+                    {
+                        "ProtectedFromScaleIn": false,
+                        "AvailabilityZone": "us-west-2c",
+                        "InstanceId": "i-2",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "abc-lc"
+                    },
+                    {
+                        "ProtectedFromScaleIn": false,
+                        "AvailabilityZone": "us-west-2b",
+                        "InstanceId": "i-3",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "abc-lc"
+                    }
+                ],
+                "MaxSize": 3,
+                "VPCZoneIdentifier": "subnet-1,subnet-2",
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "LaunchConfigurationName": "abc-lc",
+                "CreatedTime": {
+                    "hour": 18,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 46,
+                    "microsecond": 612000,
+                    "year": 2016,
+                    "day": 5,
+                    "minute": 57
+                },
+                "AvailabilityZones": [
+                    "us-west-2a",
+                    "us-west-2b",
+                    "us-west-2c"
+                ],
+                "HealthCheckType": "EC2",
+                "NewInstancesProtectedFromScaleIn": false
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "6f007004-3ed3-11e6-b978-ed42136cd099"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/autoscaling.DescribeLaunchConfigurations_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/autoscaling.DescribeLaunchConfigurations_1.json
@@ -1,0 +1,51 @@
+{
+    "status_code": 200,
+    "data": {
+        "LaunchConfigurations": [
+            {
+                "UserData": "",
+                "IamInstanceProfile": "IIP",
+                "EbsOptimized": false,
+                "LaunchConfigurationARN": "arn:aws:autoscaling:us-west-2:123:launchConfiguration:a0a6956b-d82c-4f44-a6be-ccca88788bc2:launchConfigurationName/abc-lc",
+                "InstanceMonitoring": {
+                    "Enabled": true
+                },
+                "ClassicLinkVPCSecurityGroups": [],
+                "CreatedTime": {
+                    "hour": 18,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 44,
+                    "microsecond": 890000,
+                    "year": 2016,
+                    "day": 5,
+                    "minute": 57
+                },
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "VolumeSize": 50,
+                            "VolumeType": "standard"
+                        }
+                    }
+                ],
+                "KeyName": "k1",
+                "SecurityGroups": [
+                    "sg-1",
+                    "sg-2"
+                ],
+                "LaunchConfigurationName": "abc-lc",
+                "KernelId": "",
+                "RamdiskId": "",
+                "ImageId": "ami-1",
+                "InstanceType": "m3.medium"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "2e2b3067-3ed4-11e6-967f-b52c408b2489"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeImages_1.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "VirtualizationType": "hvm",
+                "Name": "NNN",
+                "Hypervisor": "xen",
+                "SriovNetSupport": "simple",
+                "ImageId": "ami-1",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-1",
+                            "VolumeSize": 20,
+                            "VolumeType": "gp2",
+                            "Encrypted": true
+                        }
+                    }
+                ],
+                "Architecture": "x86_64",
+                "ImageLocation": "123/NNN",
+                "RootDeviceType": "ebs",
+                "OwnerId": "123",
+                "RootDeviceName": "/dev/sda1",
+                "CreationDate": "2016-06-24T20:28:16.000Z",
+                "Public": false,
+                "ImageType": "machine",
+                "Description": "DDD"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "e1678255-2aae-4a1c-a424-85721c62d6c3"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeKeyPairs_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeKeyPairs_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "KeyPairs": [
+            {
+                "KeyName": "k1", 
+                "KeyFingerprint": "81:2c:ad:55:96:f5:86:af:7c:e1:4b:fc:4b:f2:6a:43:71:63:ab:44"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "bf4239a5-3fd0-4c6d-832f-a13a07c893b4"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123",
+                                "GroupId": "sg-2"
+                            }
+                        ],
+                        "PrefixListIds": []
+                    }
+                ],
+                "Description": "DDD",
+                "Tags": [],
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123",
+                                "GroupId": "sg-2"
+                            }
+                        ],
+                        "PrefixListIds": []
+                    }
+                ],
+                "GroupName": "GN",
+                "VpcId": "vpc-1",
+                "OwnerId": "123",
+                "GroupId": "sg-1"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "a5424d02-1d02-40d3-a237-3483aecd7f9b"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeSnapshots_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "1c37cfbf-49d3-4e50-8e94-1548c4ae1d83"
+        },
+        "Snapshots": [
+            {
+                "Description": "",
+                "Encrypted": false,
+                "VolumeId": "vol-1",
+                "State": "completed",
+                "VolumeSize": 10,
+                "Progress": "100%",
+                "StartTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 5,
+                    "second": 50,
+                    "microsecond": 0,
+                    "year": 2012,
+                    "day": 31,
+                    "minute": 29
+                },
+                "SnapshotId": "snap-1",
+                "OwnerId": "123"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeSubnets_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/ec2.DescribeSubnets_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "Subnets": [
+            {
+                "VpcId": "vpc-1",
+                "Tags": [],
+                "CidrBlock": "1.2.3.4/5",
+                "MapPublicIpOnLaunch": false,
+                "DefaultForAz": false,
+                "State": "available",
+                "AvailabilityZone": "us-west-2a",
+                "SubnetId": "subnet-1",
+                "AvailableIpAddressCount": 26
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "359e2df1-9925-479e-894d-b281431c25ed"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/elasticloadbalancing.DescribeLoadBalancers_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/elasticloadbalancing.DescribeLoadBalancers_1.json
@@ -1,0 +1,80 @@
+{
+    "status_code": 200,
+    "data": {
+        "LoadBalancerDescriptions": [
+            {
+                "Subnets": [
+                    "subnet-1"
+                ],
+                "CanonicalHostedZoneNameID": "CHZNID",
+                "VPCId": "vpc-1",
+                "ListenerDescriptions": [
+                    {
+                        "Listener": {
+                            "InstancePort": 80,
+                            "LoadBalancerPort": 80,
+                            "Protocol": "HTTP",
+                            "InstanceProtocol": "HTTP"
+                        },
+                        "PolicyNames": []
+                    }
+                ],
+                "HealthCheck": {
+                    "HealthyThreshold": 2,
+                    "Interval": 30,
+                    "Target": "TCP:80",
+                    "Timeout": 5,
+                    "UnhealthyThreshold": 6
+                },
+                "BackendServerDescriptions": [],
+                "Instances": [
+                    {
+                        "InstanceId": "i-1"
+                    },
+                    {
+                        "InstanceId": "i-2"
+                    },
+                    {
+                        "InstanceId": "i-3"
+                    }
+                ],
+                "DNSName": "abc.us-west-2.elb.amazonaws.com",
+                "SecurityGroups": [
+                    "sg-1"
+                ],
+                "Policies": {
+                    "LBCookieStickinessPolicies": [],
+                    "AppCookieStickinessPolicies": [],
+                    "OtherPolicies": [
+                        "ELBSecurityPolicy-2015-05"
+                    ]
+                },
+                "LoadBalancerName": "abc-elb",
+                "CreatedTime": {
+                    "hour": 18,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 21,
+                    "microsecond": 610000,
+                    "year": 2016,
+                    "day": 5,
+                    "minute": 44
+                },
+                "AvailabilityZones": [
+                    "us-west-2a",
+                    "us-west-2b",
+                    "us-west-2c"
+                ],
+                "Scheme": "internal",
+                "SourceSecurityGroup": {
+                    "OwnerAlias": "123",
+                    "GroupName": "GGG"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "79f2de1e-3ed3-11e6-a775-f76e0e070837"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_bad/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_bad/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "8b30839d-3ed4-11e6-8a34-8feafdf2d35d"
+        },
+        "TagDescriptions": [
+            {
+                "Tags": [
+                  {
+                      "Value": "V",
+                      "Key": "K"
+                  }
+                ],
+                "LoadBalancerName": "abc-elb"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,0 +1,82 @@
+{
+    "status_code": 200,
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-2:123:autoScalingGroup:f03353dd-fb08-4f12-912a-a72319cf47e4:autoScalingGroupName/abc",
+                "HealthCheckGracePeriod": 0,
+                "SuspendedProcesses": [],
+                "DesiredCapacity": 3,
+                "Tags": [
+                    {
+                        "ResourceType": "auto-scaling-group",
+                        "ResourceId": "abc",
+                        "PropagateAtLaunch": true,
+                        "Value": "abc",
+                        "Key": "Name"
+                    }
+                ],
+                "EnabledMetrics": [],
+                "LoadBalancerNames": [
+                    "abc-elb"
+                ],
+                "AutoScalingGroupName": "abc",
+                "DefaultCooldown": 300,
+                "MinSize": 3,
+                "Instances": [
+                    {
+                        "ProtectedFromScaleIn": false,
+                        "AvailabilityZone": "us-west-2a",
+                        "InstanceId": "i-1",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "abc-lc"
+                    },
+                    {
+                        "ProtectedFromScaleIn": false,
+                        "AvailabilityZone": "us-west-2c",
+                        "InstanceId": "i-2",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "abc-lc"
+                    },
+                    {
+                        "ProtectedFromScaleIn": false,
+                        "AvailabilityZone": "us-west-2b",
+                        "InstanceId": "i-3",
+                        "HealthStatus": "Healthy",
+                        "LifecycleState": "InService",
+                        "LaunchConfigurationName": "abc-lc"
+                    }
+                ],
+                "MaxSize": 3,
+                "VPCZoneIdentifier": "subnet-1",
+                "TerminationPolicies": [
+                    "Default"
+                ],
+                "LaunchConfigurationName": "abc-lc",
+                "CreatedTime": {
+                    "hour": 18,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 46,
+                    "microsecond": 612000,
+                    "year": 2016,
+                    "day": 5,
+                    "minute": 57
+                },
+                "AvailabilityZones": [
+                    "us-west-2a",
+                    "us-west-2b",
+                    "us-west-2c"
+                ],
+                "HealthCheckType": "EC2",
+                "NewInstancesProtectedFromScaleIn": false
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "6f007004-3ed3-11e6-b978-ed42136cd099"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/autoscaling.DescribeLaunchConfigurations_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/autoscaling.DescribeLaunchConfigurations_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200,
+    "data": {
+        "LaunchConfigurations": [
+            {
+                "UserData": "",
+                "IamInstanceProfile": "IIP",
+                "EbsOptimized": false,
+                "LaunchConfigurationARN": "arn:aws:autoscaling:us-west-2:123:launchConfiguration:a0a6956b-d82c-4f44-a6be-ccca88788bc2:launchConfigurationName/abc-lc",
+                "InstanceMonitoring": {
+                    "Enabled": true
+                },
+                "ClassicLinkVPCSecurityGroups": [],
+                "CreatedTime": {
+                    "hour": 18,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 44,
+                    "microsecond": 890000,
+                    "year": 2016,
+                    "day": 5,
+                    "minute": 57
+                },
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "VolumeSize": 50,
+                            "VolumeType": "standard"
+                        }
+                    }
+                ],
+                "KeyName": "k1",
+                "SecurityGroups": [
+                    "sg-1"
+                ],
+                "LaunchConfigurationName": "abc-lc",
+                "KernelId": "",
+                "RamdiskId": "",
+                "ImageId": "ami-1",
+                "InstanceType": "m3.medium"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "2e2b3067-3ed4-11e6-967f-b52c408b2489"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeImages_1.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "VirtualizationType": "hvm",
+                "Name": "NNN",
+                "Hypervisor": "xen",
+                "SriovNetSupport": "simple",
+                "ImageId": "ami-1",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/sda1",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-1",
+                            "VolumeSize": 20,
+                            "VolumeType": "gp2",
+                            "Encrypted": true
+                        }
+                    }
+                ],
+                "Architecture": "x86_64",
+                "ImageLocation": "123/NNN",
+                "RootDeviceType": "ebs",
+                "OwnerId": "123",
+                "RootDeviceName": "/dev/sda1",
+                "CreationDate": "2016-06-24T20:28:16.000Z",
+                "Public": false,
+                "ImageType": "machine",
+                "Description": "DDD"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "e1678255-2aae-4a1c-a424-85721c62d6c3"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeKeyPairs_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeKeyPairs_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 200,
+    "data": {
+        "KeyPairs": [
+            {
+                "KeyName": "k1", 
+                "KeyFingerprint": "81:2c:ad:55:96:f5:86:af:7c:e1:4b:fc:4b:f2:6a:43:71:63:ab:44"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "bf4239a5-3fd0-4c6d-832f-a13a07c893b4"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,45 @@
+{
+    "status_code": 200,
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123",
+                                "GroupId": "sg-2"
+                            }
+                        ],
+                        "PrefixListIds": []
+                    }
+                ],
+                "Description": "DDD",
+                "Tags": [],
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1",
+                        "IpRanges": [],
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123",
+                                "GroupId": "sg-2"
+                            }
+                        ],
+                        "PrefixListIds": []
+                    }
+                ],
+                "GroupName": "GN",
+                "VpcId": "vpc-1",
+                "OwnerId": "123",
+                "GroupId": "sg-1"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "a5424d02-1d02-40d3-a237-3483aecd7f9b"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeSnapshots_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "1c37cfbf-49d3-4e50-8e94-1548c4ae1d83"
+        },
+        "Snapshots": [
+            {
+                "Description": "",
+                "Encrypted": false,
+                "VolumeId": "vol-1",
+                "State": "completed",
+                "VolumeSize": 10,
+                "Progress": "100%",
+                "StartTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 5,
+                    "second": 50,
+                    "microsecond": 0,
+                    "year": 2012,
+                    "day": 31,
+                    "minute": 29
+                },
+                "SnapshotId": "snap-1",
+                "OwnerId": "123"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeSubnets_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/ec2.DescribeSubnets_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200,
+    "data": {
+        "Subnets": [
+            {
+                "VpcId": "vpc-1",
+                "Tags": [],
+                "CidrBlock": "1.2.3.4/5",
+                "MapPublicIpOnLaunch": false,
+                "DefaultForAz": false,
+                "State": "available",
+                "AvailabilityZone": "us-west-2a",
+                "SubnetId": "subnet-1",
+                "AvailableIpAddressCount": 26
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "359e2df1-9925-479e-894d-b281431c25ed"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/elasticloadbalancing.DescribeLoadBalancers_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/elasticloadbalancing.DescribeLoadBalancers_1.json
@@ -1,0 +1,80 @@
+{
+    "status_code": 200,
+    "data": {
+        "LoadBalancerDescriptions": [
+            {
+                "Subnets": [
+                    "subnet-1"
+                ],
+                "CanonicalHostedZoneNameID": "CHZNID",
+                "VPCId": "vpc-1",
+                "ListenerDescriptions": [
+                    {
+                        "Listener": {
+                            "InstancePort": 80,
+                            "LoadBalancerPort": 80,
+                            "Protocol": "HTTP",
+                            "InstanceProtocol": "HTTP"
+                        },
+                        "PolicyNames": []
+                    }
+                ],
+                "HealthCheck": {
+                    "HealthyThreshold": 2,
+                    "Interval": 30,
+                    "Target": "TCP:80",
+                    "Timeout": 5,
+                    "UnhealthyThreshold": 6
+                },
+                "BackendServerDescriptions": [],
+                "Instances": [
+                    {
+                        "InstanceId": "i-1"
+                    },
+                    {
+                        "InstanceId": "i-2"
+                    },
+                    {
+                        "InstanceId": "i-3"
+                    }
+                ],
+                "DNSName": "abc.us-west-2.elb.amazonaws.com",
+                "SecurityGroups": [
+                    "sg-1"
+                ],
+                "Policies": {
+                    "LBCookieStickinessPolicies": [],
+                    "AppCookieStickinessPolicies": [],
+                    "OtherPolicies": [
+                        "ELBSecurityPolicy-2015-05"
+                    ]
+                },
+                "LoadBalancerName": "abc-elb",
+                "CreatedTime": {
+                    "hour": 18,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 21,
+                    "microsecond": 610000,
+                    "year": 2016,
+                    "day": 5,
+                    "minute": 44
+                },
+                "AvailabilityZones": [
+                    "us-west-2a",
+                    "us-west-2b",
+                    "us-west-2c"
+                ],
+                "Scheme": "internal",
+                "SourceSecurityGroup": {
+                    "OwnerAlias": "123",
+                    "GroupName": "GGG"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "79f2de1e-3ed3-11e6-a775-f76e0e070837"
+        }
+    }
+}

--- a/tests/data/placebo/test_asg_invalid_filter_good/elasticloadbalancing.DescribeTags_1.json
+++ b/tests/data/placebo/test_asg_invalid_filter_good/elasticloadbalancing.DescribeTags_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "8b30839d-3ed4-11e6-8a34-8feafdf2d35d"
+        },
+        "TagDescriptions": [
+            {
+                "Tags": [
+                    {
+                        "Value": "V",
+                        "Key": "K"
+                    }
+                ],
+                "LoadBalancerName": "abc-elb"
+            }
+        ]
+    }
+}

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -216,3 +216,27 @@ class AutoScalingTest(BaseTest):
             AutoScalingGroupNames=[resources[0]['AutoScalingGroupName']])[
                 'AutoScalingGroups'].pop()
         self.assertFalse(result['SuspendedProcesses'])
+
+    def test_asg_invalid_filter_good(self):
+        factory = self.replay_flight_data('test_asg_invalid_filter_good')
+        p = self.load_policy({
+            'name': 'asg-invalid-filter',
+            'resource': 'asg',
+            'filters': ['invalid']
+            }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_asg_invalid_filter_bad(self):
+        factory = self.replay_flight_data('test_asg_invalid_filter_bad')
+        p = self.load_policy({
+            'name': 'asg-invalid-filter',
+            'resource': 'asg',
+            'filters': ['invalid']
+            }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        s = set([x[0] for x in resources[0]['Invalid']])
+        self.assertTrue('invalid-subnet' in s)
+        self.assertTrue('invalid-security-group' in s)


### PR DESCRIPTION
* Add check for security groups in Invalid AutoScaling Group filter
* Add check for key pairs to Invalid AutoScaling Group filter
* Add Placebo tests for Invalid AutoScaling Group filter
* Fixes https://github.com/capitalone/cloud-custodian/issues/251