### PR TITLE
Add 'delete-instances' option to RDS Cluster 'delete' action

### DIFF
--- a/docs/source/policy/resources/rds-cluster.rst
+++ b/docs/source/policy/resources/rds-cluster.rst
@@ -12,8 +12,9 @@ Actions
 -------
 
 ``delete``
-  Delete DB cluster.
+  Delete DB cluster and optionally associated DB instances.
   You can specify if you want to ``skip-snapshot``, default is False
+  You can specify if you want to ``delete-instances``, default is False
 
 ``snapshot``
   Create a manual DB cluster snapshot

--- a/tests/data/placebo/test_rdscluster_delete_with_instances/rds.DeleteDBCluster_1.json
+++ b/tests/data/placebo/test_rdscluster_delete_with_instances/rds.DeleteDBCluster_1.json
@@ -1,0 +1,67 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBCluster": {
+            "MasterUsername": "u1",
+            "VpcSecurityGroups": [
+                {
+                    "Status": "active",
+                    "VpcSecurityGroupId": "sg-1"
+                }
+            ],
+            "Status": "deleting",
+            "LatestRestorableTime": {
+                "hour": 14,
+                "__class__": "datetime",
+                "month": 7,
+                "second": 47,
+                "microsecond": 674000,
+                "year": 2016,
+                "day": 27,
+                "minute": 37
+            },
+            "PreferredBackupWindow": "08:28-08:58",
+            "DBSubnetGroup": "dbsubnetgroup1",
+            "AllocatedStorage": 1,
+            "BackupRetentionPeriod": 1,
+            "PreferredMaintenanceWindow": "wed:04:07-wed:04:37",
+            "Engine": "aurora",
+            "Endpoint": "cccc.cluster-abc.us-east-1.rds.amazonaws.com",
+            "EarliestRestorableTime": {
+                "hour": 14,
+                "__class__": "datetime",
+                "month": 7,
+                "second": 47,
+                "microsecond": 674000,
+                "year": 2016,
+                "day": 27,
+                "minute": 37
+            },
+            "EngineVersion": "5.6.10a",
+            "DBClusterIdentifier": "cccc",
+            "DbClusterResourceId": "cluster-ABCD",
+            "DBClusterMembers": [
+                {
+                    "IsClusterWriter": true,
+                    "DBClusterParameterGroupStatus": "in-sync",
+                    "PromotionTier": 0,
+                    "DBInstanceIdentifier": "test-cluster-1"
+                }
+            ],
+            "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+            "StorageEncrypted": true,
+            "DatabaseName": "mydb",
+            "DBClusterParameterGroup": "default.aurora5.6",
+            "AvailabilityZones": [
+                "us-east-1a",
+                "us-east-1b",
+                "us-east-1e"
+            ],
+            "Port": 3306
+        },
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "86256d71-5408-11e6-9e2b-195660273320"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_delete_with_instances/rds.DeleteDBInstance_1.json
+++ b/tests/data/placebo/test_rdscluster_delete_with_instances/rds.DeleteDBInstance_1.json
@@ -1,0 +1,108 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBInstance": {
+            "PubliclyAccessible": true, 
+            "MasterUsername": "superduper", 
+            "MonitoringInterval": 0, 
+            "LicenseModel": "postgresql-license", 
+            "VpcSecurityGroups": [
+                {
+                    "Status": "active", 
+                    "VpcSecurityGroupId": "sg-0a08e365"
+                }
+            ], 
+            "InstanceCreateTime": {
+                "hour": 0, 
+                "__class__": "datetime", 
+                "month": 5, 
+                "second": 10, 
+                "microsecond": 155000, 
+                "year": 2016, 
+                "day": 8, 
+                "minute": 22
+            }, 
+            "CopyTagsToSnapshot": false, 
+            "OptionGroupMemberships": [
+                {
+                    "Status": "in-sync", 
+                    "OptionGroupName": "default:postgres-9-4"
+                }
+            ], 
+            "PendingModifiedValues": {}, 
+            "Engine": "postgres", 
+            "MultiAZ": false, 
+            "LatestRestorableTime": {
+                "hour": 0, 
+                "__class__": "datetime", 
+                "month": 5, 
+                "second": 51, 
+                "microsecond": 0, 
+                "year": 2016, 
+                "day": 8, 
+                "minute": 44
+            }, 
+            "DBSecurityGroups": [], 
+            "DBParameterGroups": [
+                {
+                    "DBParameterGroupName": "default.postgres9.4", 
+                    "ParameterApplyStatus": "in-sync"
+                }
+            ], 
+            "AutoMinorVersionUpgrade": true, 
+            "PreferredBackupWindow": "06:38-07:08", 
+            "DBSubnetGroup": {
+                "Subnets": [
+                    {
+                        "SubnetStatus": "Active", 
+                        "SubnetIdentifier": "subnet-389e3d53", 
+                        "SubnetAvailabilityZone": {
+                            "Name": "us-west-2c"
+                        }
+                    }, 
+                    {
+                        "SubnetStatus": "Active", 
+                        "SubnetIdentifier": "subnet-3e9e3d55", 
+                        "SubnetAvailabilityZone": {
+                            "Name": "us-west-2a"
+                        }
+                    }, 
+                    {
+                        "SubnetStatus": "Active", 
+                        "SubnetIdentifier": "subnet-3f9e3d54", 
+                        "SubnetAvailabilityZone": {
+                            "Name": "us-west-2b"
+                        }
+                    }
+                ], 
+                "DBSubnetGroupName": "default", 
+                "VpcId": "vpc-399e3d52", 
+                "DBSubnetGroupDescription": "default", 
+                "SubnetGroupStatus": "Complete"
+            }, 
+            "ReadReplicaDBInstanceIdentifiers": [], 
+            "AllocatedStorage": 5, 
+            "BackupRetentionPeriod": 21, 
+            "PreferredMaintenanceWindow": "mon:09:22-mon:09:52", 
+            "Endpoint": {
+                "Port": 5432, 
+                "Address": "oneness.cj9uic5xuiu0.us-west-2.rds.amazonaws.com"
+            }, 
+            "DBInstanceStatus": "deleting", 
+            "EngineVersion": "9.4.7", 
+            "AvailabilityZone": "us-west-2a", 
+            "DomainMemberships": [], 
+            "StorageType": "gp2", 
+            "DbiResourceId": "db-BHKFSGDR5S2DSUNBF465JT2VRI", 
+            "CACertificateIdentifier": "rds-ca-2015", 
+            "StorageEncrypted": false, 
+            "DBInstanceClass": "db.m3.medium", 
+            "DbInstancePort": 0, 
+            "DBInstanceIdentifier": "oneness"
+        }, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "cdbbf7c5-14b6-11e6-b743-37a6d3ed4c4c"
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_delete_with_instances/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_delete_with_instances/rds.DescribeDBClusters_1.json
@@ -1,0 +1,124 @@
+{
+    "status_code": 200,
+    "data": {
+        "DBClusters": [
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "bbb.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "bbb",
+                "MasterUsername": "user1",
+                "EarliestRestorableTime": {
+                    "hour": 8,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 23,
+                    "microsecond": 306000,
+                    "year": 2016,
+                    "day": 12,
+                    "minute": 1
+                },
+                "DbClusterResourceId": "cluster-ABCDEF",
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-poolmember-1"
+                    },
+                    {
+                        "IsClusterWriter": false,
+                        "DBClusterParameterGroupStatus": "in-sync",
+                        "PromotionTier": 1,
+                        "DBInstanceIdentifier": "bbb-rds-poolmember-2"
+                    }
+                ],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-1"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-1",
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 0,
+                    "__class__": "datetime",
+                    "month": 7,
+                    "second": 7,
+                    "microsecond": 80000,
+                    "year": 2016,
+                    "day": 27,
+                    "minute": 59
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            },
+            {
+                "Status": "available",
+                "Engine": "aurora",
+                "Endpoint": "aaa.cluster-xyz.us-east-1.rds.amazonaws.com",
+                "KmsKeyId": "arn:aws:kms:us-east-1:123:key/k1",
+                "DBClusterIdentifier": "aaa",
+                "MasterUsername": "user2",
+                "EarliestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "DbClusterResourceId": "cluster-ZYXWVU",
+                "DBClusterMembers": [],
+                "Port": 3306,
+                "PreferredBackupWindow": "08:00-09:00",
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active",
+                        "VpcSecurityGroupId": "sg-2"
+                    }
+                ],
+                "DBSubnetGroup": "default-vpc-2", 
+                "StorageEncrypted": true,
+                "AllocatedStorage": 1,
+                "EngineVersion": "5.6.10a",
+                "DBClusterParameterGroup": "default.aurora5.6",
+                "BackupRetentionPeriod": 14,
+                "AvailabilityZones": [
+                    "us-east-1a",
+                    "us-east-1b",
+                    "us-east-1c"
+                ],
+                "LatestRestorableTime": {
+                    "hour": 15,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 31,
+                    "microsecond": 154000,
+                    "year": 2016,
+                    "day": 25,
+                    "minute": 44
+                },
+                "PreferredMaintenanceWindow": "sun:07:00-sun:08:00"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RequestId": "ca5ef80a-5396-11e6-b9e0-ddf0c53d86bf"
+        }
+    }
+}

--- a/tests/test_rdscluster.py
+++ b/tests/test_rdscluster.py
@@ -50,7 +50,25 @@ class RDSClusterTest(BaseTest):
                 {'type': 'value',
                  'key': 'DBClusterIdentifier',
                  'value': 'bbb'}],
-            'actions': ['delete']},
+            'actions': [
+                {'type': 'delete',
+                 'delete-instances': False}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_rdscluster_delete_with_instances(self):
+        session_factory = self.replay_flight_data('test_rdscluster_delete_with_instances')
+        p = self.load_policy({
+            'name': 'rdscluster-delete',
+            'resource': 'rds-cluster',
+            'filters': [
+                {'type': 'value',
+                 'key': 'DBClusterIdentifier',
+                 'value': 'bbb'}],
+            'actions': [
+                {'type': 'delete',
+                 'delete-instances': True}]},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)


### PR DESCRIPTION
* Add unit tests and documentation for RDS Cluster 'delete'/'delete-instances' action option
* Also tidied up various Flake8 issues with `rdscluster.py`
* Fixes #371 