### PR TITLE
make sure all files are readable before packaging for Lambda

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -112,17 +112,11 @@ class PythonPackageArchive(object):
                     info.date_time = datetime.timetuple(
                         datetime.fromtimestamp(f_timestamp)
                     )
-                    if os.path.isdir(f_path):
-                        info.external_attr = 0555 << 16L
-                        info.compress_type = zipfile.ZIP_STORED
-                        info.external_attr |= 0x10  # MS-DOS directory flag
-                        self._zip_file.writestr(info, '')
-                    else:
-                        info.external_attr = 0444 << 16L
-                        fp = open(f_path, 'rb')
-                        file_bytes = fp.read()
-                        fp.close()
-                        self._zip_file.writestr(info, file_bytes)
+                    info.external_attr = 0444 << 16L
+                    fp = open(f_path, 'rb')
+                    file_bytes = fp.read()
+                    fp.close()
+                    self._zip_file.writestr(info, file_bytes)
 
         # Library Source
         venv_lib_path = os.path.join(
@@ -140,17 +134,11 @@ class PythonPackageArchive(object):
                 info.date_time = datetime.timetuple(
                     datetime.fromtimestamp(f_timestamp)
                 )
-                if os.path.isdir(f_path):
-                    info.external_attr = 0555 << 16L
-                    info.compress_type = zipfile.ZIP_STORED
-                    info.external_attr |= 0x10  # MS-DOS directory flag
-                    self._zip_file.writestr(info, '')
-                else:
-                    info.external_attr = 0444 << 16L
-                    fp = open(f_path, 'rb')
-                    file_bytes = fp.read()
-                    fp.close()
-                    self._zip_file.writestr(info, file_bytes)
+                info.external_attr = 0444 << 16L
+                fp = open(f_path, 'rb')
+                file_bytes = fp.read()
+                fp.close()
+                self._zip_file.writestr(info, file_bytes)
 
     def add_file(self, src, dest):
         self._zip_file.write(src, dest)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -126,10 +126,6 @@ class PythonPackageArchive(object):
 
     def add_file(self, src, dest):
         info = zipfile.ZipInfo(dest)
-        timestamp = os.path.getmtime(src)
-        info.date_time = datetime.timetuple(
-            datetime.fromtimestamp(timestamp)
-        )
         fp = open(src, 'rb')
         contents = fp.read()
         fp.close()

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -608,7 +608,6 @@ def zinfo(fname):
     """
     info = zipfile.ZipInfo(fname)
     # Grant other users permissions to read
-    info.external_attr = 0o644 << 16
     info.compress_type = zipfile.ZIP_DEFLATED
     return info
 

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -126,10 +126,9 @@ class PythonPackageArchive(object):
 
     def add_file(self, src, dest):
         info = zipfile.ZipInfo(dest)
-        fp = open(src, 'rb')
-        contents = fp.read()
-        fp.close()
-        self.add_contents(info, contents)
+        with open(src, 'rb') as fp:
+            contents = fp.read()
+            self.add_contents(info, contents)
 
     def add_contents(self, dest, contents):
         if not isinstance(dest, zipfile.ZipInfo):

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -336,3 +336,15 @@ class PythonArchiveTest(unittest.TestCase):
                       'c7n/resources/s3.pyc',
                       'boto3/__init__.py']:
                 self.assertFalse(i in fileset)
+
+    def test_archive_permissions(self):
+        # files should all be readable
+        self.archive = custodian_archive("*.pyc")
+        self.archive.create()
+        self.addCleanup(self.archive.remove)
+        self.archive.close()
+        readable = 0444 << 16L
+        with open(self.archive.path) as fh:
+            reader = zipfile.ZipFile(fh, mode='r')
+            for i in reader.infolist():
+                self.assertGreaterEqual(i.external_attr, readable)


### PR DESCRIPTION
As described in the commit message, this will create a temporary copy of package files so permissions on the originals aren’t modified. I don’t *think* we need to do that dance for the library source (since you generally only read from them to begin with), but let me know if you think we should.