### PR TITLE
Suppress --json option for schema subcommand.

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -121,9 +121,7 @@ def _schema_options(p):
     p.add_argument(
         '--summary', action="store_true",
         help="Summarize counts of available resources, actions and filters")
-    p.add_argument(
-        '--json', action="store_true",
-        help="Output to JSON format")
+    p.add_argument('--json', action="store_true", help=argparse.SUPPRESS)
     p.add_argument(
         '-v', '--verbose', action="store_true",
         help="Verbose logging")


### PR DESCRIPTION
    Suppress --json option for schema subcommand.  It does not yet fully work with selectors.
