### PR TITLE
Add new actions to the account resource

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -444,6 +444,7 @@ class LoggingStart(BaseAction):
                         "Error while starting logging: %s",
                         e.response['Error']['Message'],
                     )
+                raise
 
 
 @actions.register('logging-stop')
@@ -487,3 +488,4 @@ class LoggingStop(BaseAction):
                         "Error while stoping logging: %s",
                         e.response['Error']['Message'],
                     )
+                raise

--- a/tests/data/placebo/test_account_logging/cloudtrail.StartLogging_1.json
+++ b/tests/data/placebo/test_account_logging/cloudtrail.StartLogging_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cdd00460-bbc2-11e6-bf9f-1fb63d564a69", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cdd00460-bbc2-11e6-bf9f-1fb63d564a69", 
+                "date": "Tue, 06 Dec 2016 14:46:43 GMT", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging/cloudtrail.StopLogging_1.json
+++ b/tests/data/placebo/test_account_logging/cloudtrail.StopLogging_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cd2ac3a3-bbc2-11e6-bf9f-1fb63d564a69", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cd2ac3a3-bbc2-11e6-bf9f-1fb63d564a69", 
+                "date": "Tue, 06 Dec 2016 14:46:42 GMT", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_logging/iam.ListAccountAliases_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ccce4b51-bbc2-11e6-b03e-911baa2f243e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ccce4b51-bbc2-11e6-b03e-911baa2f243e", 
+                "date": "Tue, 06 Dec 2016 14:46:41 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging/iam.ListAccountAliases_2.json
+++ b/tests/data/placebo/test_account_logging/iam.ListAccountAliases_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cd6c11f8-bbc2-11e6-9b24-91612b9e7f00", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cd6c11f8-bbc2-11e6-9b24-91612b9e7f00", 
+                "date": "Tue, 06 Dec 2016 14:46:42 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_account_logging/iam.ListRoles_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "ABodXw7JGrq1IIiuM3KHS2tcgx4050YWa7qPihuJqFtAaDkpQ+vjH1EUdiKhukxtyEpP1kcp19Q88yrL/GjsRXPL", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22quicksight.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJ7VIQKM2MU4RUFTLO", 
+                "CreateDate": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 27, 
+                    "minute": 42
+                }, 
+                "RoleName": "aws-quicksight-service-role-v0", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/aws-quicksight-service-role-v0"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ccf645e8-bbc2-11e6-b03e-911baa2f243e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ccf645e8-bbc2-11e6-b03e-911baa2f243e", 
+                "date": "Tue, 06 Dec 2016 14:46:41 GMT", 
+                "content-length": "1004", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging/iam.ListRoles_2.json
+++ b/tests/data/placebo/test_account_logging/iam.ListRoles_2.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "ABCx/dpPyi2SsnGJDHqSSmjRp05aerQ6q6UHLB92h4ytSMWqYMKAE/uiLqIW3Ou8B6HQ7C01JT5TOENUGc29xueg", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22quicksight.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJ7VIQKM2MU4RUFTLO", 
+                "CreateDate": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 27, 
+                    "minute": 42
+                }, 
+                "RoleName": "aws-quicksight-service-role-v0", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/aws-quicksight-service-role-v0"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cd9badbc-bbc2-11e6-9b24-91612b9e7f00", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cd9badbc-bbc2-11e6-9b24-91612b9e7f00", 
+                "date": "Tue, 06 Dec 2016 14:46:42 GMT", 
+                "content-length": "1004", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging_fail/cloudtrail.StartLogging_1.json
+++ b/tests/data/placebo/test_account_logging_fail/cloudtrail.StartLogging_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 400, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 400, 
+            "RequestId": "811976c7-bbd0-11e6-bf9f-1fb63d564a69", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "811976c7-bbd0-11e6-bf9f-1fb63d564a69", 
+                "date": "Tue, 06 Dec 2016 16:24:46 GMT", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "close"
+            }
+        }, 
+        "Error": {
+            "Message": "Unknown trail: invalid for the user: 644160558196", 
+            "Code": "TrailNotFoundException"
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging_fail/cloudtrail.StopLogging_1.json
+++ b/tests/data/placebo/test_account_logging_fail/cloudtrail.StopLogging_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 400, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 400, 
+            "RequestId": "8052080e-bbd0-11e6-bf9f-1fb63d564a69", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "8052080e-bbd0-11e6-bf9f-1fb63d564a69", 
+                "date": "Tue, 06 Dec 2016 16:24:45 GMT", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "close"
+            }
+        }, 
+        "Error": {
+            "Message": "Unknown trail: invalid for the user: 644160558196", 
+            "Code": "TrailNotFoundException"
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging_fail/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_logging_fail/iam.ListAccountAliases_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "7fe2079c-bbd0-11e6-ac30-13747c915507", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "7fe2079c-bbd0-11e6-ac30-13747c915507", 
+                "date": "Tue, 06 Dec 2016 16:24:45 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging_fail/iam.ListAccountAliases_2.json
+++ b/tests/data/placebo/test_account_logging_fail/iam.ListAccountAliases_2.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "808859d3-bbd0-11e6-ac30-13747c915507", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "808859d3-bbd0-11e6-ac30-13747c915507", 
+                "date": "Tue, 06 Dec 2016 16:24:46 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging_fail/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_account_logging_fail/iam.ListRoles_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AB0wta/QzGBwyWLSRbIYq8p0OSl2U67McyGbg4cz+DkjkWiGVoS7doSwxSys1fmcVFJ/K89he92LGZMNl6cJnJ+W", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22quicksight.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJ7VIQKM2MU4RUFTLO", 
+                "CreateDate": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 27, 
+                    "minute": 42
+                }, 
+                "RoleName": "aws-quicksight-service-role-v0", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/aws-quicksight-service-role-v0"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "8011f18d-bbd0-11e6-ac30-13747c915507", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "8011f18d-bbd0-11e6-ac30-13747c915507", 
+                "date": "Tue, 06 Dec 2016 16:24:45 GMT", 
+                "content-length": "1004", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_logging_fail/iam.ListRoles_2.json
+++ b/tests/data/placebo/test_account_logging_fail/iam.ListRoles_2.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AAb7d/RwG+U2n6QN4QdVAyIxSxt1fgf36t9uRJuk9oVVawQLvUHnM5yoYKfZInR9hyIb968LVl2hbTk1Ah4GGSkb", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22quicksight.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJ7VIQKM2MU4RUFTLO", 
+                "CreateDate": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 27, 
+                    "minute": 42
+                }, 
+                "RoleName": "aws-quicksight-service-role-v0", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/aws-quicksight-service-role-v0"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "80e5bca1-bbd0-11e6-ac30-13747c915507", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "80e5bca1-bbd0-11e6-ac30-13747c915507", 
+                "date": "Tue, 06 Dec 2016 16:24:46 GMT", 
+                "content-length": "1004", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_recording/config.DescribeConfigurationRecorders_1.json
+++ b/tests/data/placebo/test_account_recording/config.DescribeConfigurationRecorders_1.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ConfigurationRecorders": [
+            {
+                "recordingGroup": {
+                    "allSupported": true, 
+                    "resourceTypes": [], 
+                    "includeGlobalResourceTypes": false
+                }, 
+                "roleARN": "arn:aws:iam::644160558196:role/service-role/config-role-us-west-1", 
+                "name": "default"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d763c8ac-bbbe-11e6-b047-953f12086c66", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d763c8ac-bbbe-11e6-b047-953f12086c66", 
+                "date": "Tue, 06 Dec 2016 14:18:21 GMT", 
+                "content-length": "218", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_recording/config.StartConfigurationRecorder_1.json
+++ b/tests/data/placebo/test_account_recording/config.StartConfigurationRecorder_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4115bafc-bb36-11e6-b8f1-39b9a0c1bde8", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "4115bafc-bb36-11e6-b8f1-39b9a0c1bde8", 
+                "date": "Mon, 05 Dec 2016 22:00:36 GMT", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_recording/config.StopConfigurationRecorder_1.json
+++ b/tests/data/placebo/test_account_recording/config.StopConfigurationRecorder_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d773801d-bbbe-11e6-b047-953f12086c66", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d773801d-bbbe-11e6-b047-953f12086c66", 
+                "date": "Tue, 06 Dec 2016 14:18:21 GMT", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_recording/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_recording/iam.ListAccountAliases_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d6f6af62-bbbe-11e6-90ac-d57cbd3d718e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d6f6af62-bbbe-11e6-90ac-d57cbd3d718e", 
+                "date": "Tue, 06 Dec 2016 14:18:20 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_recording/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_account_recording/iam.ListRoles_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "ACSvgznvNfxapl1JMkHuSHFjYzZE/hbmYqmRn5cnJAVweGY0BU3rKu2muS8WvrESzbGAzfmPtKkvyqEPNdPIRobo", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22quicksight.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJ7VIQKM2MU4RUFTLO", 
+                "CreateDate": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 27, 
+                    "minute": 42
+                }, 
+                "RoleName": "aws-quicksight-service-role-v0", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/aws-quicksight-service-role-v0"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d7214158-bbbe-11e6-90ac-d57cbd3d718e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d7214158-bbbe-11e6-90ac-d57cbd3d718e", 
+                "date": "Tue, 06 Dec 2016 14:18:20 GMT", 
+                "content-length": "1004", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -11,6 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+from botocore.exceptions import ClientError
 from common import BaseTest
 
 
