### PR TITLE
use list_objects_v2 for S3 paginators

### DIFF
--- a/c7n/logs_support.py
+++ b/c7n/logs_support.py
@@ -99,10 +99,10 @@ def log_entries_from_s3(session_factory, output, start, end):
         start.strftime('%Y/%m/%d/00'),
         log_filename,
     )
-    p = client.get_paginator('list_objects').paginate(
+    p = client.get_paginator('list_objects_v2').paginate(
         Bucket=output.bucket,
         Prefix=key_prefix + '/',
-        Marker=marker,
+        StartAfter=marker,
     )
     with ThreadPoolExecutor(max_workers=20) as w:
         for key_set in p:

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -215,10 +215,10 @@ def record_set(session_factory, bucket, key_prefix, start_date):
     marker = key_prefix.strip("/") + "/" + start_date.strftime(
          '%Y/%m/%d/00') + "/resources.json.gz"
 
-    p = s3.get_paginator('list_objects').paginate(
+    p = s3.get_paginator('list_objects_v2').paginate(
         Bucket=bucket,
         Prefix=key_prefix.strip('/') + '/',
-        Marker=marker
+        StartAfter=marker,
     )
 
     with ThreadPoolExecutor(max_workers=20) as w:


### PR DESCRIPTION
This was done for #668 but didn’t get pushed prior to merge. V2 is supposedly more efficient, so I’m putting this out there.