### PR TITLE
WIP: Read ~/.aws/config and use region from there

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -22,6 +22,8 @@ import traceback
 
 from dateutil.parser import parse as date_parse
 
+from c7n.utils import read_aws_config_file
+
 DEFAULT_REGION = 'us-east-1'
 
 
@@ -33,10 +35,11 @@ def _default_options(p, blacklist=""):
     """
     provider = p.add_argument_group(
         "provider", "AWS account information, defaults per the aws cli")
+
+    default_region = determine_default_region()
     if 'region' not in blacklist:
         provider.add_argument(
-            "-r", "--region",
-            default=os.environ.get('AWS_DEFAULT_REGION', DEFAULT_REGION),
+            "-r", "--region", default=default_region,
             help="AWS Region to target (Default: %(default)s)")
     provider.add_argument(
         "--profile",
@@ -215,6 +218,27 @@ def setup_parser():
         help="Emit metrics to CloudWatch Metrics")
 
     return parser
+
+
+def determine_default_region():
+    """ Return the default region
+    
+    If the region is not specified on the command line we will use a default.
+
+    The priority order for determining this is:
+     - AWS_DEFAULT_REGION command line variable
+     - region defined in ~/.aws/config
+     - The DEFAULT_REGION defined at the top of this file
+    """
+    env_key = 'AWS_DEFAULT_REGION'
+    if os.environ.get(env_key):
+        return os.environ[env_key]
+
+    config = read_aws_config_file()
+    if config.get('default', 'region', fallback=None):
+        return config['default']['region']
+    
+    return DEFAULT_REGION
 
 
 def cmd_version(options):

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -227,7 +227,8 @@ def determine_default_region():
 
     The priority order for determining this is:
      - AWS_DEFAULT_REGION environment variable
-     - region defined in ~/.aws/config
+     - region defined in the file pointed to by AWS_CONFIG_FILE env variable
+       (the default for this file is ~/.aws/config)
      - The DEFAULT_REGION defined at the top of this file
     """
     env_key = 'AWS_DEFAULT_REGION'

--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -226,7 +226,7 @@ def determine_default_region():
     If the region is not specified on the command line we will use a default.
 
     The priority order for determining this is:
-     - AWS_DEFAULT_REGION command line variable
+     - AWS_DEFAULT_REGION environment variable
      - region defined in ~/.aws/config
      - The DEFAULT_REGION defined at the top of this file
     """

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -329,7 +329,8 @@ def read_aws_config_file(file=None):
     """ Read the AWS config file and return the config """
 
     if file is None:
-        file = os.path.expanduser(os.path.join('~', '.aws', 'config'))
+        file = os.environ.get('AWS_CONFIG_FILE',
+                              os.path.expanduser('~/.aws/config'))
 
     config = ConfigParser()
     config.read([file])

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -13,17 +13,18 @@
 # limitations under the License.
 from botocore.exceptions import ClientError
 
+from configparser import ConfigParser
 import copy
 from datetime import datetime
 import functools
 import json
 import itertools
 import logging
+import os
 import random
 import threading
 import time
 import ipaddress
-
 
 # Try to place nice in lambda exec environment
 # where we don't require yaml
@@ -323,6 +324,17 @@ class IPv4Network(ipaddress.IPv4Network):
 
 worker_log = logging.getLogger('c7n.worker')
 
+
+def read_aws_config_file(file=None):
+    """ Read the AWS config file and return the config """
+
+    if file is None:
+        file = os.path.expanduser(os.path.join('~', '.aws', 'config'))
+
+    config = ConfigParser()
+    config.read([file])
+    return config
+        
 
 def worker(f):
     """Generic wrapper to log uncaught exceptions in a function.

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 import json
 import unittest
+import tempfile
 import time
 
 from botocore.exceptions import ClientError
@@ -100,6 +101,17 @@ class WorkerDecorator(BaseTest):
 
 
 class UtilTest(unittest.TestCase):
+
+    def write_temp_file(self, contents, suffix='.tmp'):
+        """ Write a temporary file and return the filename.
+        
+        The file will be cleaned up after the test.
+        """
+        file = tempfile.NamedTemporaryFile(suffix=suffix)
+        file.write(contents)
+        file.flush()
+        self.addCleanup(file.close)
+        return file.name
 
     def test_ipv4_network(self):
         n1 = utils.IPv4Network(u'10.0.0.0/16')
@@ -214,4 +226,16 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(
             utils.parse_s3('s3://things'),
             ('s3://things', 'things', ''),
+        )
+
+    def test_read_aws_config_file(self):
+        region = 'us-west-2'
+
+        ini_contents = "[default]\nregion={}".format(region)
+        filename = self.write_temp_file(ini_contents, suffix='.ini')
+
+        config = utils.read_aws_config_file(filename)
+        self.assertEqual(
+            config.get('default', 'region'),
+            region
         )

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -12,6 +12,7 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 import json
+import os
 import unittest
 import tempfile
 import time
@@ -229,8 +230,10 @@ class UtilTest(unittest.TestCase):
         )
 
     def test_read_aws_config_file(self):
+        #
+        # Test 1 - make sure we can read a file
+        #
         region = 'us-west-2'
-
         ini_contents = "[default]\nregion={}".format(region)
         filename = self.write_temp_file(ini_contents, suffix='.ini')
 
@@ -239,3 +242,24 @@ class UtilTest(unittest.TestCase):
             config.get('default', 'region'),
             region
         )
+
+        #
+        # Test 2 - make sure that setting AWS_CONFIG_FILE works
+        #
+        region = 'us-west-1'
+        ini_contents = "[default]\nregion={}".format(region)
+        filename = self.write_temp_file(ini_contents, suffix='.ini')
+
+        original_setting = os.environ.get('AWS_CONFIG_FILE')
+        os.environ['AWS_CONFIG_FILE'] = filename
+        
+        config = utils.read_aws_config_file()
+        self.assertEqual(
+            config.get('default', 'region'),
+            region
+        )
+
+        if original_setting:
+            os.environ['AWS_CONFIG_FILE'] = original_setting
+        else:
+            del(os.environ['AWS_CONFIG_FILE'])


### PR DESCRIPTION
I am always using the `[default]` section of the config file.  If I should use the specific profile (as passed via `--profile` on the cli) then I need to add that in, so I marked this as WIP.
