### PR TITLE
Make some initial changes to c7n-sentry

### DIFF
--- a/tools/c7n_sentry/README.md
+++ b/tools/c7n_sentry/README.md
@@ -8,3 +8,51 @@ to sentry.
 Useful for any python code logging to cloud watch logs
 including lambdas.
 
+
+# Install
+
+```
+(cloud-custodian) $ pip install tools/c7n_sentry
+[...]
+(cloud-custodian) $ c7n-sentry
+usage: c7n-sentry [-h] [--verbose] {orgreplay} ...
+c7n-sentry: error: too few arguments
+(cloud-custodian) $
+```
+
+
+# Run Locally
+
+```
+(cloud-custodian) $ export SENTRY_DSN=foo
+(cloud-custodian) $ export SENTRY_TOKEN=deadbeef
+(cloud-custodian) $ c7n-sentry --verbose orgreplay -c config.json --sentry-org=yours
+```
+
+Where `config.json` looks something like this:
+
+```json
+{
+    "": {
+        "name": "your-aws-account-name",
+        "account_id": "0123456789",
+        "config_files": {
+            "": {
+                "policies": [
+                    {
+                        "mode": "",
+                        "name": "foo"
+                    }
+                ]
+            }
+        },
+        "role": ""
+    }
+}
+```
+
+Both `name` and `account_id` refer to your AWS account. Empty values are
+optional, though some keys are required even if the value doesn't matter. The
+crucial bit is `name` under `policies`: we are going to look for a Lambda named
+`custodian-foo` and replay the CloudWatch logs for that Lambda, sending any
+Python exceptions we discover over to Sentry.

--- a/tools/c7n_sentry/c7n_sentry/c7nsentry.py
+++ b/tools/c7n_sentry/c7n_sentry/c7nsentry.py
@@ -227,8 +227,8 @@ def get_sentry_message(config, data, log_client=None, is_lambda=True):
         level, logger = 'ERROR', None
 
     for f in reversed(error['stacktrace']['frames']):
+        culprit = "%s.%s" % (f['module'], f['function'])
         if f['module'].startswith('c7n'):
-            culprit = "%s.%s" % (f['module'], f['function'])
             break
 
     breadcrumbs = None

--- a/tools/c7n_sentry/c7n_sentry/c7nsentry.py
+++ b/tools/c7n_sentry/c7n_sentry/c7nsentry.py
@@ -328,7 +328,6 @@ def get_function(session_factory, name, role,
 
     # Lazy import to avoid runtime dependency
     import inspect
-    import os
 
     import c7n
     from c7n.mu import (
@@ -440,9 +439,9 @@ def orgreplay(options):
         for a in accounts:
             futures[w.submit(process_account, a)] = a
         for f in as_completed(futures):
-            if f.exception():
-                log.error("Error processing account %s: %s",
-                          a['name'], f.exception())
+            exc = f.exception()
+            if exc:
+                log.error("Error processing account %s: %r", a['name'], exc)
 
 
 def setup_parser():

--- a/tools/c7n_sentry/c7n_sentry/c7nsentry.py
+++ b/tools/c7n_sentry/c7n_sentry/c7nsentry.py
@@ -387,25 +387,21 @@ def orgreplay(options):
         if team_name not in teams:
 
             log.info("creating org team %s", team_name)
-            result = spost(
+            spost(
                 endpoint + "organizations/%s/teams/" % options.sentry_org,
                 json={'name': team_name})
             teams.add(team_name)
 
         if a['name'] not in projects:
             log.info("creating account project %s", a['name'])
-            result = spost(endpoint + "teams/%s/%s/projects/" % (
+            spost(endpoint + "teams/%s/%s/projects/" % (
                 options.sentry_org, team_name),
                   json={'name': a['name']})
-
-        result = sget(endpoint + "projects/%s/%s/keys/" % (
-            options.sentry_org, a['name'])).json()
-        dsn = result[0]['dsn']['secret']
 
         bagger = partial(
             Bag,
             profile=options.profile, role=None, log_streams=None,
-            start=options.start, end=options.end, sentry_dsn=dsn,
+            start=options.start, end=options.end, sentry_dsn=options.sentry_dsn,
             account_id=a['account_id'],
             account_name=a['name'])
 

--- a/tools/c7n_sentry/c7n_sentry/common.py
+++ b/tools/c7n_sentry/c7n_sentry/common.py
@@ -48,11 +48,3 @@ def get_accounts(options):
     else:
         accounts = account_data.values()
     return accounts
-
-
-def find_policies(accounts, matcher):
-    for a in accounts:
-        for cname, config in a['config_files'].items():
-            for p in config['policies']:
-                if matcher(p):
-                    yield (a, cname, p)

--- a/tools/c7n_sentry/setup.py
+++ b/tools/c7n_sentry/setup.py
@@ -17,7 +17,7 @@ from setuptools import setup
 setup(
     name="c7n_sentry",
     version='0.1',
-    description="Cloud Custodian - Salactus S3",
+    description="Cloud Custodian - Sentry",
     classifiers=[
       "Topic :: System :: Systems Administration",
       "Topic :: System :: Distributed Computing"


### PR DESCRIPTION
Some initial small changes under https://github.com/capitalone/cloud-custodian/issues/738.

- repair the description in setup.py
- use repr instead of str for (slightly) more helpful error logging
- remove an unused `import os`
- remove an unused function
- basic usage instructions + bugfixes to support them