### PR TITLE
Ensure excess tags are actually deleted in 'tag-trim' action.

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -418,7 +418,7 @@ class GroupTagTrim(TagTrim):
 
     def process_tag_removal(self, resource, candidates):
         client = local_session(
-            self.manager.session_factory).client('asg')
+            self.manager.session_factory).client('autoscaling')
         tags = []
         for t in candidates:
             tags.append(

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -137,6 +137,9 @@ class TagTrim(Action, ResourceTag):
         if not candidates:
             self.log.warning(
                 "Could not find any candidates to trim %s" % i[self.id_key])
+            return
+
+        self.process_tag_removal(i, candidates)
 
     def process_tag_removal(self, resource, tags):
         client = utils.local_session(


### PR DESCRIPTION
* Call `TagTrim.process_tag_removal` from `TagTrim.process_resource`
* Correct the name of the ASG boto3 client
* Fixes https://github.com/capitalone/cloud-custodian/issues/269