### PR TITLE
asg not-encrypted filter - no longer filtering dead AMIs refs in results

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -356,6 +356,8 @@ class NotEncryptedFilter(Filter, LaunchConfigFilterBase):
                     snaps.setdefault(
                         bd['Ebs']['SnapshotId'].strip(), []).append(cid)
                 elif not bd['Ebs'].get('Encrypted'):
+                    if image is None:
+                        continue
                     unencrypted_configs.add(cid)
         if not snaps:
             return unencrypted_configs


### PR DESCRIPTION
ASG 'not-encrypted' filter - LaunchConfig references to dead AMI images should not longer show up in the filtered results. Dead AMI references are already being filtered by the ASG 'invalid' filter.