### PR TITLE
include files from lib64

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -41,10 +41,13 @@ import c7n
 # Static event mapping to help simplify cwe rules creation
 from c7n.cwe import CloudWatchEvents
 from c7n.utils import parse_s3, local_session
-from c7n.version import RUNTIME
 
 
 log = logging.getLogger('custodian.lambda')
+RUNTIME = 'python{}.{}'.format(
+    sys.version_info.major,
+    sys.version_info.minor,
+)
 
 
 class PythonPackageArchive(object):

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -41,6 +41,7 @@ import c7n
 # Static event mapping to help simplify cwe rules creation
 from c7n.cwe import CloudWatchEvents
 from c7n.utils import parse_s3, local_session
+from c7n.version import RUNTIME
 
 
 log = logging.getLogger('custodian.lambda')
@@ -51,6 +52,8 @@ class PythonPackageArchive(object):
 
     Packages up a virtualenv and a source package directory per lambda's
     directory structure.
+
+    See http://docs.aws.amazon.com/lambda/latest/dg/with-s3-example-deployment-pkg.html#with-s3-example-deployment-pkg-python
     """
 
     def __init__(self, src_path, virtualenv_dir=None, skip=None,
@@ -110,18 +113,29 @@ class PythonPackageArchive(object):
                     self.add_file(f_path, dest_path)
 
         # Library Source
-        venv_lib_path = os.path.join(
-            self.virtualenv_dir, 'lib', 'python2.7', 'site-packages')
+        venv_lib_paths = (
+            os.path.join(
+                self.virtualenv_dir,
+                'lib', RUNTIME, 'site-packages',
+            ),
+            os.path.join(
+                self.virtualenv_dir,
+                'lib64', RUNTIME, 'site-packages',
+            ),
+        )
 
-        for root, dirs, files in os.walk(venv_lib_path):
-            if self.lib_filter:
-                dirs, files = self.lib_filter(root, dirs, files)
-            arc_prefix = os.path.relpath(root, venv_lib_path)
-            files = self.filter_files(files)
-            for f in files:
-                f_path = os.path.join(root, f)
-                dest_path = os.path.join(arc_prefix, f)
-                self.add_file(f_path, dest_path)
+        for venv_lib_path in venv_lib_paths:
+            if not os.path.exists(venv_lib_path):
+                continue
+            for root, dirs, files in os.walk(venv_lib_path):
+                if self.lib_filter:
+                    dirs, files = self.lib_filter(root, dirs, files)
+                arc_prefix = os.path.relpath(root, venv_lib_path)
+                files = self.filter_files(files)
+                for f in files:
+                    f_path = os.path.join(root, f)
+                    dest_path = os.path.join(arc_prefix, f)
+                    self.add_file(f_path, dest_path)
 
     def add_file(self, src, dest):
         info = zipfile.ZipInfo(dest)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -19,7 +19,6 @@ docs/lambda.rst
 
 import abc
 import base64
-from datetime import datetime
 import inspect
 import fnmatch
 import hashlib

--- a/c7n/version.py
+++ b/c7n/version.py
@@ -11,11 +11,5 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import sys
-
 
 version = "0.8.21.2"
-RUNTIME = 'python{}.{}'.format(
-    sys.version_info.major,
-    sys.version_info.minor,
-)

--- a/c7n/version.py
+++ b/c7n/version.py
@@ -11,5 +11,11 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import sys
+
 
 version = "0.8.21.2"
+RUNTIME = 'python{}.{}'.format(
+    sys.version_info.major,
+    sys.version_info.minor,
+)

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -20,7 +20,7 @@ import zipfile
 
 from c7n.mu import (
     custodian_archive, LambdaManager, PolicyLambda,
-    CloudWatchLogSubscription)
+    CloudWatchLogSubscription, RUNTIME)
 from c7n.policy import Policy
 from c7n.ufuncs import logsub
 from .common import BaseTest, Config, event_data
@@ -184,7 +184,7 @@ class PolicyLambdaProvision(BaseTest):
              'FunctionName': 'custodian-s3-bucket-policy',
              'Handler': 'custodian_policy.run',
              'MemorySize': 512,
-             'Runtime': 'python2.7',
+             'Runtime': RUNTIME,
              'Timeout': 60})
         mgr.remove(pl)
 
@@ -227,7 +227,7 @@ class PolicyLambdaProvision(BaseTest):
              'FunctionName': 'maid-ec2-encrypted-vol',
              'Handler': 'maid_policy.run',
              'MemorySize': 512,
-             'Runtime': 'python2.7',
+             'Runtime': RUNTIME,
              'Timeout': 60})
 
         events = session_factory().client('events')
@@ -262,7 +262,7 @@ class PolicyLambdaProvision(BaseTest):
             {'FunctionName': 'maid-asg-spin-detector',
              'Handler': 'maid_policy.run',
              'MemorySize': 512,
-             'Runtime': 'python2.7',
+             'Runtime': RUNTIME,
              'Timeout': 60})
 
         events = session_factory().client('events')
@@ -298,7 +298,7 @@ class PolicyLambdaProvision(BaseTest):
             {'FunctionName': 'maid-periodic-ec2-checker',
              'Handler': 'maid_policy.run',
              'MemorySize': 512,
-             'Runtime': 'python2.7',
+             'Runtime': RUNTIME,
              'Timeout': 60})
 
         events = session_factory().client('events')


### PR DESCRIPTION
Fixes #627

We can just repeat what we were doing with `lib/python2.7/site-packages` on `lib64`. This is the process described in [the AWS documentation][docs] (step 10).

I’ve tested this branch on an Amazon Linux instance and the YAML library is added to the ZIP archive.

[docs]: http://docs.aws.amazon.com/lambda/latest/dg/with-s3-example-deployment-pkg.html#with-s3-example-deployment-pkg-python