### PR TITLE
Fix doc link and build bug

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,8 +37,10 @@ sphinx:
 	make -f docs/Makefile.sphinx html
 
 ghpages:
-	-git checkout gh-pages && \
-	cp -r docs/build/html/* ./docs/ && \
+	git checkout gh-pages && \
+	mv docs/build/html new-docs && \
+	rm -rf docs && \
+	mv new-docs docs && \
 	git add -u && \
 	git add -A && \
 	git commit -m "Updated generated Sphinx documentation"

--- a/README.rst
+++ b/README.rst
@@ -64,7 +64,7 @@ Links
 #####
 
 - `Docs <http://www.capitalone.io/cloud-custodian/>`_
-- `Developer Install <http://www.capitalone.io/cloud-custodian/docs/quickstart/developer.html>`_
+- `Developer Install <http://www.capitalone.io/cloud-custodian/docs/developer.html>`_
 
 
 Quick Install


### PR DESCRIPTION
If we just copy in new docs then we never remove old doc files.

Fixes #782.