### PR TITLE
minor fix for multiline yaml in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -110,7 +110,7 @@ First a policy file needs to be created in YAML format, as an example::
 
   - name: tag-compliance
     resource: ec2
-    description:
+    description: |
       Schedule a resource that does not meet tag compliance policies
       to be stopped in four days.
     filters:


### PR DESCRIPTION
Turned the third policy description in the policy yaml example into a literal block as per the description blocks above it