### PR TITLE
Add 'rds-cluster' and 'rds-cluster-snapshot' resources

### DIFF
--- a/c7n/resources/__init__.py
+++ b/c7n/resources/__init__.py
@@ -40,6 +40,7 @@ def load_resources():
     import kms
     import redshift
     import rds
+    import rdscluster
     import route53
     import s3
     import sns

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -1,0 +1,205 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import logging
+
+from concurrent.futures import as_completed
+
+from c7n.actions import ActionRegistry, BaseAction
+from c7n.filters import FilterRegistry, AgeFilter, OPERATORS
+from c7n.manager import resources
+from c7n.query import QueryResourceManager
+from c7n.utils import (
+    type_schema, local_session, snapshot_identifier, chunks)
+
+log = logging.getLogger('custodian.rds-cluster')
+
+filters = FilterRegistry('rds-cluster.filters')
+actions = ActionRegistry('rds-cluster.actions')
+
+
+@resources.register('rds-cluster')
+class RDSCluster(QueryResourceManager):
+    """Resource manager for RDS clusters.
+    """
+
+    class Meta(object):
+
+        service = 'rds'
+        type = 'rds-cluster'
+        enum_spec = ('describe_db_clusters', 'DBClusters', None)
+        name = id = 'DBClusterIdentifier'
+        filter_name = None
+        filter_type = None
+        dimension = 'DBClusterIdentifier'
+        date = None
+
+    resource_type = Meta
+    filter_registry = filters
+    action_registry = actions
+
+
+@actions.register('delete')
+class Delete(BaseAction):
+
+    schema = type_schema(
+        'delete', **{'skip-snapshot': {'type': 'boolean'}})
+
+    def process(self, resources):
+        self.skip = self.data.get('skip-snapshot', False)
+        client = local_session(self.manager.session_factory).client('rds')
+
+        for cluster in resources:
+            params = {'DBClusterIdentifier': cluster['DBClusterIdentifier']}
+            if self.skip:
+                params['SkipFinalSnapshot'] = True
+            else:
+                params['FinalDBSnapshotIdentifier'] = snapshot_identifier(
+                    'Final', cluster['DBClusterIdentifier'])
+            try:
+                client.delete_db_cluster(**params)
+            except ClientError as e:
+                if e.response['Error']['Code'] in ['InvalidDBClusterStateFault']:
+                    continue
+                raise
+
+            self.log.info('Deleted RDS cluster: %s' % cluster['DBClusterIdentifier'])
+
+
+@actions.register('retention')
+class RetentionWindow(BaseAction):
+
+    date_attribute = "BackupRetentionPeriod"
+    # Tag copy not yet available for Aurora:
+    #   https://forums.aws.amazon.com/thread.jspa?threadID=225812
+    schema = type_schema(
+        'retention',
+        **{'days': {'type': 'number'}})
+
+    def process(self, resources):
+        with self.executor_factory(max_workers=2) as w:
+            futures = []
+            for resource in resources:
+                futures.append(w.submit(
+                    self.process_snapshot_retention,
+                    resource))
+                for f in as_completed(futures):
+                    if f.exception():
+                        self.log.error(
+                            "Exception setting RDS cluster retention  \n %s" % (
+                                f.exception()))
+
+    def process_snapshot_retention(self, resource):
+        current_retention = int(resource.get('BackupRetentionPeriod', 0))
+        new_retention = self.data['days']
+
+        if current_retention < new_retention:
+            self.set_retention_window(
+                resource,
+                max(current_retention, new_retention))
+            return resource
+
+    def set_retention_window(self, resource, retention):
+        c = local_session(self.manager.session_factory).client('rds')
+        c.modify_db_cluster(
+            DBClusterIdentifier=resource['DBClusterIdentifier'],
+            BackupRetentionPeriod=retention,
+            PreferredBackupWindow=resource['PreferredBackupWindow'],
+            PreferredMaintenanceWindow=resource['PreferredMaintenanceWindow'])
+
+
+@actions.register('snapshot')
+class Snapshot(BaseAction):
+
+    schema = type_schema('snapshot')
+
+    def process(self, resources):
+        with self.executor_factory(max_workers=3) as w:
+            futures = []
+            for resource in resources:
+                futures.append(w.submit(
+                    self.process_cluster_snapshot,
+                    resource))
+                for f in as_completed(futures):
+                    if f.exception():
+                        self.log.error(
+                            "Exception creating RDS cluster snapshot  \n %s" % (
+                                f.exception()))
+        return resources
+
+    def process_cluster_snapshot(self, resource):
+        c = local_session(self.manager.session_factory).client('rds')
+        c.create_db_cluster_snapshot(
+            DBClusterSnapshotIdentifier=snapshot_identifier(
+                'Backup',
+                resource['DBClusterIdentifier']),
+            DBClusterIdentifier=resource['DBClusterIdentifier'])
+
+
+@resources.register('rds-cluster-snapshot')
+class RDSClusterSnapshot(QueryResourceManager):
+    """Resource manager for RDS cluster snapshots.
+    """
+
+    class Meta(object):
+
+        service = 'rds'
+        type = 'rds-cluster-snapshot'
+        enum_spec = ('describe_db_cluster_snapshots', 'DBClusterSnapshots', None)
+        name = id = 'DBClusterSnapshotIdentifier'
+        filter_name = None
+        filter_type = None
+        dimension = None
+        date = 'SnapshotCreateTime'
+
+    resource_type = Meta
+
+    filter_registry = FilterRegistry('rdscluster-snapshot.filters')
+    action_registry = ActionRegistry('rdscluster-snapshot.actions')
+
+
+@RDSClusterSnapshot.filter_registry.register('age')
+class RDSSnapshotAge(AgeFilter):
+
+    schema = type_schema(
+        'age', days={'type': 'number'},
+        op={'type': 'string', 'enum': OPERATORS.keys()})
+
+    date_attribute = 'SnapshotCreateTime'
+
+
+@RDSClusterSnapshot.action_registry.register('delete')
+class RDSClusterSnapshotDelete(BaseAction):
+
+    def process(self, snapshots):
+        log.info("Deleting %d RDS cluster snapshots", len(snapshots))
+        with self.executor_factory(max_workers=3) as w:
+            futures = []
+            for snapshot_set in chunks(reversed(snapshots), size=50):
+                futures.append(
+                    w.submit(self.process_snapshot_set, snapshot_set))
+                for f in as_completed(futures):
+                    if f.exception():
+                        self.log.error(
+                            "Exception deleting snapshot set \n %s" % (
+                                f.exception()))
+        return snapshots
+
+    def process_snapshot_set(self, snapshots_set):
+        c = local_session(self.manager.session_factory).client('rds')
+        for s in snapshots_set:
+            try:
+                c.delete_db_cluster_snapshot(
+                    DBClusterSnapshotIdentifier=s['DBClusterSnapshotIdentifier'])
+            except ClientError as e:
+                raise

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -20,7 +20,6 @@ import threading
 import time
 
 
