### PR TITLE
Correct indentation for 'as_completed' calls

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -76,11 +76,11 @@ class SnapshotDelete(BaseAction):
             for snapshot_set in chunks(reversed(snapshots), size=50):
                 futures.append(
                     w.submit(self.process_snapshot_set, snapshot_set))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception deleting snapshot set \n %s" % (
-                                f.exception()))
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception deleting snapshot set \n %s" % (
+                            f.exception()))
         return snapshots
 
     def process_snapshot_set(self, snapshots_set):
@@ -241,11 +241,11 @@ class CopyInstanceTags(BaseAction):
                 futures.append(
                     w.submit(self.process_volume_set, volume_set))
 
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception copying instance tags \n %s" % (
-                                f.exception()))
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception copying instance tags \n %s" % (
+                            f.exception()))
 
     def process_volume_set(self, volume_set):
         instance_vol_map = {}

--- a/c7n/resources/elb.py
+++ b/c7n/resources/elb.py
@@ -299,12 +299,12 @@ class SSLPolicyFilter(Filter):
                 futures.append(
                     w.submit(self.process_elb_policy_set, elb_policy_set))
 
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception processing elb policies \n %s" % (
-                                f.exception()))
-                        continue
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception processing elb policies \n %s" % (
+                            f.exception()))
+                    continue
                 for elb_policies in f.result():
                     active_policy_attribute_tuples.append(elb_policies)
 

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -363,11 +363,11 @@ class Snapshot(BaseAction):
                 futures.append(w.submit(
                     self.process_rds_snapshot,
                     db))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception creating rds snapshot  \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception creating rds snapshot  \n %s",
+                        f.exception())
         return dbs
 
     def process_rds_snapshot(self, resource):
@@ -397,11 +397,11 @@ class RetentionWindow(BaseAction):
                 futures.append(w.submit(
                     self.process_snapshot_retention,
                     db))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception setting rds retention  \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception setting rds retention  \n %s",
+                        f.exception())
         return dbs
 
     def process_snapshot_retention(self, resource):
@@ -469,11 +469,11 @@ class RDSSnapshotDelete(BaseAction):
             for snapshot_set in chunks(reversed(snapshots), size=50):
                 futures.append(
                     w.submit(self.process_snapshot_set, snapshot_set))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception deleting snapshot set \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception deleting snapshot set \n %s",
+                        f.exception())
         return snapshots
 
     def process_snapshot_set(self, snapshots_set):

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -110,11 +110,11 @@ class RetentionWindow(BaseAction):
                 futures.append(w.submit(
                     self.process_snapshot_retention,
                     cluster))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception setting RDS cluster retention  \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception setting RDS cluster retention  \n %s",
+                        f.exception())
 
     def process_snapshot_retention(self, cluster):
         current_retention = int(cluster.get('BackupRetentionPeriod', 0))
@@ -147,11 +147,11 @@ class Snapshot(BaseAction):
                 futures.append(w.submit(
                     self.process_cluster_snapshot,
                     cluster))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception creating RDS cluster snapshot  \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception creating RDS cluster snapshot  \n %s",
+                        f.exception())
         return clusters
 
     def process_cluster_snapshot(self, cluster):
@@ -206,11 +206,11 @@ class RDSClusterSnapshotDelete(BaseAction):
             for snapshot_set in chunks(reversed(snapshots), size=50):
                 futures.append(
                     w.submit(self.process_snapshot_set, snapshot_set))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception deleting snapshot set \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception deleting snapshot set \n %s",
+                        f.exception())
         return snapshots
 
     def process_snapshot_set(self, snapshots_set):

--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -101,11 +101,11 @@ class Delete(BaseAction):
             for db_set in chunks(clusters, size=5):
                 futures.append(
                     w.submit(self.process_db_set, db_set))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception deleting redshift set \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception deleting redshift set \n %s",
+                        f.exception())
 
     def process_db_set(self, db_set):
         skip = self.data.get('skip-snapshot', False)
@@ -135,11 +135,11 @@ class RetentionWindow(BaseAction):
                 futures.append(w.submit(
                     self.process_snapshot_retention,
                     cluster))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception setting Redshift retention  \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception setting Redshift retention  \n %s",
+                        f.exception())
 
     def process_snapshot_retention(self, cluster):
         current_retention = int(cluster.get(self.date_attribute, 0))
@@ -170,11 +170,11 @@ class Snapshot(BaseAction):
                 futures.append(w.submit(
                     self.process_cluster_snapshot,
                     cluster))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception creating Redshift snapshot  \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception creating Redshift snapshot  \n %s",
+                        f.exception())
         return clusters
 
     def process_cluster_snapshot(self, cluster):
@@ -228,11 +228,11 @@ class RedshiftSnapshotDelete(BaseAction):
             for snapshot_set in chunks(reversed(snapshots), size=50):
                 futures.append(
                     w.submit(self.process_snapshot_set, snapshot_set))
-                for f in as_completed(futures):
-                    if f.exception():
-                        self.log.error(
-                            "Exception deleting snapshot set \n %s",
-                            f.exception())
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error(
+                        "Exception deleting snapshot set \n %s",
+                        f.exception())
         return snapshots
 
     def process_snapshot_set(self, snapshots_set):


### PR DESCRIPTION
Calls to `as_completed` are indented incorrectly and have spread virally via cut 'n paste (_mea culpa_).