### PR TITLE
Warning message when -p causes all policies to be filtered out

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -43,6 +43,14 @@ def policy_command(f):
         load_resources()
         collection = policy_load(options, options.config)
         policies = collection.filter(options.policy_filter)
+        
+        if options.policy_filter and len(policies) == 0 and len(collection) > 0:
+            eprint("Warning: no policies matched the filter ({})".format(options.policy_filter))
+            eprint("  Policies:")
+            for policy in collection.policies():
+                eprint("    - ", policy.name)
+            eprint()
+
         return f(options, policies)
 
     return _load_policies
@@ -56,8 +64,7 @@ def validate(options):
     if len(options.configs) < 1:
         # no configs to test
         # We don't have the parser object, so fake ArgumentParser.error
-        print('custodian validate: error: no config files specified',
-              file=sys.stderr)
+        eprint('Error: no config files specified')
         sys.exit(2)
     used_policy_names = set()
     schm = schema.generate()
@@ -123,7 +130,14 @@ def run(options, policies):
 
 @policy_command
 def report(options, policies):
-    assert len(policies) == 1, "Only one policy report at a time"
+    if len(policies) == 0:
+        eprint("Error: No policy supplied")
+        sys.exit(2)
+
+    if len(policies) > 1:
+        eprint("Error: Report subcommand can only operate on one policy")
+        sys.exit(2)
+    
     policy = policies.pop()
     d = datetime.now()
     delta = timedelta(days=options.days)
@@ -135,7 +149,14 @@ def report(options, policies):
 
 @policy_command
 def logs(options, policies):
-    assert len(policies) == 1, "Only one policy log at a time"
+    if len(policies) == 0:
+        eprint("Error: No policy supplied")
+        sys.exit(2)
+
+    if len(policies) > 1:
+        eprint("Error: Log subcommand can only operate on one policy")
+        sys.exit(2)
+
     policy = policies.pop()
 
     for e in policy.get_logs(options.start, options.end):
@@ -196,7 +217,7 @@ def schema_cmd(options):
     #
     resource = components[0].lower()
     if resource not in resource_mapping:
-        print('{} is not a valid resource'.format(resource), file=sys.stderr)
+        eprint('Error: {} is not a valid resource'.format(resource))
         sys.exit(2)
 
     if len(components) == 1:
@@ -210,8 +231,8 @@ def schema_cmd(options):
     #
     category = components[1].lower()
     if category not in ('actions', 'filters'):
-        print(("Valid choices are 'actions' and 'filters'."
-               " You supplied '{}'").format(category), file=sys.stderr)
+        eprint(("Error: Valid choices are 'actions' and 'filters'."
+                " You supplied '{}'").format(category))
         sys.exit(2)
 
     if len(components) == 2:
@@ -227,8 +248,8 @@ def schema_cmd(options):
     #
     item = components[2].lower()
     if item not in resource_mapping[resource][category]:
-        print('{} is not in the {} list for resource {}'.format(
-            item, category, resource), file=sys.stderr)
+        eprint('Error: {} is not in the {} list for resource {}'.format(
+                item, category, resource))
         sys.exit(2)
 
     if len(components) == 3:
@@ -255,17 +276,15 @@ def schema_cmd(options):
         return
 
     # We received too much (e.g. s3.actions.foo.bar)
-    print("Invalid selector '{}'.  Max of 3 components in the "
-          "format RESOURCE.CATEGORY.ITEM".format(options.resource),
-          file=sys.stderr)
+    eprint("Invalid selector '{}'.  Max of 3 components in the "
+           "format RESOURCE.CATEGORY.ITEM".format(options.resource))
     sys.exit(2)
 
 
 def _metrics_get_endpoints(options):
     """ Determine the start and end dates based on user-supplied options. """
     if bool(options.start) ^ bool(options.end):
-        print('Error: --start and --end must be specified together',
-              file=sys.stderr)
+        eprint('Error: --start and --end must be specified together')
         sys.exit(2)
 
     if options.start and options.end:
@@ -286,3 +305,7 @@ def metrics_cmd(options, policies):
         log.info('Getting %s metrics', p)
         data[p.name] = p.get_metrics(start, end, options.period)
     print(dumps(data, indent=2))
+
+
+def eprint(*args, **kwargs):
+    print(*args, file=sys.stderr, **kwargs)

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -65,7 +65,7 @@ def validate(options):
         # no configs to test
         # We don't have the parser object, so fake ArgumentParser.error
         eprint('Error: no config files specified')
-        sys.exit(2)
+        sys.exit(1)
     used_policy_names = set()
     schm = schema.generate()
     errors = []
@@ -132,11 +132,11 @@ def run(options, policies):
 def report(options, policies):
     if len(policies) == 0:
         eprint("Error: No policy supplied")
-        sys.exit(2)
+        sys.exit(1)
 
     if len(policies) > 1:
         eprint("Error: Report subcommand can only operate on one policy")
-        sys.exit(2)
+        sys.exit(1)
     
     policy = policies.pop()
     d = datetime.now()
@@ -151,11 +151,11 @@ def report(options, policies):
 def logs(options, policies):
     if len(policies) == 0:
         eprint("Error: No policy supplied")
-        sys.exit(2)
+        sys.exit(1)
 
     if len(policies) > 1:
         eprint("Error: Log subcommand can only operate on one policy")
-        sys.exit(2)
+        sys.exit(1)
 
     policy = policies.pop()
 
