### PR TITLE
c7n test support for schema validating test policies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,7 @@ language: python
 cache: pip
 env:
   # Region required, and Bypass credential lookup
-  - AWS_DEFAULT_REGION="us-east-1" AWS_ACCESS_KEY_ID="some" AWS_SECRET_ACCESS_KEY="thing"
+  - AWS_DEFAULT_REGION="us-east-1" AWS_ACCESS_KEY_ID="some" AWS_SECRET_ACCESS_KEY="thing" C7N_VALIDATE=yes
 python:
   - "2.7"
 install:

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,26 @@
+{ 
+    "files.exclude": {
+        "**/.git": true,
+        "**/.svn": true,
+        "**/.hg": true,
+        "**/.DS_Store": true,
+
+        "tmp": true,
+        "policies": true,
+        "out": true,
+
+        ".coverage": true,
+        ".Python": true,
+        "cover": true,
+        "include": true,
+        "share": true,
+        "man": true,
+        "bin": true,        
+
+        "**/*.egg-info": true,        
+        "**/*-nspkg.pth": true,
+        "**/*.pyc": true,
+        "**/*.pyo": true,
+        "**/*.dist-info": true
+    }
+}

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -1,0 +1,16 @@
+{
+    // See https://go.microsoft.com/fwlink/?LinkId=733558
+    // for the documentation about the tasks.json format
+    "version": "0.1.0",
+    "command": "make",
+    "isShellCommand": true,
+    "echoCommand": true,
+    "args": [],
+    "showOutput": "always",
+    "tasks": [
+        {"taskName": "test",
+         "args": ["test"]},
+        {"taskName": "coverage",
+         "args": ["coverage"]}
+    ]
+}

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -209,7 +209,7 @@ class ServiceLimit(Filter):
 
     schema = type_schema(
         'service-limit',
-        threshold={'type': 'integer'},
+        threshold={'type': 'number'},
         refresh_period={'type': 'integer'},
         limits={'type': 'array', 'items': {'type': 'string'}},
         services={'type': 'array', 'items': {

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -60,4 +60,4 @@ class ImageAgeFilter(AgeFilter):
     schema = type_schema(
         'image-age',
         op={'type': 'string', 'enum': OPERATORS.keys()},
-        days={'type': 'integer', 'minimum': 0})
+        days={'type': 'number', 'minimum': 0})

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -798,7 +798,7 @@ class Suspend(BaseAction):
 class Resume(BaseAction):
     """Resume a suspended autoscale group and its instances
     """
-    schema = type_schema('resume', delay={'type': 'integer'})
+    schema = type_schema('resume', delay={'type': 'number'})
 
     def process(self, asgs):
         original_count = len(asgs)

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -37,9 +37,10 @@ from c7n.filters import ValueFilter, EventFilter, AgeFilter
 from c7n.offhours import Time as TimeFilter
 
 
-def validate(data):
-    schema = generate()
-    Validator.check_schema(schema)
+def validate(data, schema=None):
+    if schema is None:
+        schema = generate()
+        Validator.check_schema(schema)
     validator = Validator(schema)
 
     errors = list(validator.iter_errors(data))

--- a/tests/test_elb.py
+++ b/tests/test_elb.py
@@ -79,7 +79,7 @@ class ELBTagTest(BaseTest):
             'filters': [{"LoadBalancerName": 'CloudCustodian'}],
             'actions': [{
                 'type': 'mark-for-op', 'op': 'delete',
-                'tag': 'custodian_next', 'days': -1}]},
+                'tag': 'custodian_next', 'days': 1}]},
             session_factory=session_factory)
         resources = policy.run()
 
@@ -152,7 +152,7 @@ class SSLPolicyTest(BaseTest):
             'filters': [
                 {'type': 'ssl-policy'}
             ]},
-            session_factory=None)
+            session_factory=None, validate=False)
         self.fail("validtion error should have been thrown")
 
     @raises(FilterValidationError)
@@ -163,7 +163,7 @@ class SSLPolicyTest(BaseTest):
             'filters': [
                 {'type': 'ssl-policy', 'blacklist': 'single-value'}
             ]},
-            session_factory=None)
+            session_factory=None, validate=False)
         self.fail("validtion error should have been thrown")
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -94,7 +94,6 @@ class TestPolicy(BaseTest):
             'mode': {
                 'type': 'ec2-instance-state',
                 'events': ['running']},
-            'role': "arn:aws:iam::619193117841:role/CustodianDemoRole",
             'filters': [
                 {"tag:custodian_status": 'absent'},
                 {'or': [

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -101,7 +101,7 @@ class RDSTest(BaseTest):
             'filters': [
                 {'tag:Platform': 'postgres'}],
             'actions': [
-                {'type': 'mark-for-op', 'tag': 'custodian_next', 'days': -1,
+                {'type': 'mark-for-op', 'tag': 'custodian_next', 'days': 1,
                  'op': 'delete'}]},
             session_factory=session_factory)
         resources = p.run()


### PR DESCRIPTION
Off by default (environment variable enabled), does have some impact on tests, but also caught a few schema minor issues

| Test Exec        | Disabled    | Enabled   | Impact  |
| ------------- |:-------:|:-------:|-----:|
| make test      | 4.658s | 6.102s | +31%
| nosetests -s -v | 18.008s |   23.485s | +30%

Plan is to enable it on the ci server, in table make test runs in parallel.

Closes #375