### PR TITLE
Corrected mixed  `markdown` and `reST`  syntax of README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,10 +157,11 @@ of software distributed by Capital One, You reserve all right, title,
 and interest in and to Your Contributions; this Agreement does not
 impact Your rights to use Your own Contributions for any other purpose
 
-##### [Link to Agreement] (https://docs.google.com/forms/d/19LpBBjykHPox18vrZvBbZUcK6gQTj7qv1O5hCduAZFU/viewform)
+`Download the Agreement <https://docs.google.com/forms/d/19LpBBjykHPox18vrZvBbZUcK6gQTj7qv1O5hCduAZFU/viewform>`_
 
-This project adheres to the
-[Open Code of Conduct][code-of-conduct]. By participating, you are
+Code of Conduct
+###############
+
+This project adheres to the `Open Code of Conduct <http://www.capitalone.io/codeofconduct/>`_ By participating, you are
 expected to honor this code.
 
-[code-of-conduct]: http://www.capitalone.io/codeofconduct/


### PR DESCRIPTION
The README used a mix of syntax to add links near the bottom of the document. This corrects the links at the bottom of the README.

An independent question might be raised: why `reST` and not `markdown`? `reST` appears to be a highly specialized format that deviates dramatically from more the ubiquitous `markdown`, or [CommonMark](http://commonmark.org/), syntax.