### PR TITLE
Fix 'rds unmark action throws NotImplementedError'

### DIFF
--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -64,3 +64,8 @@ class ResourceManager(object):
         self.log.info("Filtered from %d to %d %s" % (
             original, len(resources), self.__class__.__name__.lower()))
         return resources
+
+    def get_model(self):
+        """Returns the resource meta-model.
+        """
+        return self.query.resolve(self.resource_type)

--- a/c7n/metrics.py
+++ b/c7n/metrics.py
@@ -117,7 +117,7 @@ class MetricsFilter(Filter):
         self.start = self.end - duration
         self.period = int(self.data.get('period', duration.total_seconds()))
         self.statistics = self.data.get('statistics', 'Average')
-        self.model = self.manager.query.resolve(self.manager.resource_type)
+        self.model = self.manager.get_model()
         self.op = OPERATORS[self.data.get('op', 'less-than')]
         self.value = self.data['value']
 
@@ -166,5 +166,3 @@ class MetricsFilter(Filter):
             if self.op(r['Metrics'][0][self.statistics], self.value):
                 matched.append(r)
         return matched
-
-

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -28,7 +28,7 @@ log = logging.getLogger('custodian.ami')
 filters = FilterRegistry('ami.filters')
 actions = ActionRegistry('ami.actions')
 
-register_tags(filters, actions, 'AmiId')
+register_tags(filters, actions)
 
 
 @resources.register('ami')

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -33,7 +33,7 @@ log = logging.getLogger('custodian.ebs')
 filters = FilterRegistry('ebs.filters')
 actions = ActionRegistry('ebs.actions')
 
-tags.register_tags(filters, actions, 'VolumeId')
+tags.register_tags(filters, actions)
 
 
 @resources.register('ebs-snapshot')

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -33,7 +33,7 @@ from c7n.utils import type_schema
 filters = FilterRegistry('ec2.filters')
 actions = ActionRegistry('ec2.actions')
 
-tags.register_tags(filters, actions, 'InstanceId')
+tags.register_tags(filters, actions)
 
 
 @resources.register('ec2')
@@ -115,7 +115,7 @@ class EC2(QueryResourceManager):
             rid = t.pop('ResourceId')
             resource_tags.setdefault(rid, []).append(t)
 
-        m = self.query.resolve(self.resource_type)
+        m = self.get_model()
         for r in resources:
             r['Tags'] = resource_tags.get(r[m.id], ())
         return resources

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -85,6 +85,8 @@ filters.register('marked-for-op', tags.TagActionFilter)
 
 @resources.register('rds')
 class RDS(QueryResourceManager):
+    """Resource manager for RDS DB instances.
+    """
 
     class resource_type(rds.DBInstance.Meta):
         filter_name = 'DBInstanceIdentifier'
@@ -93,24 +95,31 @@ class RDS(QueryResourceManager):
     action_registry = actions
     account_id = None
 
-    def augment(self, resources):
+    def __init__(self, data, options):
+        super(RDS, self).__init__(data, options)
+
         session = local_session(self.session_factory)
         if self.account_id is None:
             self.account_id = get_account_id(session)
+        self.arn_generator = DBInstanceARNGenerator(
+            self.config.region,
+            self.account_id)
+
+    def augment(self, resources):
         _rds_tags(
             self.query.resolve(self.resource_type),
             resources, self.session_factory, self.executor_factory,
-            self.account_id, region=self.config.region)
+            self.arn_generator)
         return resources
 
 
 def _rds_tags(
-        model, dbs, session_factory, executor_factory, account_id, region):
+        model, dbs, session_factory, executor_factory, arn_generator):
     """Augment rds instances with their respective tags."""
 
     def process_tags(db):
         client = local_session(session_factory).client('rds')
-        arn = "arn:aws:rds:%s:%s:db:%s" % (region, account_id, db[model.id])
+        arn = arn_generator.generate(db[model.id])
         tag_list = client.list_tags_for_resource(ResourceName=arn)['TagList']
         db['Tags'] = tag_list or []
         return db
@@ -167,9 +176,7 @@ class TagDelayedAction(tags.TagDelayedAction):
     def process_resource_set(self, resources, tags):
         client = local_session(self.manager.session_factory).client('rds')
         for r in resources:
