### PR TITLE
#289 - Filter on tag propagation value

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -476,6 +476,29 @@ class CapacityDelta(Filter):
                 len(a['Instances']) < a['MinSize']]
 
 
+@filters.register('progagated-tag')
+class PropagatedTagFilter(Filter):
+
+    schema = type_schema(
+        'progagated-tag',
+        key={'type': 'string'},
+        value={'type': 'string'}
+    )
+
+    def process(self, asgs, event=None):
+        key = self.data.get('key', DEFAULT_TAG)
+        value = self.data.get('value', None)
+        results = []
+        for r in asgs:
+            tags = r.get('Tags', [])
+            for t in tags:
+                if not t['PropagateAtLaunch']:
+                    continue
+                if t['Key'] == key and t['Value'] == value:
+                    results.append(r)
+        return results
+
+
 @actions.register('resize')
 class Resize(BaseAction):
 

--- a/tests/data/placebo/test_asg_propagate_tag_filter/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/data/placebo/test_asg_propagate_tag_filter/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,0 +1,123 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AutoScalingGroups": [
+            {
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:644160558196:autoScalingGroup:7c557a95-0502-41b0-9db3-7d90688c9ad4:autoScalingGroupName/c7n-asg-01", 
+                "TargetGroupARNs": [], 
+                "SuspendedProcesses": [], 
+                "DesiredCapacity": 1, 
+                "Tags": [
+                    {
+                        "ResourceType": "auto-scaling-group", 
+                        "ResourceId": "c7n-asg-01", 
+                        "PropagateAtLaunch": true, 
+                        "Value": "ABC", 
+                        "Key": "PropTag01"
+                    }
+                ], 
+                "EnabledMetrics": [], 
+                "LoadBalancerNames": [], 
+                "AutoScalingGroupName": "c7n-asg-01", 
+                "DefaultCooldown": 300, 
+                "MinSize": 1, 
+                "Instances": [
+                    {
+                        "ProtectedFromScaleIn": false, 
+                        "AvailabilityZone": "us-east-1d", 
+                        "InstanceId": "i-00b076f55f34c6fab", 
+                        "HealthStatus": "Healthy", 
+                        "LifecycleState": "InService", 
+                        "LaunchConfigurationName": "c7n-launchconfig-01"
+                    }
+                ], 
+                "MaxSize": 1, 
+                "VPCZoneIdentifier": "subnet-3a334610", 
+                "HealthCheckGracePeriod": 300, 
+                "TerminationPolicies": [
+                    "Default"
+                ], 
+                "LaunchConfigurationName": "c7n-launchconfig-01", 
+                "CreatedTime": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 41, 
+                    "microsecond": 196000, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 56
+                }, 
+                "AvailabilityZones": [
+                    "us-east-1d"
+                ], 
+                "HealthCheckType": "EC2", 
+                "NewInstancesProtectedFromScaleIn": false
+            }, 
+            {
+                "AutoScalingGroupARN": "arn:aws:autoscaling:us-east-1:644160558196:autoScalingGroup:cc301ee6-a588-4953-a2d2-9410f12cb192:autoScalingGroupName/c7n-asg-02", 
+                "TargetGroupARNs": [], 
+                "SuspendedProcesses": [], 
+                "DesiredCapacity": 1, 
+                "Tags": [
+                    {
+                        "ResourceType": "auto-scaling-group", 
+                        "ResourceId": "c7n-asg-02", 
+                        "PropagateAtLaunch": true, 
+                        "Value": "DEF", 
+                        "Key": "PropTag01"
+                    }
+                ], 
+                "EnabledMetrics": [], 
+                "LoadBalancerNames": [], 
+                "AutoScalingGroupName": "c7n-asg-02", 
+                "DefaultCooldown": 300, 
+                "MinSize": 1, 
+                "Instances": [
+                    {
+                        "ProtectedFromScaleIn": false, 
+                        "AvailabilityZone": "us-east-1e", 
+                        "InstanceId": "i-05f2252d8d2e29579", 
+                        "HealthStatus": "Healthy", 
+                        "LifecycleState": "InService", 
+                        "LaunchConfigurationName": "c7n-launchconfig-01"
+                    }
+                ], 
+                "MaxSize": 1, 
+                "VPCZoneIdentifier": "subnet-e3b194de", 
+                "HealthCheckGracePeriod": 300, 
+                "TerminationPolicies": [
+                    "Default"
+                ], 
+                "LaunchConfigurationName": "c7n-launchconfig-01", 
+                "CreatedTime": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 11, 
+                    "microsecond": 104000, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 57
+                }, 
+                "AvailabilityZones": [
+                    "us-east-1e"
+                ], 
+                "HealthCheckType": "EC2", 
+                "NewInstancesProtectedFromScaleIn": false
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "94da0c80-a77c-11e6-879b-6feda8ddbac5", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "94da0c80-a77c-11e6-879b-6feda8ddbac5", 
+                "vary": "Accept-Encoding", 
+                "content-length": "4091", 
+                "content-type": "text/xml", 
+                "date": "Thu, 10 Nov 2016 19:33:38 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -253,3 +253,4 @@ class AutoScalingTest(BaseTest):
                 ]}, session_factory=session)
         resources = policy.run()
         self.assertEqual(len(resources), 1)
+

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -240,3 +240,16 @@ class AutoScalingTest(BaseTest):
         s = set([x[0] for x in resources[0]['Invalid']])
         self.assertTrue('invalid-subnet' in s)
         self.assertTrue('invalid-security-group' in s)
+
+    def test_asg_propagate_tag_filter(self):
+        session = self.replay_flight_data('test_asg_propagate_tag_filter')
+        policy = self.load_policy({
+            'name': 'asg-propagate-tag-filter',
+            'resource': 'asg',
+            'filters': [{
+                'type': 'progagated-tag',
+                'key': 'PropTag01',
+                'value': 'ABC'}
+                ]}, session_factory=session)
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
* Filter allows to filter based on filter key/value if it’s set to
propagate on launch