### PR TITLE
switching db snapshot and time so the snapshot starts with a letter

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -316,8 +316,8 @@ class Delete(BaseAction):
                 params['SkipFinalSnapshot'] = True
             else:
                 params['FinalDBSnapshotIdentifier'] = "%s-%s" % (
-                        now.strftime("%Y-%m-%d"),
-                        rdb['DBInstanceIdentifier']
+                        rdb['DBInstanceIdentifier'],
+                        now.strftime("%Y-%m-%d")
                         )
             try:
                 client.delete_db_instance(**params)


### PR DESCRIPTION
It is invalid to start with a DB snapshot with a time because it must start with a number. Switching ordering of DB identifier name and time