-            arn = "arn:aws:rds:%s:%s:db:%s" % (
-                self.manager.config.region, self.manager.account_id,
-                r['DBInstanceIdentifier'])
+            arn = self.manager.arn_generator.generate(r['DBInstanceIdentifier'])
             client.add_tags_to_resource(ResourceName=arn, Tags=tags)
 
 
@@ -205,9 +212,7 @@ class Tag(tags.Tag):
         client = local_session(
             self.manager.session_factory).client('rds')
         for r in resources:
-            arn = "arn:aws:rds:%s:%s:db:%s" % (
-                self.manager.config.region, self.manager.account_id,
-                r['DBInstanceIdentifier'])
+            arn = self.manager.arn_generator.generate(r['DBInstanceIdentifier'])
             client.add_tags_to_resource(ResourceName=arn, Tags=tags)
 
 
@@ -222,9 +227,7 @@ class RemoveTag(tags.RemoveTag):
         client = local_session(
             self.manager.session_factory).client('rds')
         for r in resources:
-            arn = "arn:aws:rds:%s:%s:db:%s" % (
-                self.manager.config.region, self.manager.account_id,
-                r['DBInstanceIdentifier'])
+            arn = self.manager.arn_generator.generate(r['DBInstanceIdentifier'])
             client.remove_tags_from_resource(
                 ResourceName=arn, TagKeys=tag_keys)
 
@@ -373,6 +376,8 @@ class RetentionWindow(BaseAction):
 
 @resources.register('rds-snapshot')
 class RDSSnapshot(QueryResourceManager):
+    """Resource manager for RDS DB snapshots.
+    """
 
     class Meta(object):
 
@@ -423,3 +428,30 @@ class RDSSnapshotDelete(BaseAction):
                     DBSnapshotIdentifier=s['DBSnapshotIdentifier'])
             except ClientError as e:
                 raise
+
+
+class ARNGenerator(object):
+    """Base class for RDS ARN generators.
+    """
+
+    def __init__(self, region, account_id, resource_type):
+        self._region = region
+        self._account_id = account_id
+        self._resource_type = resource_type
+
+    def generate(self, name):
+        """Generates an Amazon Resource Name for the specified resource.
+
+        See http://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html
+        """
+        arn = 'arn:aws:rds:%s:%s:%s:%s' % (
+            self._region, self._account_id, self._resource_type, name)
+        return arn
+
+
+class DBInstanceARNGenerator(ARNGenerator):
+    """RDS DB instance ARN generator.
+    """
+
+    def __init__(self, region, account_id):
+        super(DBInstanceARNGenerator, self).__init__(region, account_id, 'db')

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -107,7 +107,7 @@ class RDS(QueryResourceManager):
 
     def augment(self, resources):
         _rds_tags(
-            self.query.resolve(self.resource_type),
+            self.get_model(),
             resources, self.session_factory, self.executor_factory,
             self.arn_generator)
         return resources

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -30,40 +30,27 @@ from c7n.filters import Filter, OPERATORS
 from c7n import utils
 
 DEFAULT_TAG = "maid_status"
-
-
-def register_tags(filters, actions, id_key):
-    filters.register('marked-for-op', TagActionFilter)
-    filters.register('tag-count', TagCountFilter)
-    actions.register('mark-for-op', TagDelayedAction.set_id(id_key))
-    actions.register('tag-trim', TagTrim.set_id(id_key))
-
-    tag = Tag.set_id(id_key)
-    actions.register('mark', tag)
-    actions.register('tag', tag)
-
-    remove_tag = RemoveTag.set_id(id_key)
-    actions.register('unmark', remove_tag)
-    actions.register('untag', remove_tag)
-    actions.register('remove-tag', remove_tag)
-
 ACTIONS = [
     'suspend', 'resume', 'terminate', 'stop', 'start',
     'delete', 'deletion']
 
 
-class ResourceTag(object):
+def register_tags(filters, actions):
+    filters.register('marked-for-op', TagActionFilter)
+    filters.register('tag-count', TagCountFilter)
 
-    @property
-    def id_key(self):
-        raise NotImplementedError()
+    actions.register('mark-for-op', TagDelayedAction)
+    actions.register('tag-trim', TagTrim)
 
