### PR TITLE
adding size to the key

### DIFF
--- a/c7n/ufuncs/s3crypt.py
+++ b/c7n/ufuncs/s3crypt.py
@@ -41,7 +41,7 @@ def process_key_event(event, context):
     processor = EncryptExtantKeys(config)
     for record in event.get('Records', []):
         bucket = record['s3']['bucket']['name']
-        key = {'Key': record['s3']['object']['key']}
+        key = {'Key': record['s3']['object']['key'], 'Size': record['s3']['object']['size']}
         version = record['s3']['object'].get('versionId')
         if version is not None:
             result = processor.process_version(s3, key, bucket)


### PR DESCRIPTION
adds size to the key. s3.py was expecting it but it wasn't in the key object.