-
 # Try to place nice in lambda exec environment
 # where we don't require yaml
 try:
@@ -238,3 +237,10 @@ def generate_arn(
     else:
         arn = arn + resource
     return arn
+
+
+def snapshot_identifier(prefix, db_identifier):
+    """Return an identifier for a snapshot of a database or cluster.
+    """
+    now = datetime.now()
+    return  '%s-%s-%s' % (prefix, db_identifier, now.strftime('%Y-%m-%d'))

--- a/docs/source/policy/resources/rds-cluster-snapshot.rst
+++ b/docs/source/policy/resources/rds-cluster-snapshot.rst
@@ -1,0 +1,18 @@
+.. _rds-cluster-snapshot:
+
+Relational Database Service DB Cluster Snapshots (RDS DB Cluster Snapshots)
+===========================================================================
+
+Filters
+-------
+
+- Standard Value Filter (see :ref:`filters`)
+
+``age``
+  Based on ``SnapshotCreateTime`` of the snapshot, the time stamp when the snapshot was created, in days
+
+Actions
+-------
+
+``delete``
+  Delete DB cluster snapshot

--- a/docs/source/policy/resources/rds-cluster.rst
+++ b/docs/source/policy/resources/rds-cluster.rst
@@ -1,0 +1,22 @@
+.. _rds-cluster:
+
+Relational Database Service DB Clusters (RDS DB Clusters)
+=========================================================
+
+Filters
+-------
+
+- Standard Value Filter (see :ref:`filters`)
+
+Actions
+-------
+
+``delete``
+  Delete DB cluster.
+  You can specify if you want to ``skip-snapshot``, default is False
+
+``snapshot``
+  Create a manual DB cluster snapshot
+
+``retention``
+  Set the DB cluster backup retention period to ``days``

--- a/tests/data/placebo/test_rdscluster_delete/rds.DeleteDBCluster_1.json
+++ b/tests/data/placebo/test_rdscluster_delete/rds.DeleteDBCluster_1.json
@@ -1,0 +1,67 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBCluster": {
+            "MasterUsername": "u1",
+            "VpcSecurityGroups": [
+                {
+                    "Status": "active",
+                    "VpcSecurityGroupId": "sg-1"
+                }
+            ],
+            "Status": "deleting",
+            "LatestRestorableTime": {
+                "hour": 14,
+                "__class__": "datetime",
+                "month": 7,
+                "second": 47,
+                "microsecond": 674000,
+                "year": 2016,
+                "day": 27,
+                "minute": 37
+            },
+            "PreferredBackupWindow": "08:28-08:58",
+            "DBSubnetGroup": "dbsubnetgroup1",
+            "AllocatedStorage": 1,
+            "BackupRetentionPeriod": 1,
+            "PreferredMaintenanceWindow": "wed:04:07-wed:04:37",
+            "Engine": "aurora",
+            "Endpoint": "cccc.cluster-abc.us-east-1.rds.amazonaws.com",
+            "EarliestRestorableTime": {
+                "hour": 14,
+                "__class__": "datetime",
+                "month": 7,
+                "second": 47,
+                "microsecond": 674000,
+                "year": 2016,
+                "day": 27,
+                "minute": 37
+            },
+            "EngineVersion": "5.6.10a",
+            "DBClusterIdentifier": "cccc",
+            "DbClusterResourceId": "cluster-ABCD",
+            "DBClusterMembers": [
+                {
+                    "IsClusterWriter": true,
+                    "DBClusterParameterGroupStatus": "in-sync",
+                    "PromotionTier": 0,
+                    "DBInstanceIdentifier": "test-cluster-1"
+                }
+            ],
+            "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+            "StorageEncrypted": true,
+            "DatabaseName": "mydb",
+            "DBClusterParameterGroup": "default.aurora5.6",
+            "AvailabilityZones": [
+                "us-east-1a",
+                "us-east-1b",
+                "us-east-1e"
+            ],
+            "Port": 3306
+        },
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "86256d71-5408-11e6-9e2b-195660273320"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_delete/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_delete/rds.DescribeDBClusters_1.json
@@ -1,0 +1,124 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusters": [
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "bbb.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "bbb",
+                "MasterUsername": "user1",
+                "EarliestRestorableTime": {
+                    "hour": 8,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 23,
+                    "microsecond": 306000,
+                    "year": 2016,
+                    "day": 12,
+                    "minute": 1
+                },
+                "DbClusterResourceId": "cluster-ABCDEF",
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-poolmember-1"
+                    },
+                    {
+                        "IsClusterWriter": false,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-rds-poolmember-2"
+                    }
+                ],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-1"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-1",
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 0,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 7,
+                    "microsecond": 80000,
+                    "year": 2016,
+                    "day": 27,
+                    "minute": 59
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            },
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "aaa.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "aaa",
+                "MasterUsername": "user2",
+                "EarliestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "DbClusterResourceId": "cluster-ZYXWVU",
+                "DBClusterMembers": [],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-2"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-2", 
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "ca5ef80a-5396-11e6-b9e0-ddf0c53d86bf"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_retention/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_retention/rds.DescribeDBClusters_1.json
@@ -1,0 +1,124 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusters": [
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "bbb.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "bbb",
+                "MasterUsername": "user1",
+                "EarliestRestorableTime": {
+                    "hour": 8,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 23,
+                    "microsecond": 306000,
+                    "year": 2016,
+                    "day": 12,
+                    "minute": 1
+                },
+                "DbClusterResourceId": "cluster-ABCDEF",
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-poolmember-1"
+                    },
+                    {
+                        "IsClusterWriter": false,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-rds-poolmember-2"
+                    }
+                ],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-1"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-1",
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 0,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 7,
+                    "microsecond": 80000,
+                    "year": 2016,
+                    "day": 27,
+                    "minute": 59
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            },
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "aaa.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "aaa",
+                "MasterUsername": "user2",
+                "EarliestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "DbClusterResourceId": "cluster-ZYXWVU",
+                "DBClusterMembers": [],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-2"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-2", 
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "ca5ef80a-5396-11e6-b9e0-ddf0c53d86bf"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_retention/rds.ModifyDBCluster_1.json
+++ b/tests/data/placebo/test_rdscluster_retention/rds.ModifyDBCluster_1.json
@@ -1,0 +1,72 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBCluster": {
+            "Status": "available",
+            "Engine": "aurora",
+            "Endpoint": "bbb.cluster-cqjpbflwiy1j.us-east-1.rds.amazonaws.com",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+            "DBClusterIdentifier": "bbb",
+            "MasterUsername": "user1",
+            "EarliestRestorableTime": {
+                "hour": 8,
+                "__class__": "datetime",
+                "month": 7,
+                "second": 20,
+                "microsecond": 487000,
+                "year": 2016,
+                "day": 13,
+                "minute": 2
+            },
+            "DbClusterResourceId": "cluster-ABCD",
+            "DBClusterMembers": [
+                {
+                    "IsClusterWriter": true,
+                    "DBClusterParameterGroupStatus": "in-sync",
+                    "PromotionTier": 1,
+                    "DBInstanceIdentifier": "bbb-poolmember-1"
+                },
+                {
+                    "IsClusterWriter": false,
+                    "DBClusterParameterGroupStatus": "in-sync",
+                    "PromotionTier": 1,
+                    "DBInstanceIdentifier": "bbb-rds-poolmember-2"
+                }
+            ],
+            "Port": 3306,
+            "PreferredBackupWindow": "08:00-09:00",
+            "VpcSecurityGroups": [
+                {
+                    "Status": "active",
+                    "VpcSecurityGroupId": "sg-1"
+                }
+            ],
+            "DBSubnetGroup": "default-vpc-1",
+            "StorageEncrypted": true,
+            "AllocatedStorage": 1,
+            "EngineVersion": "5.6.10a",
+            "DBClusterParameterGroup": "default.aurora5.6",
+            "BackupRetentionPeriod": 7,
+            "AvailabilityZones": [
+                "us-east-1a",
+                "us-east-1b",
+                "us-east-1c"
+            ],
+            "LatestRestorableTime": {
+                "hour": 17,
+                "__class__": "datetime",
+                "month": 7,
+                "second": 58,
+                "microsecond": 224000,
+                "year": 2016,
+                "day": 27,
+                "minute": 45
+            },
+            "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+        },
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "80fcc8a7-5422-11e6-a8c7-d5084096b716"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_simple/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_simple/rds.DescribeDBClusters_1.json
@@ -1,0 +1,124 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusters": [
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "bbb.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "bbb",
+                "MasterUsername": "user1",
+                "EarliestRestorableTime": {
+                    "hour": 8,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 23,
+                    "microsecond": 306000,
+                    "year": 2016,
+                    "day": 12,
+                    "minute": 1
+                },
+                "DbClusterResourceId": "cluster-ABCDEF",
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-poolmember-1"
+                    },
+                    {
+                        "IsClusterWriter": false,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-rds-poolmember-2"
+                    }
+                ],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-1"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-1",
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 0,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 7,
+                    "microsecond": 80000,
+                    "year": 2016,
+                    "day": 27,
+                    "minute": 59
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            },
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "aaa.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "aaa",
+                "MasterUsername": "user2",
+                "EarliestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "DbClusterResourceId": "cluster-ZYXWVU",
+                "DBClusterMembers": [],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-2"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-2", 
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "ca5ef80a-5396-11e6-b9e0-ddf0c53d86bf"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot/rds.CreateDBClusterSnapshot_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot/rds.CreateDBClusterSnapshot_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshot": {
+            "Engine": "aurora",
+            "SnapshotCreateTime": {
+                "hour": 18,
+                "__class__": "datetime",
+                "month": 7,
+                "second": 3,
+                "microsecond": 330000,
+                "year": 2016,
+                "day": 28,
+                "minute": 7
+            },
+            "VpcId": "vpc-1",
+            "DBClusterIdentifier": "bbb",
+            "MasterUsername": "user1",
+            "LicenseModel": "aurora",
+            "Status": "creating",
+            "PercentProgress": 0,
+            "DBClusterSnapshotIdentifier": "a-test",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1", 
+            "ClusterCreateTime": {
+                "hour": 19,
+                "__class__": "datetime",
+                "month": 2,
+                "second": 44,
+                "microsecond": 787000,
+                "year": 2016,
+                "day": 17,
+                "minute": 1
+            },
+            "StorageEncrypted": true,
+            "AllocatedStorage": 1,
+            "SnapshotType": "manual",
+            "AvailabilityZones": [
+                "us-east-1a",
+                "us-east-1b",
+                "us-east-1c"
+            ],
+            "Port": 0
+        },
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "162d5d22-54ee-11e6-b94c-51514d945ac2"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot/rds.DescribeDBClusters_1.json
@@ -1,0 +1,124 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusters": [
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "bbb.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "bbb",
+                "MasterUsername": "user1",
+                "EarliestRestorableTime": {
+                    "hour": 8,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 23,
+                    "microsecond": 306000,
+                    "year": 2016,
+                    "day": 12,
+                    "minute": 1
+                },
+                "DbClusterResourceId": "cluster-ABCDEF",
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-poolmember-1"
+                    },
+                    {
+                        "IsClusterWriter": false,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-rds-poolmember-2"
+                    }
+                ],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-1"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-1",
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 0,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 7,
+                    "microsecond": 80000,
+                    "year": 2016,
+                    "day": 27,
+                    "minute": 59
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            },
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "aaa.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "aaa",
+                "MasterUsername": "user2",
+                "EarliestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "DbClusterResourceId": "cluster-ZYXWVU",
+                "DBClusterMembers": [],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-2"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-2", 
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "ca5ef80a-5396-11e6-b9e0-ddf0c53d86bf"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_delete/rds.DeleteDBClusterSnapshot_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_delete/rds.DeleteDBClusterSnapshot_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshot": {
+            "Engine": "aurora",
+            "SnapshotCreateTime": {
+                "hour": 11,
+                "__class__": "datetime",
+                "month": 12,
+                "second": 35,
+                "microsecond": 118000,
+                "year": 2015,
+                "day": 19,
+                "minute": 6
+            },
+            "VpcId": "vpc-e2470387",
+            "DBClusterIdentifier": "bbb",
+            "MasterUsername": "root",
+            "LicenseModel": "aurora",
+            "Status": "available",
+            "PercentProgress": 100,
+            "DBClusterSnapshotIdentifier": "bbb-final-snapshot",
+            "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1", 
+            "ClusterCreateTime": {
+                "hour": 10,
+                "__class__": "datetime",
+                "month": 12,
+                "second": 52,
+                "microsecond": 866000,
+                "year": 2015,
+                "day": 19,
+                "minute": 38
+            },
+            "StorageEncrypted": true,
+            "AllocatedStorage": 1,
+            "SnapshotType": "manual",
+            "AvailabilityZones": [
+                "us-east-1a",
+                "us-east-1b",
+                "us-east-1e"
+            ],
+            "Port": 0
+        },
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "3067ccb0-55b1-11e6-9c9e-3390fb9eb3cf"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_delete/rds.DescribeDBClusterSnapshots_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_delete/rds.DescribeDBClusterSnapshots_1.json
@@ -1,0 +1,90 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshots": [
+            {
+                "Engine": "aurora",
+                "SnapshotCreateTime": {
+                    "hour": 11,
+                    "__class__": "datetime",
+                    "month": 12,
+                    "second": 35,
+                    "microsecond": 118000,
+                    "year": 2015,
+                    "day": 19,
+                    "minute": 6
+                },
+                "VpcId": "vpc-1",
+                "DBClusterIdentifier": "aaa",
+                "MasterUsername": "root",
+                "LicenseModel": "aurora",
+                "Status": "available",
+                "PercentProgress": 100,
+                "DBClusterSnapshotIdentifier": "aaa-final-snapshot",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "ClusterCreateTime": {
+                    "hour": 10,
+                    "__class__": "datetime",
+                    "month": 12,
+                    "second": 52,
+                    "microsecond": 866000,
+                    "year": 2015,
+                    "day": 19,
+                    "minute": 38
+                },
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "SnapshotType": "manual",
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1e"
+                ],
+                "Port": 0
+            },
+            {
+                "Engine": "aurora",
+                "SnapshotCreateTime": {
+                    "hour": 13,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 42,
+                    "microsecond": 566000,
+                    "year": 2016,
+                    "day": 4,
+                    "minute": 51
+                },
+                "VpcId": "vpc-2",
+                "DBClusterIdentifier": "bbb",
+                "MasterUsername": "root",
+                "LicenseModel": "aurora",
+                "Status": "available",
+                "PercentProgress": 100,
+                "DBClusterSnapshotIdentifier": "bbb-final-snapshot",
+                "ClusterCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 11,
+                    "second": 0,
+                    "microsecond": 549000,
+                    "year": 2015,
+                    "day": 20,
+                    "minute": 46
+                },
+                "StorageEncrypted": false, 
+                "AllocatedStorage": 1,
+                "SnapshotType": "manual",
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1e"
+                ],
+                "Port": 0
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "ea909505-55a4-11e6-8ef5-b3205bcebfaa"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_snapshot_simple/rds.DescribeDBClusterSnapshots_1.json
+++ b/tests/data/placebo/test_rdscluster_snapshot_simple/rds.DescribeDBClusterSnapshots_1.json
@@ -1,0 +1,90 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusterSnapshots": [
+            {
+                "Engine": "aurora",
+                "SnapshotCreateTime": {
+                    "hour": 11,
+                    "__class__": "datetime",
+                    "month": 12,
+                    "second": 35,
+                    "microsecond": 118000,
+                    "year": 2015,
+                    "day": 19,
+                    "minute": 6
+                },
+                "VpcId": "vpc-1",
+                "DBClusterIdentifier": "aaa",
+                "MasterUsername": "root",
+                "LicenseModel": "aurora",
+                "Status": "available",
+                "PercentProgress": 100,
+                "DBClusterSnapshotIdentifier": "aaa-final-snapshot",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "ClusterCreateTime": {
+                    "hour": 10,
+                    "__class__": "datetime",
+                    "month": 12,
+                    "second": 52,
+                    "microsecond": 866000,
+                    "year": 2015,
+                    "day": 19,
+                    "minute": 38
+                },
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "SnapshotType": "manual",
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1e"
+                ],
+                "Port": 0
+            },
+            {
+                "Engine": "aurora",
+                "SnapshotCreateTime": {
+                    "hour": 13,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 42,
+                    "microsecond": 566000,
+                    "year": 2016,
+                    "day": 4,
+                    "minute": 51
+                },
+                "VpcId": "vpc-2",
+                "DBClusterIdentifier": "bbb",
+                "MasterUsername": "root",
+                "LicenseModel": "aurora",
+                "Status": "available",
+                "PercentProgress": 100,
+                "DBClusterSnapshotIdentifier": "bbb-final-snapshot",
+                "ClusterCreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 11,
+                    "second": 0,
+                    "microsecond": 549000,
+                    "year": 2015,
+                    "day": 20,
+                    "minute": 46
+                },
+                "StorageEncrypted": false, 
+                "AllocatedStorage": 1,
+                "SnapshotType": "manual",
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1e"
+                ],
+                "Port": 0
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "ea909505-55a4-11e6-8ef5-b3205bcebfaa"
+        }
+    }
+}