-    @classmethod
-    def set_id(cls, key):
-        return type(cls.__name__, (cls,), {'id_key': key})
+    actions.register('mark', Tag)
+    actions.register('tag', Tag)
+
+    actions.register('unmark', RemoveTag)
+    actions.register('untag', RemoveTag)
+    actions.register('remove-tag', RemoveTag)
 
 
-class TagTrim(Action, ResourceTag):
+class TagTrim(Action):
     """Automatically remove tags from an ec2 resource.
 
     EC2 Resources have a limit of 10 tags, in order to make
@@ -106,6 +93,8 @@ class TagTrim(Action, ResourceTag):
         preserve={'type': 'array', 'items': {'type': 'string'}})
 
     def process(self, resources):
+        self.id_key = self.manager.get_model().id
+
         self.preserve = set(self.data.get('preserve'))
         self.space = self.data.get('space', 3)
 
@@ -255,7 +244,7 @@ class TagCountFilter(Filter):
         return op(tag_count, count)
 
 
-class Tag(Action, ResourceTag):
+class Tag(Action):
     """Tag an ec2 resource.
     """
 
@@ -269,6 +258,8 @@ class Tag(Action, ResourceTag):
         )
 
     def process(self, resources):
+        self.id_key = self.manager.get_model().id
+
         # Legacy
         msg = self.data.get('msg')
         msg = self.data.get('value') or msg
@@ -299,7 +290,9 @@ class Tag(Action, ResourceTag):
                 if f.exception():
                     self.log.error(
                         "Exception removing tags: %s on resources:%s \n %s" % (
-                            tags, self.id_key, f.exception()))
+                            tags,
+                            ", ".join([r[self.id_key] for r in resource_set]),
+                            f.exception()))
 
     def process_resource_set(self, resource_set, tags):
         client = utils.local_session(
@@ -310,7 +303,7 @@ class Tag(Action, ResourceTag):
             DryRun=self.manager.config.dryrun)
 
 
-class RemoveTag(Action, ResourceTag):
+class RemoveTag(Action):
     """Remove tags from ec2 resources.
     """
 
@@ -322,6 +315,8 @@ class RemoveTag(Action, ResourceTag):
         tags={'type': 'array', 'items': {'type': 'string'}})
 
     def process(self, resources):
+        self.id_key = self.manager.get_model().id
+
         tags = self.data.get('tags', [DEFAULT_TAG])
         batch_size = self.data.get('batch_size', self.batch_size)
 
@@ -335,7 +330,9 @@ class RemoveTag(Action, ResourceTag):
                 if f.exception():
                     self.log.error(
                         "Exception removing tags: %s on resources:%s \n %s" % (
-                            tags, self.id_key, f.exception()))
+                            tags,
+                            ", ".join([r[self.id_key] for r in resource_set]),
+                            f.exception()))
 
     def process_resource_set(self, vol_set, tag_keys):
         client = utils.local_session(
@@ -346,7 +343,7 @@ class RemoveTag(Action, ResourceTag):
             DryRun=self.manager.config.dryrun)
 
 
-class TagDelayedAction(Action, ResourceTag):
+class TagDelayedAction(Action):
     """Tag resources for future action.
 
     .. code-block :: yaml
@@ -374,6 +371,7 @@ class TagDelayedAction(Action, ResourceTag):
     batch_size = 200
 
     def process(self, resources):
+        self.id_key = self.manager.get_model().id
 
         # Move this to policy? / no resources bypasses actions?
         if not len(resources):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -58,8 +58,7 @@ class RDSTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-        arn = "arn:aws:rds:%s:%s:db:%s" % (
-            p.resource_manager.config.region, p.resource_manager.account_id,
+        arn = p.resource_manager.arn_generator.generate(
             resources[0]['DBInstanceIdentifier'])
 
         tags = client.list_tags_for_resource(ResourceName=arn)


### PR DESCRIPTION
* Split into 2 commits, one for the RDS ARN generator addition and one for the tag/meta-model changes
* Add `ARNGenerator` class to generate RDS ARNs
* Create ARN generator in RDS resource constructor so that account ID is always set
* Replace `ResourceTag` class with use of the resource meta-model and change callers of `register_tags`
* Add `get_model` utility method to `ResourceManager` and replace various calls to `query.resolve(resource_type)`
* Fixes https://github.com/capitalone/cloud-custodian/issues/273