### PR TITLE
respect timezone by itself in off hours tag

### DIFF
--- a/tests/test_offhours.py
+++ b/tests/test_offhours.py
@@ -288,14 +288,14 @@ class OffHoursFilterTest(BaseTest):
         t = datetime.datetime.now(zoneinfo.gettz('America/New_York'))
         t = t.replace(year=2015, month=12, day=1, hour=19, minute=5)
         with mock_datetime_now(t, datetime):
-            for i in [
+            results = [OffHour({})(i) for i in [
                     instance(Tags=[
                         {'Key': 'maid_offhours', 'Value': ''}]),
                     instance(Tags=[
                         {'Key': 'maid_offhours', 'Value': '"Offhours tz=ET"'}]),
                     instance(Tags=[
-                        {'Key': 'maid_offhours', 'Value': 'Offhours tz=PT'}])]:
-                self.assertEqual(OffHour({})(i), True)
+                        {'Key': 'maid_offhours', 'Value': 'Offhours tz=PT'}])]]
+            self.assertEqual(results, [True, False, False])
 
     def test_offhours(self):
         t = datetime.datetime(year=2015, month=12, day=1, hour=19, minute=5,
@@ -383,6 +383,14 @@ class OffHoursFilterTest(BaseTest):
             i = instance(Tags=[{'Key': 'maid_offhours',
                                 'Value': 'off=(m-f,90);on=(m-f,7);tz=et'}])
             self.assertEqual(OffHour({})(i), False)
+
+    def test_tz_only(self):
+        t = datetime.datetime.now(zoneinfo.gettz('America/New_York'))
+        t = t.replace(year=2016, month=5, day=26, hour=7, minute=00)
+        with mock_datetime_now(t, datetime):
+            i = instance(Tags=[{'Key': 'maid_offhours',
+                                'Value': 'tz=est'}])
+            self.assertEqual(OnHour({})(i), True)
 
 
 class ScheduleParserTest(BaseTest):


### PR DESCRIPTION
Let me know how this looks.

I’m not thrilled with the repeated parsing, but I couldn’t do the same caching trick used in `parse()` since the new method is static. The performance difference is probably not noticeable, but if you want me to address that, I’d probably argue for making `raw_data()` a stand-alone function independent from the `ScheduleParser` class (and create a cache variable for it outside the class as well.)