--- a/tests/test_rdscluster.py
+++ b/tests/test_rdscluster.py
@@ -1,0 +1,129 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from common import BaseTest
+
+from c7n.executor import MainThreadExecutor
+from c7n.resources import rdscluster
+
+
+class RDSClusterTest(BaseTest):
+
+    def test_rdscluster_simple(self):
+        session_factory = self.replay_flight_data('test_rdscluster_simple')
+        p = self.load_policy({
+            'name': 'rdscluster-simple',
+            'resource': 'rds-cluster'},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
+    def test_rdscluster_simple_filter(self):
+        session_factory = self.replay_flight_data('test_rdscluster_simple')
+        p = self.load_policy({
+            'name': 'rdscluster-simple-filter',
+            'resource': 'rds-cluster',
+            'filters': [
+                {'type': 'value',
+                 'key': 'DBClusterIdentifier',
+                 'value': 'bbb'}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_rdscluster_delete(self):
+        session_factory = self.replay_flight_data('test_rdscluster_delete')
+        p = self.load_policy({
+            'name': 'rdscluster-delete',
+            'resource': 'rds-cluster',
+            'filters': [
+                {'type': 'value',
+                 'key': 'DBClusterIdentifier',
+                 'value': 'bbb'}],
+            'actions': ['delete']},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_rdscluster_retention(self):
+        session_factory = self.replay_flight_data('test_rdscluster_retention')
+        p = self.load_policy({
+            'name': 'rdscluster-delete',
+            'resource': 'rds-cluster',
+            'filters': [
+                {'type': 'value',
+                 'key': 'DBClusterIdentifier',
+                 'value': 'bbb'}],
+            'actions': [{'type': 'retention', 'days': 21}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_rdscluster_snapshot(self):
+        session_factory = self.replay_flight_data('test_rdscluster_snapshot')
+        p = self.load_policy({
+            'name': 'rdscluster-snapshot',
+            'resource': 'rds-cluster',
+            'filters': [
+                {'type': 'value',
+                 'key': 'DBClusterIdentifier',
+                 'value': 'bbb'}],
+            'actions': [{'type': 'snapshot'}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+
+class RDSClusterSnapshotTest(BaseTest):
+
+    def test_rdscluster_snapshot_simple(self):
+        session_factory = self.replay_flight_data('test_rdscluster_snapshot_simple')
+        p = self.load_policy({
+            'name': 'rdscluster-snapshot-simple',
+            'resource': 'rds-cluster-snapshot'},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
+    def test_rdscluster_simple_filter(self):
+        session_factory = self.replay_flight_data('test_rdscluster_snapshot_simple')
+        p = self.load_policy({
+            'name': 'rdscluster-snapshot-simple-filter',
+            'resource': 'rds-cluster-snapshot',
+            'filters': [
+                {'type': 'value',
+                 'key': 'StorageEncrypted',
+                 'value': False}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_rdscluster_snapshot_trim(self):
+        factory = self.replay_flight_data('test_rdscluster_snapshot_simple')
+        p = self.load_policy({
+            'name': 'rdscluster-snapshot-age-filter',
+            'resource': 'rds-cluster-snapshot',
+            'filters': [{'age': 7}]},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)
+
+    def test_rdscluster_snapshot_trim(self):
+        factory = self.replay_flight_data('test_rdscluster_snapshot_delete')
+        p = self.load_policy({
+            'name': 'rdscluster-snapshot-trim',
+            'resource': 'rds-cluster-snapshot',
+            'actions': ['delete']},
+            session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 2)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-
 import unittest
 
 from c7n import utils
@@ -58,3 +57,8 @@ class UtilTest(unittest.TestCase):
                 resource_type='og',
                 separator=':'),
             'arn:aws:rds:us-east-1:123456789012:og:mysql-option-group1')
+
+    def test_snapshot_identifier(self):
+        identifier = utils.snapshot_identifier('bkup', 'abcdef')
+        # e.g. bkup-2016-07-27-abcdef
+        self.assertEqual(len(identifier), 22)


### PR DESCRIPTION
* Add `rds-cluster` resource; Simple to start
* Add RDS cluster `delete` action
* Add RDS cluster `retention` action
* Tag copy not yet available for Aurora
* Add RDS cluster `snapshot` action
* Add `rds-cluster-snapshot` resource; Simple to start
* Add RDS cluster snapshot `delete` action
* Update snapshot ID code to match https://github.com/capitalone/cloud-custodian/pull/318
* Add `rds-cluster` and `rds-cluster-snapshot` documentation
* Fixes https://github.com/capitalone/cloud-custodian/issues/343