### PR TITLE
[wip] alarm filter

### DIFF
--- a/c7n/filters/alarm.py
+++ b/c7n/filters/alarm.py
@@ -1,0 +1,52 @@
+from c7n.utils import type_schema
+from .core import ValueFilter
+
+
+class AlarmFilter(ValueFilter):
+    """Filter a resource on the basis of whether it has alarms.
+
+    Example, to find all asg with alarms that are not in an okay state.
+
+    .. yaml
+
+      policies:
+        name: alarms-fired
+        resource: asg
+        filters:
+         - type: alarm
+           key: StateValue
+           value: ok
+           value_type: normalize
+           op: not-equal
+    """
+
+    schema = type_schema('alarm', rinherit=ValueFilter.schema)
+
+    def process(self, resources, event=None):
+        model = self.manager.get_model()
+        resource_alarms = self.get_alarms_by_resource(resources)
+        results = []
+        for r in resources:
+            alarms = resource_alarms.get(r[model.id], ())
+            matched = []
+            for a in alarms:
+                if self.match(a):
+                    matched.append(a)
+            if matched:
+                r['c7n-alarms'] = matched
+                results.append(r)
+        return results
+
+    def get_alarms_by_resource(self, resources):
+        from c7n.resources.cw import Alarm as AlarmResource
+        model = self.manager.get_model()
+        alarms = AlarmResource(self.manager.ctx, {}).resources()
+        resource_alarms = {r[model.dimension]: [] for r in resources}
+        for a in alarms:
+            for d in a.get('Dimensions', ()):
+                if d['Name'] != model.dimension:
+                    continue
+                if d['Value'] in resource_alarms:
+                    resource_alarms[d['Value']].append(a)
+                    break
+        return resource_alarms

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -28,6 +28,7 @@ from botocore.client import ClientError
 from skew.resources import find_resource_class
 
 from c7n.actions import ActionRegistry
+from c7n.filters.alarm import AlarmFilter
 from c7n.filters import FilterRegistry, MetricsFilter
 from c7n.tags import register_tags
 from c7n.utils import local_session, get_retry
@@ -110,6 +111,7 @@ class QueryMeta(type):
             # Generic cloud watch metrics support
             if m.dimension and 'metrics':
                 attrs['filter_registry'].register('metrics', MetricsFilter)
+                attrs['filter_registry'].register('alarm', AlarmFilter)
             # EC2 Service boilerplate ...
             if m.service == 'ec2':
                 # Generic ec2 retry


### PR DESCRIPTION
use case is find resources with or without alarms setup on their metrics via an alarm filter, still needs some work on tests, and match mode/operator across multiple filters (currently styled any), and support for no alarms found use case.
