### PR TITLE
allow policy in report directory

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -125,7 +125,7 @@ def run(options, policies):
 def report(options, policies):
     assert len(policies) == 1, "Only one policy report at a time"
     policy = policies.pop()
-    odir = options.output_dir
+    odir = options.output_dir.rstrip(os.path.sep)
     if os.path.sep in odir and os.path.basename(odir) == policy.name:
         # policy sub-directory passed - ignore
         options.output_dir = os.path.split(odir)[0]

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -125,6 +125,12 @@ def run(options, policies):
 def report(options, policies):
     assert len(policies) == 1, "Only one policy report at a time"
     policy = policies.pop()
+    odir = options.output_dir
+    if os.path.sep in odir and os.path.basename(odir) == policy.name:
+        # policy sub-directory passed - ignore
+        options.output_dir = os.path.split(odir)[0]
+        # regenerate the execution context based on new path
+        policy = Policy(policy.data, options)
     d = datetime.now()
     delta = timedelta(days=options.days)
     begin_date = d - delta


### PR DESCRIPTION
So assuming `stuff.yaml` defines a single policy named “policy1”, `report -c stuff.yaml -s out/policy1` will be silently treated as `report -c stuff.yaml -s out`.

Should we throw in a warning on standard error?