### PR TITLE
don't set default_vpc to an empty string

### DIFF
--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -52,8 +52,6 @@ class DefaultVpcBase(Filter):
             vpcs = [v['VpcId'] for v
                     in client.describe_vpcs(VpcIds=[vpc_id])['Vpcs']
                     if v['IsDefault']]
-            if not vpcs:
-                self.default_vpc = ""
-            else:
+            if vpcs:
                 self.default_vpc = vpcs.pop()
         return vpc_id == self.default_vpc and True or False


### PR DESCRIPTION
If the first VPC wasn’t default, the first call to `match()` would change `self.default_vpc` from `None` to an empty string. Subsequent calls to `match()` would check for `None` specifically, which would never match again, so they’d all get skipped.

One solution is to set it to `None` instead, but since it will already be `None`, I just removed the assignment.

None of the tests had a problem with it, but if there’s no match, the value will remain `None`. If you think that might cause a problem down the line, I can change the default to an empty string and test for that in `match()` instead.