### PR TITLE
Feature/emr query filter

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -218,7 +218,7 @@ class ValueFilter(Filter):
             'key': {'type': 'string'},
             'value_type': {'enum': [
                 'age', 'integer', 'expiration', 'normalize', 'size',
-                'cidr', 'cidr_size', 'swap']},
+                'cidr', 'cidr_size']},
             'default': {'type': 'object'},
             'value_from': ValuesFrom.schema,
             'value': {'oneOf': [
@@ -286,13 +286,9 @@ class ValueFilter(Filter):
             r = i.get(self.k)
         elif self.expr:
             r = self.expr.search(i)
-
         else:
             self.expr = jmespath.compile(self.k)
             r = self.expr.search(i)
-
-        if self.op in ('in', 'not-in') and r is None:
-            r = ()
 
         # value type conversion
         if self.vtype is not None:
@@ -309,9 +305,13 @@ class ValueFilter(Filter):
             return True
         elif self.op:
             op = OPERATORS[self.op]
-            return op(r, v)
+            try:
+                return op(r, v)
+            except TypeError:
+                return False
         elif r == self.v:
             return True
+
         return False
 
     def process_value_type(self, sentinel, value):
@@ -335,7 +335,12 @@ class ValueFilter(Filter):
                 sentinel = datetime.now(tz=tzutc()) - timedelta(sentinel)
 
             if not isinstance(value, datetime):
-                value = parse(value)
+                # EMR bug when testing ages in EMR. This is due to
+                # EMR not having more functionality.
+                try:
+                    value = parse(value)
+                except AttributeError:
+                    value = 0
             # Reverse the age comparison, we want to compare the value being
             # greater than the sentinel typically. Else the syntax for age
             # comparisons is intuitively wrong.

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -116,7 +116,7 @@ class QueryMeta(type):
                 attrs['retry'] = staticmethod(get_retry((
                     'RequestLimitExceeded', 'Client.RequestLimitExceeded')))
                 # Generic ec2 resource tag support
-                if  getattr(m, 'taggable', True):
+                if getattr(m, 'taggable', True):
                     register_tags(
                         attrs['filter_registry'], attrs['action_registry'])
         return super(QueryMeta, cls).__new__(cls, name, parents, attrs)

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -1,0 +1,47 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import unittest
+
+from c7n.resources import emr
+from c7n.resources.emr import QueryFilter
+from c7n import tags, utils
+
+from .common import BaseTest
+
+
+class TestEMRQueryFilter(unittest.TestCase):
+
+    def test_parse(self):
+        self.assertEqual(QueryFilter.parse([]), [])
+        x = QueryFilter.parse(
+            [{'ClusterStates': 'terminated'}])
+        self.assertEqual(
+            x[0].query(),
+            {'Name': 'ClusterStates', 'Values': ['terminated']})
+
+        self.assertTrue(
+            isinstance(
+                QueryFilter.parse(
+                    [{'tag:ASV': 'REALTIMEMSG'}])[0],
+                QueryFilter))
+
+        self.assertRaises(
+            ValueError,
+            QueryFilter.parse,
+            [{'tag:ASV': None}])
+
+        self.assertRaises(
+            ValueError,
+            QueryFilter.parse,
+            [{'foo': 'bar'}])


### PR DESCRIPTION
EMR Query Support
==============

This is a new feature for Cloud Custodian, specifically for the EMR resource.

Problem
--------
Cloud Custodian currently queries all EMR clusters in an account before doing output filtering on it. On accounts with large amounts of EMR clusters ( >1000 ) we are seeing API rate limits from AWS, and this breaks the functionality. 

Solution
--------
Query filtering has been implemented for EMR. At the moment, only the *ClusterStates* filter is supported, but more will be added in the future. The implementation was inspired by the query filtering for EC2.

Related Issues
--------------
https://github.com/capitalone/cloud-custodian/issues/485