### PR TITLE
find unused security groups

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -12,6 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+from botocore.exceptions import ClientError
+
 from c7n.actions import BaseAction
 from c7n.filters import (
     DefaultVpcBase, Filter, FilterValidationError, ValueFilter)
@@ -59,6 +61,117 @@ class Subnet(QueryResourceManager):
 class SecurityGroup(QueryResourceManager):
 
     resource_type = 'aws.ec2.security-group'
+
+
+@SecurityGroup.filter_registry.register('unused')
+class UnusedSecurityGroup(Filter):
+    """Filter to just security groups that are not used.
+
+    We scan all extant enis in the vpc to get a baseline set of groups
+    in use. Then augment with those referenced by launch configs, and
+    lambdas as they may not have extant resources in the vpc at a
+    given moment. We also find any security group with references from
+    other security group either within the vpc or across peered
+    connections.
+    """
+    schema = type_schema('unused')
+
+    def process(self, resources, event=None):
+        used = self.scan_groups()
+        unused = [r for r in resources if r['GroupId'] not in used]
+        return self.filter_peered_refs(unused)
+
+    def filter_peered_refs(self, resources):
+        # Check that groups are not referenced across accounts
+        client = local_session(self.manager.session_factory).client('ec2')
+        peered_ids = set()
+        for r in resources:
+            try:
+                for sg_ref in client.describe_security_group_references(
+                        GroupId=[r['GroupId']])['SecurityGroupReferenceSet']:
+                    peered_ids.add(sg_ref['GroupId'])
+            except ClientError as e:
+                if e.response['Error']['Code'] == "InvalidGroup.NotFound":
+                    self.log.info(
+                        "sg peered refs reports %s not found", r['GroupId'])
+                    continue
+                raise
+        self.log.info(
+            "%d of %d groups w/ peered refs", len(peered_ids), len(resources))
+        return [r for r in resources if r['GroupId'] not in peered_ids]
+
+    def scan_groups(self):
+        used = set()
+        for kind, scanner in (
+                ("nics", self.get_eni_sgs),
+                ("sg-perm-refs", self.get_sg_refs),
+                ('lambdas', self.get_lambda_sgs),
+                ("launch-configs", self.get_launch_config_sgs),
+        ):
+            sg_ids = scanner()
+            new_refs = sg_ids.difference(used)
+            used = used.union(sg_ids)
+            self.log.info(
+                "%s using %d sgs, new refs %s total %s",
+                kind, len(sg_ids), len(new_refs), len(used))
+
+        return used
+#
+# these don't provide additional coverage but implemented as proof
+#
+#    def get_elb_sgs(self):
+#        sg_ids = set()
+#        from c7n.resources.elb import ELB
+#        for lb in ELB(self.manager.ctx, {}).resources():
+#            for sg in lb.get('SecurityGroups', ()):
+#                sg_ids.add(sg)
+#        return sg_ids
+#
+#    def get_rds_sgs(self):
+#        sg_ids = set()
+#        from c7n.resources.rds import RDS
+#        for rds in RDS(self.manager.ctx, {}).resources():
+#            for sg in rds.get('VpcSecurityGroups', ()):
+#                sg_ids.add(sg['VpcSecurityGroupId'])
+#        return sg_ids
+
+    def get_launch_config_sgs(self):
+        # Note assuming we also have launch config garbage collection
+        # enabled.
+        sg_ids = set()
+        from c7n.resources.asg import LaunchConfig
+        for cfg in LaunchConfig(self.manager.ctx, {}).resources():
+            for g in cfg['SecurityGroups']:
+                sg_ids.add(g)
+            for g in cfg['ClassicLinkVPCSecurityGroups']:
+                sg_ids.add(g)
+        return sg_ids
+
+    def get_lambda_sgs(self):
+        sg_ids = set()
+        from c7n.resources.awslambda import AWSLambda
+        for func in AWSLambda(self.manager.ctx, {}).resources():
+            if 'VpcConfig' not in func:
+                continue
+            for g in func['VpcConfig']['SecurityGroupIds']:
+                sg_ids.add(g)
+        return sg_ids
+
+    def get_eni_sgs(self):
+        sg_ids = set()
+        for nic in NetworkInterface(self.manager.ctx, {}).resources():
+            for g in nic['Groups']:
+                sg_ids.add(g['GroupId'])
+        return sg_ids
+
+    def get_sg_refs(self):
+        sg_ids = set()
+        for sg in SecurityGroup(self.manager.ctx, {}).resources():
+            for perm_type in ('IpPermissions', 'IpPermissionsEgress'):
+                for p in sg.get(perm_type, []):
+                    for g in p.get('UserIdGroupPairs', ()):
+                        sg_ids.add(g['GroupId'])
+        return sg_ids
 
 
 @SecurityGroup.filter_registry.register('default-vpc')