@@ -206,3 +207,30 @@ class AccountTests(BaseTest):
         )
         resources = on_p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_logging_fail(self):
+        session_factory = self.replay_flight_data('test_account_logging_fail')
+        off_p = self.load_policy(
+            {
+                'resource': 'account',
+                'name': 'account-test',
+                'actions': [{
+                    'type': 'logging-stop',
+                    'trails': ['invalid'],
+                }],
+            },
+            session_factory=session_factory,
+        )
+        self.assertRaises(ClientError, off_p.run)
+        on_p = self.load_policy(
+            {
+                'resource': 'account',
+                'name': 'account-test',
+                'actions': [{
+                    'type': 'logging-start',
+                    'trails': ['invalid'],
+                }],
+            },
+            session_factory=session_factory,
+        )
+        self.assertRaises(ClientError, on_p.run)

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -155,4 +155,54 @@ class AccountTests(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 0)
 
+    def test_recording_actions(self):
+        session_factory = self.replay_flight_data('test_account_recording')
+        off_p = self.load_policy(
+            {
+                'resource': 'account',
+                'name': 'account-test',
+                'actions': ['record-stop'],
+            },
+            session_factory=session_factory,
+        )
+        resources = off_p.run()
+        self.assertEqual(len(resources), 1)
+        on_p = self.load_policy(
+            {
+                'resource': 'account',
+                'name': 'account-test',
+                'actions': ['record-start'],
+            },
+            session_factory=session_factory,
+        )
+        resources = on_p.run()
+        self.assertEqual(len(resources), 1)
 
+    def test_logging_actions(self):
+        session_factory = self.replay_flight_data('test_account_logging')
+        off_p = self.load_policy(
+            {
+                'resource': 'account',
+                'name': 'account-test',
+                'actions': [{
+                    'type': 'logging-stop',
+                    'trails': ['skunk-trails'],
+                }],
+            },
+            session_factory=session_factory,
+        )
+        resources = off_p.run()
+        self.assertEqual(len(resources), 1)
+        on_p = self.load_policy(
+            {
+                'resource': 'account',
+                'name': 'account-test',
+                'actions': [{
+                    'type': 'logging-start',
+                    'trails': ['skunk-trails'],
+                }],
+            },
+            session_factory=session_factory,
+        )
+        resources = on_p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
Specifically, those described in #339 and #340.

One thing I wasn’t clear on: When calling `describe_configuration_recorders()` or `describe_trails()`, will you *ever* see results for an account other than the one you’ve logged into?

If not, we can probably drop the account ID checking loop in the Config actions. If so, we probably need to add a loop like that to the CloudTrail actions.