### PR TITLE
support non-lambda policies with the “logs” subcommand

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -19,7 +19,7 @@ import os
 import pdb
 import sys
 import traceback
-
+from datetime import datetime
 from dateutil.parser import parse as date_parse
 
 DEFAULT_REGION = 'us-east-1'
@@ -117,6 +117,23 @@ def _metrics_options(p):
     p.add_argument('--period', type=int, default=60*24*24)
 
 
+def _logs_options(p):
+    """ Add options specific to logs subcommand. """
+    _default_options(p)
+
+    # default time range is 0 to "now" (to include all log entries)
+    p.add_argument(
+        '--start',
+        default='the beginning',  # invalid, will result in 0
+        help='Start date and/or time',
+    )
+    p.add_argument(
+        '--end',
+        default=datetime.now().strftime('%c'),
+        help='End date and/or time',
+    )
+
+
 def _schema_options(p):
     """ Add options specific to schema subcommand. """
 
@@ -165,7 +182,7 @@ def setup_parser():
     logs = subs.add_parser(
         'logs', help=logs_desc, description=logs_desc)
     logs.set_defaults(command="c7n.commands.logs")
-    _default_options(logs, blacklist=['cache'])
+    _logs_options(logs)
 
     metrics_desc = "Retrieve metrics for policies from CloudWatch Metrics"
     metrics = subs.add_parser(

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -119,7 +119,7 @@ def _metrics_options(p):
 
 def _logs_options(p):
     """ Add options specific to logs subcommand. """
-    _default_options(p)
+    _default_options(p, blacklist=['cache'])
 
     # default time range is 0 to "now" (to include all log entries)
     p.add_argument(

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -25,13 +25,12 @@ import time
 
 import yaml
 
-from c7n.credentials import SessionFactory
 from c7n.policy import Policy, load as policy_load
 from c7n.reports import report as do_report
 from c7n.utils import Bag, dumps
 from c7n.manager import resources
 from c7n.resources import load_resources
-from c7n import mu, schema, version
+from c7n import schema, version
 
 
 log = logging.getLogger('custodian.commands')
@@ -138,14 +137,7 @@ def logs(options, policies):
     assert len(policies) == 1, "Only one policy log at a time"
     policy = policies.pop()
 
-    if not policy.is_lambda:
-        log.debug('lambda only atm')
-        return
-
-    session_factory = SessionFactory(
-        options.region, options.profile, options.assume_role)
-    manager = mu.LambdaManager(session_factory)
-    for e in manager.logs(mu.PolicyLambda(policy)):
+    for e in policy.get_logs(options.start, options.end):
         print("%s: %s" % (
             time.strftime(
                 "%Y-%m-%d %H:%M:%S", time.localtime(e['timestamp'] / 1000)),

--- a/c7n/logs_support.py
+++ b/c7n/logs_support.py
@@ -1,0 +1,118 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+'''
+Supporting utilities for various implementations
+of PolicyExecutionMode.get_logs()
+'''
+import logging
+import re
+from concurrent.futures import as_completed
+from cStringIO import StringIO
+from datetime import datetime
+from gzip import GzipFile
+
+from c7n.executor import ThreadPoolExecutor
+from c7n.utils import timestamp_from_string
+
+
+log = logging.getLogger('custodian.logs')
+
+
+def normalized_log_entries(raw_entries):
+    '''Mimic the format returned by LambdaManager.logs()'''
+    entry_start = '([0-9:, \-]+) - .* - (\w+) - (.*)$'
+    entry = None
+    # process start/end here - avoid parsing log entries twice
+    for line in raw_entries:
+        m = re.match(entry_start, line)
+        if m:
+            # this is the start of a new entry
+            # spit out the one previously built up (if any)
+            if entry is not None:
+                yield entry
+            (log_time, log_level, log_text) = m.groups()
+            # convert time
+            log_timestamp = timestamp_from_string(log_time) * 1000
+            # join level and first line of message
+            msg = '[{}] {}'.format(log_level, log_text)
+            entry = {
+                'timestamp': log_timestamp,
+                'message': msg,
+            }
+        else:
+            # additional line(s) for entry (i.e. stack trace)
+            entry['message'] = entry['message'] + line
+    if entry is not None:
+        # return the final entry
+        yield entry
+
+
+def log_entries_in_range(entries, start, end):
+    '''filter out entries before start and after end'''
+    start = timestamp_from_string(start) * 1000
+    end = timestamp_from_string(end) * 1000
+    for entry in entries:
+        log_timestamp = entry.get('timestamp', 0)
+        if log_timestamp >= start and log_timestamp <= end:
+            yield entry
+
+
+def s3_folders_from_date(session, output, start):
+    client = session.client('s3')
+    key_prefix = output.key_prefix.strip('/')
+    start = datetime.fromtimestamp(
+        timestamp_from_string(start)
+    )
+    records = []
+    key_count = 0
+    log_filename = 'custodian-run.log.gz'
+    marker = '{}/{}/{}'.format(
+        key_prefix,
+        start.strftime('%Y/%m/%d/00'),
+        log_filename,
+    )
+    p = client.get_paginator('list_objects').paginate(
+        Bucket=output.bucket,
+        Prefix=key_prefix + '/',
+        Marker=marker,
+    )
+    with ThreadPoolExecutor(max_workers=20) as w:
+        for key_set in p:
+            if 'Contents' not in key_set:
+                continue
+            keys = [k for k in key_set['Contents']
+                    if k['Key'].endswith(log_filename)]
+            key_count += len(keys)
+            futures = map(
+                lambda k: w.submit(get_records, output.bucket, k, client), keys
+            )
+
+            for f in as_completed(futures):
+                records.extend(f.result())
+
+    log.info('Fetched {} records across {} files'.format(
+        len(records),
+        key_count,
+    ))
+    return records
+
+
+def get_records(bucket, key, client):
+    result = client.get_object(Bucket=bucket, Key=key['Key'])
+    blob = StringIO(result['Body'].read())
+
+    records = GzipFile(fileobj=blob).readlines()
+    log.debug("bucket: %s key: %s records: %d",
+              bucket, key['Key'], len(records))
+    return records

--- a/c7n/logs_support.py
+++ b/c7n/logs_support.py
@@ -68,7 +68,7 @@ def log_entries_in_range(entries, start, end):
             yield entry
 
 
-def s3_folders_from_date(session, output, start):
+def log_entries_from_s3(session, output, start):
     client = session.client('s3')
     key_prefix = output.key_prefix.strip('/')
     start = datetime.fromtimestamp(

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -97,9 +97,9 @@ class PolicyExecutionMode(object):
     def provision(self):
         """Provision any resources needed for the policy."""
 
-    def get_logs(self, start, end, period):
+    def get_logs(self, start, end):
         """Retrieve logs for the policy"""
-        raise NotImplementedError("not yet")
+        raise NotImplementedError("subclass responsibility")
 
     def get_metrics(self, start, end, period):
         """Retrieve any associated metrics for the policy."""
@@ -447,6 +447,10 @@ class Policy(object):
         """Query resources and apply policy."""
         mode = self.get_execution_mode()
         return mode.run()
+
+    def get_logs(self, start, end):
+        mode = self.get_execution_mode()
+        return mode.get_logs(start, end)
 
     def get_metrics(self, start, end, period):
         mode = self.get_execution_mode()

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -31,7 +31,7 @@ from c7n import utils
 from c7n.logs_support import (
     normalized_log_entries,
     log_entries_in_range,
-    s3_folders_from_date,
+    log_entries_from_s3,
 )
 from c7n.version import version
 
@@ -218,7 +218,7 @@ class PullMode(PolicyExecutionMode):
         log_gen = ()
         if log_source.use_s3():
             session = utils.local_session(self.policy.session_factory)
-            raw_entries = s3_folders_from_date(session, log_source, start)
+            raw_entries = log_entries_from_s3(session, log_source, start)
             # log files can be downloaded out of order, so sort on timestamp
             # log_gen isn't really a generator once we do this, but oh well
             log_gen = sorted(

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -15,6 +15,7 @@ from botocore.exceptions import ClientError
 
 import copy
 from datetime import datetime
+from dateutil import parser
 import functools
 import json
 import itertools
@@ -343,3 +344,11 @@ def worker(f):
             raise
     functools.update_wrapper(_f, f)
     return _f
+
+
+def timestamp_from_string(date_text):
+    try:
+        date_dt = parser.parse(date_text)
+        return time.mktime(date_dt.timetuple())
+    except (AttributeError, TypeError, ValueError):
+        return 0

--- a/tests/data/logs/test-policy/custodian-run.log
+++ b/tests/data/logs/test-policy/custodian-run.log
@@ -1,0 +1,144 @@
+2016-11-21 11:13:07,750 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 11:13:07,751 - custodian.resources.rds - INFO - Filtered from 0 to 0 rds
+2016-11-21 11:13:07,751 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:0 time:0.00
+2016-11-21 11:17:58,586 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 11:17:58,587 - custodian.resources.rds - INFO - Filtered from 0 to 0 rds
+2016-11-21 11:17:58,587 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:0 time:0.00
+2016-11-21 11:19:55,868 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 11:19:55,868 - custodian.resources.rds - INFO - Filtered from 0 to 0 rds
+2016-11-21 11:19:55,868 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:0 time:0.00
+2016-11-21 11:24:02,557 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 11:24:02,557 - custodian.resources.rds - INFO - Filtered from 0 to 0 rds
+2016-11-21 11:24:02,557 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:0 time:0.00
+2016-11-21 11:25:09,765 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 11:25:09,766 - custodian.resources.rds - INFO - Filtered from 0 to 0 rds
+2016-11-21 11:25:09,767 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:0 time:0.00
+2016-11-21 11:25:25,884 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 11:25:25,887 - custodian.resources.rds - INFO - Filtered from 0 to 0 rds
+2016-11-21 11:25:25,888 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:0 time:0.00
+2016-11-21 11:25:51,811 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 11:25:51,812 - custodian.resources.rds - INFO - Filtered from 0 to 0 rds
+2016-11-21 11:25:51,812 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:0 time:0.00
+2016-11-21 12:37:09,502 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 12:37:12,287 - custodian.output - ERROR - Error while executing policy
+Traceback (most recent call last):
+  File "/path/prefix/c7n/policy.py", line 167, in run
+    resources = self.policy.resource_manager.resources()
+  File "/path/prefix/c7n/query.py", line 164, in resources
+    return self.filter_resources(resources)
+  File "/path/prefix/c7n/manager.py", line 63, in filter_resources
+    resources = f.process(resources, event)
+  File "/path/prefix/c7n/filters/related.py", line 95, in process
+    return [r for r in resources if self.process_resource(r, related)]
+  File "/path/prefix/c7n/filters/related.py", line 70, in process_resource
+    self.data['key'], resource)
+  File "/path/prefix/c7n/filters/core.py", line 274, in get_resource_value
+    self.expr = jmespath.compile(self.k)
+AttributeError: 'SecurityGroupFilter' object has no attribute 'k'
+2016-11-21 12:41:39,200 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 12:44:33,030 - custodian.resources.rds - INFO - Filtered from 1 to 1 rds
+2016-11-21 12:44:33,030 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:1 time:173.83
+2016-11-21 12:44:33,761 - custodian.policy - INFO - policy: related-rds-test action: retentionwindow resources: 1 execution_time: 0.73
+2016-11-21 12:46:57,214 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 12:46:57,971 - custodian.output - ERROR - Error while executing policy
+Traceback (most recent call last):
+  File "/path/prefix/c7n/policy.py", line 167, in run
+    resources = self.policy.resource_manager.resources()
+  File "/path/prefix/c7n/query.py", line 152, in resources
+    return self.filter_resources(resources)
+  File "/path/prefix/c7n/manager.py", line 63, in filter_resources
+    resources = f.process(resources, event)
+  File "/path/prefix/c7n/filters/related.py", line 95, in process
+    return [r for r in resources if self.process_resource(r, related)]
+  File "/path/prefix/c7n/filters/related.py", line 70, in process_resource
+    self.data['key'], resource)
+  File "/path/prefix/c7n/filters/core.py", line 274, in get_resource_value
+    self.expr = jmespath.compile(self.k)
+AttributeError: 'SecurityGroupFilter' object has no attribute 'k'
+2016-11-21 12:48:18,732 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 12:50:50,251 - custodian.output - ERROR - Error while executing policy
+Traceback (most recent call last):
+  File "/path/prefix/c7n/policy.py", line 167, in run
+    resources = self.policy.resource_manager.resources()
+  File "/path/prefix/c7n/query.py", line 152, in resources
+    return self.filter_resources(resources)
+  File "/path/prefix/c7n/manager.py", line 63, in filter_resources
+    resources = f.process(resources, event)
+  File "/path/prefix/c7n/filters/related.py", line 96, in process
+    return [r for r in resources if self.process_resource(r, related)]
+  File "/path/prefix/c7n/filters/related.py", line 70, in process_resource
+    self.data['value'] = self.get_resource_value(
+  File "/path/prefix/c7n/filters/core.py", line 274, in get_resource_value
+    self.expr = jmespath.compile(self.k)
+AttributeError: 'SecurityGroupFilter' object has no attribute 'k'
+2016-11-21 12:52:34,415 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 12:54:44,670 - custodian.output - ERROR - Error while executing policy
+Traceback (most recent call last):
+  File "/path/prefix/c7n/policy.py", line 167, in run
+    resources = self.policy.resource_manager.resources()
+  File "/path/prefix/c7n/query.py", line 152, in resources
+    return self.filter_resources(resources)
+  File "/path/prefix/c7n/manager.py", line 63, in filter_resources
+    resources = f.process(resources, event)
+  File "/path/prefix/c7n/filters/related.py", line 96, in process
+  File "/path/prefix/c7n/filters/related.py", line 70, in process_resource
+    self.data['key'], resource)
+  File "/path/prefix/c7n/filters/related.py", line 70, in process_resource
+    self.data['key'], resource)
+  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/bdb.py", line 49, in trace_dispatch
+    return self.dispatch_line(frame)
+  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/bdb.py", line 67, in dispatch_line
+    self.user_line(frame)
+  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/pdb.py", line 158, in user_line
+    self.interaction(frame, None)
+  File "/path/prefix/lib/python2.7/site-packages/pdb.py", line 250, in interaction
+    self.cmdloop()
+  File "/usr/local/Cellar/python/2.7.12_2/Frameworks/Python.framework/Versions/2.7/lib/python2.7/cmd.py", line 130, in cmdloop
+    line = raw_input(self.prompt)
+  File "/path/prefix/lib/python2.7/site-packages/pyrepl/readline.py", line 199, in raw_input
+    return reader.readline(reader, startup_hook=self.startup_hook)
+  File "/path/prefix/lib/python2.7/site-packages/pyrepl/reader.py", line 603, in readline
+    self.handle1()
+  File "/path/prefix/lib/python2.7/site-packages/pyrepl/reader.py", line 586, in handle1
+    self.do_cmd(cmd)
+  File "/path/prefix/lib/python2.7/site-packages/pyrepl/reader.py", line 533, in do_cmd
+    cmd.do()
+  File "/path/prefix/lib/python2.7/site-packages/pyrepl/commands.py", line 187, in do
+    os.kill(os.getpid(), signal.SIGINT)
+KeyboardInterrupt
+2016-11-21 12:57:01,955 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 12:57:02,664 - custodian.resources.rds - INFO - Filtered from 1 to 1 rds
+2016-11-21 12:57:02,664 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:1 time:0.71
+2016-11-21 12:57:03,375 - custodian.policy - INFO - policy: related-rds-test action: retentionwindow resources: 1 execution_time: 0.71
+2016-11-21 13:07:26,678 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 13:07:27,464 - custodian.resources.rds - INFO - Filtered from 1 to 1 rds
+2016-11-21 13:07:27,464 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:1 time:0.79
+2016-11-21 13:07:28,179 - custodian.policy - INFO - policy: related-rds-test action: retentionwindow resources: 1 execution_time: 0.71
+2016-11-21 13:07:40,577 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 13:07:41,117 - custodian.resources.rds - INFO - Filtered from 1 to 1 rds
+2016-11-21 13:07:41,117 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:1 time:0.54
+2016-11-21 13:07:41,688 - custodian.policy - INFO - policy: related-rds-test action: retentionwindow resources: 1 execution_time: 0.57
+2016-11-21 13:13:27,352 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 13:13:28,075 - custodian.output - ERROR - Error while executing policy
+Traceback (most recent call last):
+  File "/path/prefix/c7n/policy.py", line 167, in run
+    resources = self.policy.resource_manager.resources()
+  File "/path/prefix/c7n/query.py", line 152, in resources
+    return self.filter_resources(resources)
+  File "/path/prefix/c7n/manager.py", line 63, in filter_resources
+    resources = f.process(resources, event)
+  File "/path/prefix/c7n/filters/related.py", line 95, in process
+    return [r for r in resources if self.process_resource(r, related)]
+  File "/path/prefix/c7n/filters/related.py", line 70, in process_resource
+    self.data['key'], resource)
+  File "/path/prefix/c7n/filters/core.py", line 274, in get_resource_value
+    self.expr = jmespath.compile(self.k)
+AttributeError: 'SecurityGroupFilter' object has no attribute 'k'
+2016-11-21 13:13:40,040 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 13:13:40,594 - custodian.resources.rds - INFO - Filtered from 1 to 1 rds
+2016-11-21 13:13:40,594 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:1 time:0.55
+2016-11-21 13:13:41,477 - custodian.policy - INFO - policy: related-rds-test action: retentionwindow resources: 1 execution_time: 0.88
+2016-11-21 13:42:44,192 - custodian.policy - INFO - Running policy related-rds-test resource: rds region:us-west-1 c7n:0.8.21.0
+2016-11-21 13:42:46,619 - custodian.resources.rds - INFO - Filtered from 1 to 1 rds
+2016-11-21 13:42:46,620 - custodian.policy - INFO - policy: related-rds-test resource:rds has count:1 time:2.43
+2016-11-21 13:42:46,624 - custodian.policy - INFO - policy: related-rds-test action: retentionwindow resources: 1 execution_time: 0.00

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -240,5 +240,5 @@ class LogsTest(CliTest):
         empty_policies = {'policies': []}
         yaml_file = self.write_policy_file(empty_policies)
         self.run_and_expect_exception(
-            ['custodian', 'report', '-c', yaml_file, '-s', temp_dir],
+            ['custodian', 'logs', '-c', yaml_file, '-s', temp_dir],
             AssertionError)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import os
 import shutil
 import sys
 import tempfile
@@ -254,3 +255,24 @@ class LogsTest(CliTest):
         self.run_and_expect_exception(
             ['custodian', 'logs', '-c', yaml_file, '-s', temp_dir],
             AssertionError)
+        p_data = {
+            'name': 'test-policy',
+            'resource': 'rds',
+            'filters': [
+                {
+                    'key': 'GroupName',
+                    'type': 'security-group',
+                    'value': 'default',
+                },
+            ],
+            'actions': [{'days': 10, 'type': 'retention'}],
+        }
+        yaml_file = self.write_policy_file({'policies': [p_data]})
+        output_dir = os.path.join(
+            os.path.dirname(__file__),
+            'data',
+            'logs',
+        )
+        self.run_and_expect_success(
+            ['custodian', 'logs', '-c', yaml_file, '-s', output_dir],
+        )

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -17,7 +17,7 @@ import sys
 import tempfile
 import yaml
 
-
+from argparse import ArgumentTypeError
 from common import BaseTest
 from cStringIO import StringIO
 from c7n import cli, version
@@ -88,6 +88,18 @@ class CliTest(BaseTest):
         except exception:
             return
         self.fail('Error: did not raise {}.'.format(exception))
+
+
+class UtilsTest(BaseTest):
+
+    def test_key_val_pair(self):
+        self.assertRaises(
+            ArgumentTypeError,
+            cli._key_val_pair,
+            'invalid option',
+        )
+        param = 'day=today'
+        self.assertIs(cli._key_val_pair(param), param)
 
 
 class VersionTest(CliTest):

--- a/tests/test_logs_support.py
+++ b/tests/test_logs_support.py
@@ -1,0 +1,67 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+import os
+
+from unittest import TestCase
+
+from c7n.logs_support import (
+    normalized_log_entries,
+    log_entries_in_range,
+)
+
+
+def log_lines():
+    with open(
+        os.path.join(
+            os.path.dirname(__file__),
+            'data',
+            'logs',
+            'test-policy',
+            'custodian-run.log',
+        )
+    ) as fh:
+        return fh.readlines()
+
+
+class TestLogsSupport(TestCase):
+
+    def test_normailization(self):
+        raw_entries = log_lines()
+        log_gen = normalized_log_entries(raw_entries)
+        nrm_entries = list(log_gen)
+        # multi-line entries are being combined
+        self.assertEqual(len(raw_entries), 144)
+        self.assertEqual(len(nrm_entries), 55)
+        # entries look reasonable
+        entry = nrm_entries[1]
+        self.assertIn('timestamp', entry)
+        self.assertIn('message', entry)
+        self.assertIsInstance(entry['timestamp'], float)
+        self.assertIsInstance(entry['message'], str)
+
+    def test_entries_in_range(self):
+        raw_entries = log_lines()
+        log_gen = normalized_log_entries(raw_entries)
+        nrm_entries = list(log_gen)
+        range_gen = log_entries_in_range(
+            nrm_entries,
+            '2016-11-21 12:40:00',
+            '2016-11-21 12:45:00',
+        )
+        in_range = list(range_gen)
+        # fewer entries than we started with
+        self.assertLess(len(in_range), len(nrm_entries))
+        # entries are within 5 minutes of each other
+        span = (in_range[-1]['timestamp'] - in_range[0]['timestamp']) / 1000
+        self.assertLess(span, 300)

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -215,3 +215,9 @@ class UtilTest(unittest.TestCase):
             utils.parse_s3('s3://things'),
             ('s3://things', 'things', ''),
         )
+
+    def test_timestamp_from_string(self):
+        tfs = utils.timestamp_from_string
+        date_text = '2016-11-21 13:13:41 EST'
+        self.assertEqual(tfs(date_text), 1479752021.0)
+        self.assertEqual(tfs('not a date'), 0)


### PR DESCRIPTION
Implemented in the execution modes’ respective `get_logs()` methods.

It could use a few more tests for the S3 and CloudWatch implementations, but I wanted to get it out the door so you could have a look.