--- a/tests/data/placebo/test_security_group_unused/autoscaling.DescribeLaunchConfigurations_1.json
+++ b/tests/data/placebo/test_security_group_unused/autoscaling.DescribeLaunchConfigurations_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "LaunchConfigurations": [], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "06358a48-6a0d-11e6-bf24-75e990bfdbd7", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "06358a48-6a0d-11e6-bf24-75e990bfdbd7", 
+                "date": "Wed, 24 Aug 2016 15:11:24 GMT", 
+                "content-length": "350", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_security_group_unused/ec2.DescribeNetworkInterfaces_1.json
+++ b/tests/data/placebo/test_security_group_unused/ec2.DescribeNetworkInterfaces_1.json
@@ -1,0 +1,176 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "86b15f4e-2e23-4add-bd50-76ca2afb0f0e", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Wed, 24 Aug 2016 15:11:23 GMT"
+            }
+        }, 
+        "NetworkInterfaces": [
+            {
+                "Status": "in-use", 
+                "MacAddress": "02:7f:f1:7a:69:89", 
+                "SourceDestCheck": true, 
+                "VpcId": "vpc-4a9ff72e", 
+                "Description": "RDSNetworkInterface", 
+                "Association": {
+                    "PublicIp": "52.41.66.102", 
+                    "PublicDnsName": "ec2-52-41-66-102.us-west-2.compute.amazonaws.com", 
+                    "IpOwnerId": "amazon-rds"
+                }, 
+                "NetworkInterfaceId": "eni-794e5a04", 
+                "PrivateIpAddresses": [
+                    {
+                        "PrivateDnsName": "ip-172-31-23-100.us-west-2.compute.internal", 
+                        "Association": {
+                            "PublicIp": "52.41.66.102", 
+                            "PublicDnsName": "ec2-52-41-66-102.us-west-2.compute.amazonaws.com", 
+                            "IpOwnerId": "amazon-rds"
+                        }, 
+                        "Primary": true, 
+                        "PrivateIpAddress": "172.31.23.100"
+                    }
+                ], 
+                "RequesterManaged": true, 
+                "Groups": [
+                    {
+                        "GroupName": "default", 
+                        "GroupId": "sg-f9cc4d9f"
+                    }
+                ], 
+                "PrivateDnsName": "ip-172-31-23-100.us-west-2.compute.internal", 
+                "AvailabilityZone": "us-west-2a", 
+                "Attachment": {
+                    "Status": "attached", 
+                    "DeviceIndex": 1, 
+                    "AttachTime": {
+                        "hour": 18, 
+                        "__class__": "datetime", 
+                        "month": 7, 
+                        "second": 36, 
+                        "microsecond": 0, 
+                        "year": 2016, 
+                        "day": 28, 
+                        "minute": 41
+                    }, 
+                    "DeleteOnTermination": false, 
+                    "AttachmentId": "eni-attach-9ec3d632", 
+                    "InstanceOwnerId": "amazon-rds"
+                }, 
+                "RequesterId": "amazon-rds", 
+                "SubnetId": "subnet-15452171", 
+                "OwnerId": "644160558196", 
+                "TagSet": [], 
+                "PrivateIpAddress": "172.31.23.100"
+            }, 
+            {
+                "Status": "in-use", 
+                "MacAddress": "02:8c:7e:01:d3:ed", 
+                "SourceDestCheck": true, 
+                "VpcId": "vpc-4a9ff72e", 
+                "Description": "RDSNetworkInterface", 
+                "Association": {
+                    "PublicIp": "52.38.217.137", 
+                    "PublicDnsName": "ec2-52-38-217-137.us-west-2.compute.amazonaws.com", 
+                    "IpOwnerId": "amazon-rds"
+                }, 
+                "NetworkInterfaceId": "eni-c57041b8", 
+                "PrivateIpAddresses": [
+                    {
+                        "PrivateDnsName": "ip-172-31-24-254.us-west-2.compute.internal", 
+                        "Association": {
+                            "PublicIp": "52.38.217.137", 
+                            "PublicDnsName": "ec2-52-38-217-137.us-west-2.compute.amazonaws.com", 
+                            "IpOwnerId": "amazon-rds"
+                        }, 
+                        "Primary": true, 
+                        "PrivateIpAddress": "172.31.24.254"
+                    }
+                ], 
+                "RequesterManaged": true, 
+                "Groups": [
+                    {
+                        "GroupName": "default", 
+                        "GroupId": "sg-f9cc4d9f"
+                    }
+                ], 
+                "PrivateDnsName": "ip-172-31-24-254.us-west-2.compute.internal", 
+                "AvailabilityZone": "us-west-2a", 
+                "Attachment": {
+                    "Status": "attached", 
+                    "DeviceIndex": 1, 
+                    "AttachTime": {
+                        "hour": 21, 
+                        "__class__": "datetime", 
+                        "month": 7, 
+                        "second": 39, 
+                        "microsecond": 0, 
+                        "year": 2016, 
+                        "day": 23, 
+                        "minute": 34
+                    }, 
+                    "DeleteOnTermination": false, 
+                    "AttachmentId": "eni-attach-b3635c1f", 
+                    "InstanceOwnerId": "amazon-rds"
+                }, 
+                "RequesterId": "amazon-rds", 
+                "SubnetId": "subnet-15452171", 
+                "OwnerId": "644160558196", 
+                "TagSet": [], 
+                "PrivateIpAddress": "172.31.24.254"
+            }, 
+            {
+                "Status": "in-use", 
+                "MacAddress": "0a:0e:49:d9:55:0d", 
+                "SourceDestCheck": true, 
+                "VpcId": "vpc-4a9ff72e", 
+                "Description": "ELB test-load-balancer", 
+                "NetworkInterfaceId": "eni-042ea05b", 
+                "PrivateIpAddresses": [
+                    {
+                        "PrivateDnsName": "ip-172-31-1-181.us-west-2.compute.internal", 
+                        "Primary": true, 
+                        "PrivateIpAddress": "172.31.1.181"
+                    }
+                ], 
+                "RequesterManaged": true, 
+                "Groups": [
+                    {
+                        "GroupName": "default", 
+                        "GroupId": "sg-f9cc4d9f"
+                    }
+                ], 
+                "PrivateDnsName": "ip-172-31-1-181.us-west-2.compute.internal", 
+                "AvailabilityZone": "us-west-2c", 
+                "Attachment": {
+                    "Status": "attached", 
+                    "DeviceIndex": 1, 
+                    "AttachTime": {
+                        "hour": 2, 
+                        "__class__": "datetime", 
+                        "month": 7, 
+                        "second": 19, 
+                        "microsecond": 0, 
+                        "year": 2016, 
+                        "day": 29, 
+                        "minute": 31
+                    }, 
+                    "DeleteOnTermination": false, 
+                    "AttachmentId": "eni-attach-813ccf22", 
+                    "InstanceOwnerId": "amazon-elb"
+                }, 
+                "RequesterId": "760845874091", 
+                "SubnetId": "subnet-5fb47507", 
+                "OwnerId": "644160558196", 
+                "TagSet": [], 
+                "PrivateIpAddress": "172.31.1.181"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_security_group_unused/ec2.DescribeSecurityGroupReferences_1.json
+++ b/tests/data/placebo/test_security_group_unused/ec2.DescribeSecurityGroupReferences_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "SecurityGroupReferenceSet": [], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "0c24f2e7-c862-4832-ac34-7983654b7214", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Wed, 24 Aug 2016 15:11:25 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_security_group_unused/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_security_group_unused/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,115 @@
+{
+    "status_code": 200, 
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "644160558196", 
+                                "GroupId": "sg-13de8f75"
+                            }
+                        ], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-dc0452b8", 
+                "OwnerId": "644160558196", 
+                "GroupId": "sg-13de8f75"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "644160558196", 
+                                "GroupId": "sg-f9cc4d9f"
+                            }
+                        ], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-4a9ff72e", 
+                "OwnerId": "644160558196", 
+                "GroupId": "sg-f9cc4d9f"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 5432, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "108.56.194.116/32"
+                            }
+                        ], 
+                        "ToPort": 5432, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard", 
+                "VpcId": "vpc-4a9ff72e", 
+                "OwnerId": "644160558196", 
+                "GroupId": "sg-f6a42890"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "16ff449b-ac35-4e07-84b8-6ad2f725fc7d", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Wed, 24 Aug 2016 15:11:23 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_security_group_unused/ec2.DescribeSecurityGroups_2.json
+++ b/tests/data/placebo/test_security_group_unused/ec2.DescribeSecurityGroups_2.json
@@ -1,0 +1,115 @@
+{
+    "status_code": 200, 
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "644160558196", 
+                                "GroupId": "sg-13de8f75"
+                            }
+                        ], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-dc0452b8", 
+                "OwnerId": "644160558196", 
+                "GroupId": "sg-13de8f75"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "644160558196", 
+                                "GroupId": "sg-f9cc4d9f"
+                            }
+                        ], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-4a9ff72e", 
+                "OwnerId": "644160558196", 
+                "GroupId": "sg-f9cc4d9f"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "PrefixListIds": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 5432, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "108.56.194.116/32"
+                            }
+                        ], 
+                        "ToPort": 5432, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard", 
+                "VpcId": "vpc-4a9ff72e", 
+                "OwnerId": "644160558196", 
+                "GroupId": "sg-f6a42890"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "d9e4e432-c163-40a8-a871-d1d6ada2f440", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Wed, 24 Aug 2016 15:11:23 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_security_group_unused/lambda.ListFunctions_1.json
+++ b/tests/data/placebo/test_security_group_unused/lambda.ListFunctions_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Functions": [
+            {
+                "Version": "$LATEST", 
+                "CodeSha256": "Ys1Syk2A7u/lMTJwQbjxeUNZ+A4o8nw4COQIQfdTXAE=", 
+                "FunctionName": "ec2-instance-type", 
+                "MemorySize": 128, 
+                "CodeSize": 1257, 
+                "FunctionArn": "arn:aws:lambda:us-west-2:644160558196:function:ec2-instance-type", 
+                "Handler": "index.handler", 
+                "Role": "arn:aws:iam::644160558196:role/lambda_basic_execution", 
+                "Timeout": 10, 
+                "LastModified": "2016-08-08T10:34:32.668+0000", 
+                "Runtime": "nodejs4.3", 
+                "Description": "An AWS Config rule that is triggered by configuration changes to EC2 instances. Checks instance types."
+            }, 
+            {
+                "Version": "$LATEST", 
+                "CodeSha256": "8341HwPhM/J5h8xbCM/io4DV55d16S5CFc7V/x13Fow=", 
+                "FunctionName": "process_resources", 
+                "VpcConfig": {
+                    "SubnetIds": [], 
+                    "SecurityGroupIds": []
+                }, 
+                "MemorySize": 128, 
+                "CodeSize": 240, 
+                "FunctionArn": "arn:aws:lambda:us-west-2:644160558196:function:process_resources", 
+                "Handler": "lambda_function.process_resources", 
+                "Role": "arn:aws:iam::644160558196:role/lambda_basic_execution", 
+                "Timeout": 5, 
+                "LastModified": "2016-06-26T12:13:51.420+0000", 
+                "Runtime": "python2.7", 
+                "Description": ""
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "05fb680e-6a0d-11e6-ad0d-d593f1ef780f", 
+            "HTTPHeaders": {
+                "date": "Wed, 24 Aug 2016 15:11:24 GMT", 
+                "x-amzn-requestid": "05fb680e-6a0d-11e6-ad0d-d593f1ef780f", 
+                "content-length": "1184", 
+                "content-type": "application/json", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -29,5 +29,3 @@ class TestAMI(BaseTest):
         }, session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        
-        

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -74,6 +74,17 @@ class NetworkInterfaceTest(BaseTest):
 
 class SecurityGroupTest(BaseTest):
 
+    def test_unused(self):
+        factory = self.replay_flight_data(
+            'test_security_group_unused')
+        p = self.load_policy({
+            'name': 'sg-unused',
+            'resource': 'security-group',
+            'filters': ['unused'],
+            }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_only_ports(self):
         factory = self.replay_flight_data(
             'test_security_group_only_ports')


### PR DESCRIPTION
Filter to just security groups that are not used.

 We scan all extant enis in the vpc to get a baseline set of groups
in use. Then augment with those referenced by launch configs, and
ambdas as they may not have extant resources in the vpc at a
given moment. We also find any security group with references from
 other security group either within the vpc or across peered
connections.

todo before merge

- [x] backfill tests
- [x] filter out vpc groups when scanning for peers
- [x] figure out what to do with non vpc security groups (skip them?)
