### PR TITLE
tag-trim action for RDS instances

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -214,3 +214,18 @@ def parse_s3(s3_path):
     else:
         key_prefix = s3_path[s3_path.find('/', 5):]
     return s3_path, bucket, key_prefix
+
+
+def generate_arn(
+        service, resource, partition='aws',
+        region=None, account_id=None, resource_type=None, separator='/'):
+    """Generate an Amazon Resource Name.
+    See http://docs.aws.amazon.com/general/latest/gr/aws-arns-and-namespaces.html.
+    """
+    arn = 'arn:%s:%s:%s:%s:' % (
+        partition, service, region if region else '', account_id if account_id else '')
+    if resource_type:
+        arn = arn + '%s%s%s' % (resource_type, separator, resource)
+    else:
+        arn = arn + resource
+    return arn

--- a/tests/data/placebo/test_rds_tag_trim/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_rds_tag_trim/iam.ListRoles_1.json
@@ -1,0 +1,30 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AAKVUG6oouqUWrxlFukIbjuEpYbnFs07xCfDiKrqFwQXJ5FtAS+E41rwcx8anK0PS96pdOV2t4dX2nmpIR0+E7T7", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22ec2.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAIBRFOWJZSGZJEZVAK", 
+                "CreateDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 55
+                }, 
+                "RoleName": "BaseIAMRole", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::619193117841:role/BaseIAMRole"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "d4b5d85e-2023-11e6-964c-7b76c530a910"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_tag_trim/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_tag_trim/rds.DescribeDBInstances_1.json
@@ -1,0 +1,111 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBInstances": [
+            {
+                "PubliclyAccessible": false, 
+                "MasterUsername": "custodian", 
+                "MonitoringInterval": 0, 
+                "LicenseModel": "postgresql-license", 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-0a08e365"
+                    }
+                ], 
+                "InstanceCreateTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 22, 
+                    "microsecond": 993000, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 43
+                }, 
+                "CopyTagsToSnapshot": true, 
+                "OptionGroupMemberships": [
+                    {
+                        "Status": "in-sync", 
+                        "OptionGroupName": "default:postgres-9-4"
+                    }
+                ], 
+                "PendingModifiedValues": {}, 
+                "Engine": "postgres", 
+                "MultiAZ": false, 
+                "LatestRestorableTime": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 44
+                }, 
+                "DBSecurityGroups": [], 
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.postgres9.4", 
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ], 
+                "AutoMinorVersionUpgrade": true, 
+                "PreferredBackupWindow": "08:35-09:05", 
+                "DBSubnetGroup": {
+                    "Subnets": [
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-389e3d53", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2c"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3e9e3d55", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2a"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-3f9e3d54", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2b"
+                            }
+                        }
+                    ], 
+                    "DBSubnetGroupName": "default", 
+                    "VpcId": "vpc-399e3d52", 
+                    "DBSubnetGroupDescription": "default", 
+                    "SubnetGroupStatus": "Complete"
+                }, 
+                "ReadReplicaDBInstanceIdentifiers": [], 
+                "AllocatedStorage": 5, 
+                "BackupRetentionPeriod": 7, 
+                "PreferredMaintenanceWindow": "thu:10:25-thu:10:55", 
+                "Endpoint": {
+                    "Port": 5432, 
+                    "Address": "custodiantest.cj9uic5xuiu0.us-west-2.rds.amazonaws.com"
+                }, 
+                "DBInstanceStatus": "available", 
+                "EngineVersion": "9.4.7", 
+                "AvailabilityZone": "us-west-2b", 
+                "DomainMemberships": [], 
+                "StorageType": "gp2", 
+                "DbiResourceId": "db-V57KXLXSG4MTCQYEUXJF3D4LLE", 
+                "CACertificateIdentifier": "rds-ca-2015", 
+                "KmsKeyId": "arn:aws:kms:us-west-2:619193117841:key/43811d5f-db1f-448d-b61d-04c5bf49b9d8", 
+                "StorageEncrypted": true, 
+                "DBInstanceClass": "db.m3.medium", 
+                "DbInstancePort": 0, 
+                "DBInstanceIdentifier": "custodiantest"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "d46cc0b1-2023-11e6-9541-0dacbe99b868"
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_tag_trim/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_rds_tag_trim/rds.ListTagsForResource_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "d4ec0352-2023-11e6-bcfb-97d0579f549a"
+        }, 
+        "TagList": [
+            {
+                "Value": "postgres", 
+                "Key": "Platform"
+            }, 
+            {
+                "Value": "other", 
+                "Key": "workload-type"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_tag_trim/rds.RemoveTagsFromResource_1.json
+++ b/tests/data/placebo/test_rds_tag_trim/rds.RemoveTagsFromResource_1.json
@@ -1,0 +1,9 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "8facab58-2a8a-11e6-bccf-cb3bd81739e8"
+        }
+    }
+}

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -42,6 +42,19 @@ class RDSTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_rds_tag_trim(self):
+        session_factory = self.replay_flight_data('test_rds_tag_trim')
+        p = self.load_policy({
+            'name': 'rds-tags',
+            'resource': 'rds',
+            'filters': [
+                {'tag:Platform': 'postgres'}],
+            'actions': [
+                {'type': 'tag-trim', 'preserve': ['Name', 'Owner']}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_rds_tag_and_remove(self):
         self.patch(rds.RDS, 'executor_factory', MainThreadExecutor)
         session_factory = self.replay_flight_data('test_rds_tag_and_remove')
@@ -58,7 +71,7 @@ class RDSTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
-        arn = p.resource_manager.arn_generator.generate(
+        arn = p.resource_manager.generate_arn(
             resources[0]['DBInstanceIdentifier'])
 
         tags = client.list_tags_for_resource(ResourceName=arn)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -29,7 +29,7 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(
             list(utils.chunks(range(60), size=50)),
             [range(50), range(50, 60, 1)])
-        
+
     def test_type_schema(self):
         self.assertEqual(
             utils.type_schema('tester'),
@@ -38,4 +38,23 @@ class UtilTest(unittest.TestCase):
              'required': ['type'],
              'properties': {
                  'type': {'enum': ['tester']}}})
-        
+
+    def test_generate_arn(self):
+        self.assertEqual(
+            utils.generate_arn('s3', 'my_bucket'),
+            'arn:aws:s3:::my_bucket')
+        self.assertEqual(
+            utils.generate_arn('cloudformation',
+                'MyProductionStack/abc9dbf0-43c2-11e3-a6e8-50fa526be49c',
+                region='us-east-1',
+                account_id='123456789012',
+                resource_type='stack'),
+            'arn:aws:cloudformation:us-east-1:123456789012:stack/MyProductionStack/abc9dbf0-43c2-11e3-a6e8-50fa526be49c')
+        self.assertEqual(
+            utils.generate_arn('rds',
+                'mysql-option-group1',
+                region='us-east-1',
+                account_id='123456789012',
+                resource_type='og',
+                separator=':'),
+            'arn:aws:rds:us-east-1:123456789012:og:mysql-option-group1')


### PR DESCRIPTION
* Add `generate_arn()` in `utils.py`
* Replace `ARNGenerator` class hierarchy with `functools.partial` (as requested here: https://github.com/capitalone/cloud-custodian/pull/281#issuecomment-231530194)
* Add RDS 'tag-trim' action
* Add RDS 'tag-trim' action unit tests
* Fix _UnboundLocalError: local variable 'tag_list' referenced before assignment_
* Fixes #307