### PR TITLE
Improve dev onboarding docs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,3 +42,6 @@ ghpages:
 	git add -u && \
 	git add -A && \
 	git commit -m "Updated generated Sphinx documentation"
+
+clean:
+	rm -rf .Python bin include lib pip-selfcheck.json 

--- a/Makefile
+++ b/Makefile
@@ -1,11 +1,11 @@
 
 install:
-	virtualenv .
+	python2.7 -m virtualenv .
 	source bin/activate && pip install -r requirements.txt
 	source bin/activate && python setup.py develop
 
 develop:
-	virtualenv .
+	python2.7 -m virtualenv .
 	source bin/activate && pip install -r requirements-dev.txt
 	source bin/activate && python setup.py develop
 
@@ -26,7 +26,7 @@ ftests:
 
 depcache:
 	mkdir -p deps
-	virtualenv dep-download
+	python2.7 -m virtualenv dep-download
 	dep-download/bin/pip install -d deps -r requirements.txt
 	tar cvf custodian-deps.tgz deps
 	rm -Rf dep-download

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -23,30 +23,20 @@ On Mac
 Installing
 ----------
 
+Building the Custodian requires Python 2 or 3, and a make/C toolchain.
+
 First, clone the repository:
 
 .. code-block:: bash
 
    $ git clone https://github.com/capitalone/cloud-custodian.git
+   $ cd cloud-custodian
 
-Also recommended is to use a virtualenv to sandbox this install from your system packages:
-
-.. code-block:: bash
-
-   $ virtualenv cloud-custodian
-   $ source cloud-custodian/bin/activate
-
-And then install the dependencies. Deployed systems will just use `requirements.txt`; you'll need the additional testing libraries in `requirements-dev.txt`.
+Then build the software:
 
 .. code-block:: bash
 
-   $ pip install -r requirements-dev.txt
-
-And then the Custodian itself:
-
-.. code-block:: bash
-
-   $ python setup.py develop
+   $ make develop
 
 You should have the ``custodian`` command available now:
 
@@ -54,25 +44,10 @@ You should have the ``custodian`` command available now:
 
    $ custodian -h
 
-Alternatively, you can just run the commands below:
-
-.. code-block:: bash
-
-   $ cd cloud-custodian
-   $ make develop
-   $ ./bin/custodian -h
-
 Running tests
 -------------
 
-There are several additional dependencies for running unit tests.
-
-.. code-block:: bash
-
-   $ cd cloud-custodian
-   $ make install
-
-Then unit tests can be run with:
+Unit tests can be run with:
 
 .. code-block:: bash
 

--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -6,6 +6,8 @@ Developer Install and Testing
 Requirements
 ------------
 
+The Custodian requires Python 2.7, and a make/C toolchain.
+
 On Linux
 ~~~~~~~~
 
@@ -22,8 +24,6 @@ On Mac
 
 Installing
 ----------
-
-Building the Custodian requires Python 2 or 3, and a make/C toolchain.
 
 First, clone the repository:
 


### PR DESCRIPTION
I started following the [build instructions](http://www.capitalone.io/cloud-custodian/docs/quickstart/developer.html) without reading them all first. Yes, I know, I should've read them all first. For the next person, I think we should make the "alternative" the default. Devs who wish to diverge can read the Makefile for themselves.

Then I learned that we're Python 2.7 only (no Python 3).