### PR TITLE
rds should support unmark action

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -195,6 +195,7 @@ class AutoPatch(BaseAction):
 
 
 @actions.register('tag')
+@actions.register('mark')
 class Tag(tags.Tag):
 
     concurrency = 2
@@ -211,6 +212,7 @@ class Tag(tags.Tag):
 
 
 @actions.register('remove-tag')
+@actions.register('unmark')
 class RemoveTag(tags.RemoveTag):
 
     concurrency = 2


### PR DESCRIPTION
* Add `mark` as an alias for `tag`
* Add `unmark` as an alias for `remove-tag`
* Fixes https://github.com/capitalone/cloud-custodian/issues/264