@@ -218,7 +218,7 @@ def schema_cmd(options):
     resource = components[0].lower()
     if resource not in resource_mapping:
         eprint('Error: {} is not a valid resource'.format(resource))
-        sys.exit(2)
+        sys.exit(1)
 
     if len(components) == 1:
         del(resource_mapping[resource]['classes'])
@@ -233,7 +233,7 @@ def schema_cmd(options):
     if category not in ('actions', 'filters'):
         eprint(("Error: Valid choices are 'actions' and 'filters'."
                 " You supplied '{}'").format(category))
-        sys.exit(2)
+        sys.exit(1)
 
     if len(components) == 2:
         output = "No {} available for resource {}.".format(category, resource)
@@ -250,7 +250,7 @@ def schema_cmd(options):
     if item not in resource_mapping[resource][category]:
         eprint('Error: {} is not in the {} list for resource {}'.format(
                 item, category, resource))
-        sys.exit(2)
+        sys.exit(1)
 
     if len(components) == 3:
         cls = resource_mapping[resource]['classes'][category][item]
@@ -278,14 +278,14 @@ def schema_cmd(options):
     # We received too much (e.g. s3.actions.foo.bar)
     eprint("Invalid selector '{}'.  Max of 3 components in the "
            "format RESOURCE.CATEGORY.ITEM".format(options.resource))
-    sys.exit(2)
+    sys.exit(1)
 
 
 def _metrics_get_endpoints(options):
     """ Determine the start and end dates based on user-supplied options. """
     if bool(options.start) ^ bool(options.end):
         eprint('Error: --start and --end must be specified together')
-        sys.exit(2)
+        sys.exit(1)
 
     if options.start and options.end:
         start = options.start

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -88,6 +88,9 @@ class PolicyCollection(object):
     def __contains__(self, policy_name):
         return policy_name in [p['name'] for p in self.data['policies']]
 
+    def __len__(self):
+        return len(self.data.get('policies', []))
+
 
 class PolicyExecutionMode(object):
     """Policy execution semantics"""

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -135,7 +135,7 @@ class ValidateTest(CliTest):
         self.run_and_expect_failure(['custodian', 'validate', json_file], 1)
 
         # no config files given
-        self.run_and_expect_failure(['custodian', 'validate'], 2)
+        self.run_and_expect_failure(['custodian', 'validate'], 1)
 
         # nonexistent file given
         self.run_and_expect_exception(
@@ -192,19 +192,19 @@ class SchemaTest(CliTest):
     def test_invalid_options(self):
 
         # invalid resource
-        self.run_and_expect_failure(['custodian', 'schema', 'fakeresource'], 2)
+        self.run_and_expect_failure(['custodian', 'schema', 'fakeresource'], 1)
 
         # invalid category
         self.run_and_expect_failure(
-            ['custodian', 'schema', 'ec2.arglbargle'], 2)
+            ['custodian', 'schema', 'ec2.arglbargle'], 1)
 
         # invalid item
         self.run_and_expect_failure(
-            ['custodian', 'schema', 'ec2.filters.nonexistent'], 2)
+            ['custodian', 'schema', 'ec2.filters.nonexistent'], 1)
 
         # invalid number of selectors
         self.run_and_expect_failure(
-            ['custodian', 'schema', 'ec2.filters.and.foo'], 2)
+            ['custodian', 'schema', 'ec2.filters.and.foo'], 1)
 
     def test_schema_output(self):
 
@@ -247,7 +247,7 @@ class ReportTest(CliTest):
         yaml_file = self.write_policy_file(empty_policies)
         self.run_and_expect_failure(
             ['custodian', 'report', '-c', yaml_file, '-s', temp_dir],
-            2)
+            1)
 
         # more than 1 policy
         policies = {
@@ -259,7 +259,7 @@ class ReportTest(CliTest):
         yaml_file = self.write_policy_file(policies)
         self.run_and_expect_failure(
             ['custodian', 'report', '-c', yaml_file, '-s', temp_dir],
-            2)
+            1)
 
     def test_warning_on_empty_policy_filter(self):
         """
@@ -282,7 +282,7 @@ class ReportTest(CliTest):
         bad_policy_name = policy_name + '-nonexistent'
         _, err = self.run_and_expect_failure(
             ['custodian', 'report', '-c', yaml_file, '-s', temp_dir, '-p', bad_policy_name], 
-            2)
+            1)
         
         self.assertIn('Warning', err)
         self.assertIn(policy_name, err)
@@ -298,7 +298,7 @@ class LogsTest(CliTest):
         yaml_file = self.write_policy_file(empty_policies)
         self.run_and_expect_failure(
             ['custodian', 'logs', '-c', yaml_file, '-s', temp_dir],
-            2)
+            1)
 
         # Test 2 - more than one policy
         policies = {
@@ -310,7 +310,7 @@ class LogsTest(CliTest):
         yaml_file = self.write_policy_file(policies)
         self.run_and_expect_failure(
             ['custodian', 'logs', '-c', yaml_file, '-s', temp_dir],
-            2)
+            1)
 
         # Test 3 - successful test
         p_data = {


### PR DESCRIPTION
From ticket #813 - added a warning message when `-p` is specified and that causes all policies to be filtered out.

Also improved error messages from `report` and `logs` subcommands and made error messages more consistent.  `report` and `logs` used to raise an AssertionError when the wrong number of policies was supplied, and I changed this to be an informational message and then `sys.exit` (explicitly mentioning this in case you preferred the old behavior).