### PR TITLE
New IAM Policy filter for CIS 1.24 compliance

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -262,6 +262,77 @@ class UnusedIamPolicies(Filter):
         return [r for r in resources if r['AttachmentCount'] == 0]
 
 
+@Policy.filter_registry.register('has-allow-all')
+class AllowAllIamPolicies(Filter):
+    """Check if IAM policy resource(s) have allow-all IAM policy statement block.
+
+    This allows users to implement CIS AWS check 1.24 which states that no
+    policy must exist with the following requirements.
+
+    Policy must have 'Action' and Resource = '*' with 'Effect' = 'Allow'
+
+    The policy will trigger on the following IAM policy (statement).
+    For example:
+    {
+        'Version': '2012-10-17',
+        'Statement': [{
+            'Action': '*',
+            'Resource': '*',
+            'Effect': 'Allow'
+        }]
+    }
+
+    Additionally, the policy checks if the statement has no 'Condition' or
+    'NotAction'
+
+    For example, if the user wants to check all used policies and filter on
+    allow all:
+
+    .. code-block: yaml
+
+     - name: iam-no-used-all-all-policy
+       description: |
+         Verify that used policies have no allow-all
+       resource: iam-policy
+       filters:
+         - type: used
+         - type: has-allow-all
+
+    Note that scanning and getting all policies and all statements can take
+    a while. Use it sparingly or combine it with filters such as 'used' as
+    above.
+    """
+
+    schema = type_schema('has-allow-all')
+    permissions = ('iam:ListPolicies', 'iam:ListPolicyVersions')
+
+    def has_allow_all_policy(self, client, resource):
+        statements = client.get_policy_version(
+            PolicyArn=resource['Arn'],
+            VersionId=resource['DefaultVersionId']
+        )['PolicyVersion']['Document']['Statement']
+        if isinstance(statements, dict):
+            statements = [statements]
+
+        for s in statements:
+            if ('Condition' not in s and
+                    'Action' in s and
+                    isinstance(s['Action'], basestring) and
+                    s['Action'] == "*" and
+                    isinstance(s['Resource'], basestring) and
+                    s['Resource'] == "*" and
+                    s['Effect'] == "Allow"):
+                return True
+        return False
+
+    def process(self, resources, event=None):
+        c = local_session(self.manager.session_factory).client('iam')
+        results = [r for r in resources if self.has_allow_all_policy(c, r)]
+        self.log.info(
+            "%d of %d iam policies have allow all.",
+            len(results), len(resources))
+        return results
+
 ###############################
 #    IAM Instance Profiles    #
 ###############################

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -273,14 +273,16 @@ class AllowAllIamPolicies(Filter):
 
     The policy will trigger on the following IAM policy (statement).
     For example:
-    {
-        'Version': '2012-10-17',
-        'Statement': [{
-            'Action': '*',
-            'Resource': '*',
-            'Effect': 'Allow'
-        }]
-    }
+
+    .. code-block: json
+     {
+         'Version': '2012-10-17',
+         'Statement': [{
+             'Action': '*',
+             'Resource': '*',
+             'Effect': 'Allow'
+         }]
+     }
 
     Additionally, the policy checks if the statement has no 'Condition' or
     'NotAction'
@@ -291,8 +293,6 @@ class AllowAllIamPolicies(Filter):
     .. code-block: yaml
 
      - name: iam-no-used-all-all-policy
-       description: |
-         Verify that used policies have no allow-all
        resource: iam-policy
        filters:
          - type: used
@@ -301,8 +301,8 @@ class AllowAllIamPolicies(Filter):
     Note that scanning and getting all policies and all statements can take
     a while. Use it sparingly or combine it with filters such as 'used' as
     above.
-    """
 
+    """
     schema = type_schema('has-allow-all')
     permissions = ('iam:ListPolicies', 'iam:ListPolicyVersions')
 

--- a/tests/data/placebo/test_iam_policy_allow_all/iam.GetPolicyVersion_1.json
+++ b/tests/data/placebo/test_iam_policy_allow_all/iam.GetPolicyVersion_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b0c6c9a5-dbff-11e6-a291-af5f80ef2d32", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b0c6c9a5-dbff-11e6-a291-af5f80ef2d32", 
+                "date": "Mon, 16 Jan 2017 15:23:11 GMT", 
+                "content-length": "759", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "PolicyVersion": {
+            "CreateDate": {
+                "hour": 18, 
+                "__class__": "datetime", 
+                "month": 2, 
+                "second": 46, 
+                "microsecond": 0, 
+                "year": 2015, 
+                "day": 6, 
+                "minute": 39
+            }, 
+            "VersionId": "v1", 
+            "Document": "%7B%0A%20%20%22Version%22%3A%20%222012-10-17%22%2C%0A%20%20%22Statement%22%3A%20%5B%0A%20%20%20%20%7B%0A%20%20%20%20%20%20%22Effect%22%3A%20%22Allow%22%2C%0A%20%20%20%20%20%20%22Action%22%3A%20%22%2A%22%2C%0A%20%20%20%20%20%20%22Resource%22%3A%20%22%2A%22%0A%20%20%20%20%7D%0A%20%20%5D%0A%7D", 
+            "IsDefaultVersion": true
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_policy_allow_all/iam.ListPolicies_1.json
+++ b/tests/data/placebo/test_iam_policy_allow_all/iam.ListPolicies_1.json
@@ -1,0 +1,2920 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "ACLB5HLLHIfgVfKYL8zVy+tCrl0rGMd6WwFaAnZT0KxpAwT7ixxaUBot49JsM87tbLqgUOT5pdabsyJIhEKIV8+K0Fbq/gzuvvTelW/IQF3neQ==", 
+        "IsTruncated": true, 
+        "Policies": [
+            {
+                "PolicyName": "AWSDirectConnectReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 8, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI23HZ27SI6FQMGNQ2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSDirectConnectReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 8, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonGlacierReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI2D5NJKMU274MET4E", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonGlacierReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 10, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 5, 
+                    "minute": 46
+                }
+            }, 
+            {
+                "PolicyName": "AWSMarketplaceFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 21
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI2DV5ULJSO2FYVPYG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSMarketplaceFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 21
+                }
+            }, 
+            {
+                "PolicyName": "AutoScalingConsoleReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 48
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI3A7GDXOYQV3VUQMK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AutoScalingConsoleReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 48
+                }
+            }, 
+            {
+                "PolicyName": "AmazonDMSRedshiftS3Role", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 5
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI3CCUQ4U5WNC5F6B6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonDMSRedshiftS3Role", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 5
+                }
+            }, 
+            {
+                "PolicyName": "AWSQuickSightListIAM", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 10, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI3CH5UUWZN4EKGILO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSQuickSightListIAM", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 10, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "AWSHealthFullAccess", 
+                "CreateDate": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 30
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI3CUMPCPEUPCSXC4Y", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSHealthFullAccess", 
+                "UpdateDate": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 30
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRDSFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 52, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI3R4QMOG6Q5A4VWVG", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRDSFullAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 16, 
+                    "minute": 2
+                }
+            }, 
+            {
+                "PolicyName": "SupportUser", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 21
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI3V4GSSN5SJY3P2RO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/job-function/", 
+                "Arn": "arn:aws:iam::aws:policy/job-function/SupportUser", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 21
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2FullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 15, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI3VAJF5ZCRZ7MCQE6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonEC2FullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 15, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSElasticBeanstalkReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI47KNGXDAXFD4SDHG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSElasticBeanstalkReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSCertificateManagerReadOnly", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 7
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI4GSWX6S4MESJ3EWC", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCertificateManagerReadOnly", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AWSQuicksightAthenaAccess", 
+                "CreateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 31
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI4JB77JXFQXDWNRPM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSQuicksightAthenaAccess", 
+                "UpdateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 31
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeCommitPowerUser", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 6
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI4UIINUVGB5SEC57G", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeCommitPowerUser", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 22, 
+                    "minute": 21
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeCommitFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 2
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI4VCZ3XPIZLQ5NZV2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeCommitFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 2
+                }
+            }, 
+            {
+                "PolicyName": "IAMSelfManageServiceSpecificCredentials", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI4VT74EMXK2PMQJM2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/IAMSelfManageServiceSpecificCredentials", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSQSFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI65L554VRJ33ECQS6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSQSFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI6E2CYYMI4XI7AA5K", 
+                "DefaultVersionId": "v5", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSLambdaFullAccess", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 9
+                }
+            }, 
+            {
+                "PolicyName": "AWSIoTLogging", 
+                "CreateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 8, 
+                    "minute": 17
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI6R6Z2FHHGS454W7W", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSIoTLogging", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 8, 
+                    "minute": 17
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2RoleforSSM", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 48
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI6TL3SMY22S4KMMX6", 
+                "DefaultVersionId": "v3", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforSSM", 
+                "UpdateDate": {
+                    "hour": 7, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 7
+                }
+            }, 
+            {
+                "PolicyName": "AWSCloudHSMRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI7QIUU4GC66SF26WE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSCloudHSMRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "IAMFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI7XKCFMBPM3QQRRVQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/IAMFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonInspectorFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 4, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 8
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAI7Y6NTA27NWNA5U5E", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonInspectorFullAccess", 
+                "UpdateDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 6
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElastiCacheFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIA2V44CPHAUAAECKG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElastiCacheFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSAgentlessDiscoveryService", 
+                "CreateDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 11, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 2, 
+                    "minute": 35
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIA3DIL7BYQ35ISM4K", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSAgentlessDiscoveryService", 
+                "UpdateDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 11, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 2, 
+                    "minute": 35
+                }
+            }, 
+            {
+                "PolicyName": "AWSXrayWriteOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 19
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIAACM4LMYSRGBCTM6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSXrayWriteOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 19
+                }
+            }, 
+            {
+                "PolicyName": "AutoScalingReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIAFWUVLC2LPLSFTFG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AutoScalingReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AutoScalingFullAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 58, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 31
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIAWRCSJDDXDXGPCFU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AutoScalingFullAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 58, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 31
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2RoleforAWSCodeDeploy", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 10
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIAZKXZ27TAJ4PVWGK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforAWSCodeDeploy", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 10
+                }
+            }, 
+            {
+                "PolicyName": "AWSMobileHub_ReadOnly", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 5, 
+                    "minute": 55
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIBXVYVL3PWQFBZFGW", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSMobileHub_ReadOnly", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 19
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchEventsBuiltInTargetExecutionAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 35
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIC5AQ5DATYSNF4AUM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/CloudWatchEventsBuiltInTargetExecutionAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 35
+                }
+            }, 
+            {
+                "PolicyName": "AWSOpsWorksFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAICN26VXMXASXKOQCG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSOpsWorksFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSOpsWorksCMInstanceProfileRole", 
+                "CreateDate": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 48
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAICSU3OSHCURP2WIZW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSOpsWorksCMInstanceProfileRole", 
+                "UpdateDate": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 48
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodePipelineApproverAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 17, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 28, 
+                    "minute": 59
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAICXNWK42SQ6LMDXM2", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodePipelineApproverAccess", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 39, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 3, 
+                    "minute": 31
+                }
+            }, 
+            {
+                "PolicyName": "AWSApplicationDiscoveryAgentAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 47, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 38
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAICZIOVAGC6JPF3WHC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSApplicationDiscoveryAgentAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 47, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 38
+                }
+            }, 
+            {
+                "PolicyName": "ViewOnlyAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 15, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 20
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAID22R6XPJATWOFDK6", 
+                "DefaultVersionId": "v2", 
+                "Path": "/job-function/", 
+                "Arn": "arn:aws:iam::aws:policy/job-function/ViewOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 20
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticMapReduceRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIDI2BQT2LKXZG36TW", 
+                "DefaultVersionId": "v7", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceRole", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 17, 
+                    "minute": 17
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRoute53DomainsReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIDRINP6PPTRXYVQCI", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRoute53DomainsReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSOpsWorksRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIDUTMOKHJFAPJV45W", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSOpsWorksRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ContainerRegistryFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 21, 
+                    "minute": 6
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIESRL7KD7IIVF6V4W", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 21, 
+                    "minute": 6
+                }
+            }, 
+            {
+                "PolicyName": "SimpleWorkflowFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 4, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIFE3AV6VE7EANYBVM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/SimpleWorkflowFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 4, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonS3FullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 58, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIFIR6V6BVTRAHWINE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonS3FullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 58, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSStorageGatewayReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 10, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIFKCTUVOPD5NICXJK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSStorageGatewayReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 10, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "Billing", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 33
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIFTHXT6FFMIRT7ZEA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/job-function/", 
+                "Arn": "arn:aws:iam::aws:policy/job-function/Billing", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 33
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ContainerRegistryReadOnly", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 15, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 21, 
+                    "minute": 4
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIFYZPA37OOHVIH7KQ", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryReadOnly", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticMapReduceforEC2Role", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIGALS5RCDLZLB3PGS", 
+                "DefaultVersionId": "v2", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforEC2Role", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 13, 
+                    "minute": 27
+                }
+            }, 
+            {
+                "PolicyName": "DatabaseAdministrator", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIGBMAW4VUQKOQNVT6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/job-function/", 
+                "Arn": "arn:aws:iam::aws:policy/job-function/DatabaseAdministrator", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRedshiftReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIGD46KSON64QBSEZM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRedshiftReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 17, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 1, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIGDT4SV4GSETWTBZK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonEC2ReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 17, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSXrayReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 27
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIH4OFXWPS6ZX6OPGQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSXrayReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 27
+                }
+            }, 
+            {
+                "PolicyName": "AWSElasticBeanstalkEnhancedHealth", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 8, 
+                    "minute": 17
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIH5EFJNMOGUUTKLFE", 
+                "DefaultVersionId": "v2", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkEnhancedHealth", 
+                "UpdateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 28
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticMapReduceReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIHP6NH2S6GYFCOINC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElasticMapReduceReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSDirectoryServiceReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIHWYO6WSDNCG64M2W", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSDirectoryServiceReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 11
+                }
+            }, 
+            {
+                "PolicyName": "AmazonVPCReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 17, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIICZJNOJN36GTG6CM", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonVPCReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 17, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchEventsReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 27
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIILJPXXA6F7GYLYBS", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudWatchEventsReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 27
+                }
+            }, 
+            {
+                "PolicyName": "AmazonAPIGatewayInvokeFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 36
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIIWAX2NOOQJ4AIEQ6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonAPIGatewayInvokeFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 36
+                }
+            }, 
+            {
+                "PolicyName": "AmazonKinesisAnalyticsReadOnly", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 16
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIJIEXZAFUK43U7ARK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonKinesisAnalyticsReadOnly", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 16
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMobileAnalyticsFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIJIKLU2IJ7WJ6DZFG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMobileAnalyticsFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSMobileHub_FullAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 5, 
+                    "minute": 56
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIJLU43R6AGRBK76DM", 
+                "DefaultVersionId": "v6", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSMobileHub_FullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 26
+                }
+            }, 
+            {
+                "PolicyName": "AmazonAPIGatewayPushToCloudWatchLogs", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIK4GFO7HLKYN64ASK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonAPIGatewayPushToCloudWatchLogs", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSDataPipelineRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIKCP6XS3ESGF4GLO2", 
+                "DefaultVersionId": "v5", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSDataPipelineRole", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 17
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIKEABORKUXN6DEAZU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudWatchFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "ServiceCatalogAdminFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIKTX42IAS75B7B7BY", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ServiceCatalogAdminFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRDSDirectoryServiceAccess", 
+                "CreateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 26, 
+                    "minute": 2
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIL4KBY57XWMYUHKUU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonRDSDirectoryServiceAccess", 
+                "UpdateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 26, 
+                    "minute": 2
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodePipelineReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 43
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAILFKZXIBOTNC5TO2Q", 
+                "DefaultVersionId": "v5", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodePipelineReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 4, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "ReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAILL3HVNFSB6DCOWYQ", 
+                "DefaultVersionId": "v21", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 19
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMachineLearningBatchPredictionsAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 12
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAILOI4HTQSFTF3GQSC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMachineLearningBatchPredictionsAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 12
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRekognitionReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 58
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAILWSUHXUY4ES43SA4", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRekognitionReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 58
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeDeployReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 21
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAILZHHKCKB4NE7XOIQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeDeployReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 21
+                }
+            }, 
+            {
+                "PolicyName": "CloudSearchFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIM6OOWKQ7L7VBOZOC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudSearchFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AWSCloudHSMFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIMBQYQZM7F63DA2UU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCloudHSMFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2SpotFleetAutoscaleRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 19, 
+                    "minute": 27
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIMFFRMIOBGDP2TAVE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetAutoscaleRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 19, 
+                    "minute": 27
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeBuildDeveloperAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 2
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIMKTMR34XSBQW45HS", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeBuildDeveloperAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 2
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2SpotFleetRole", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 18, 
+                    "minute": 28
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIMRTKHWK7ESSNETSW", 
+                "DefaultVersionId": "v3", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2SpotFleetRole", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 19
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticTranscoderJobsSubmitter", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIN5WGARIKZ3E2UQOU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElasticTranscoderJobsSubmitter", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSDirectoryServiceFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 11, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAINAW5ANUWTH3R4ANI", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSDirectoryServiceFullAccess", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 10
+                }
+            }, 
+            {
+                "PolicyName": "AmazonDynamoDBFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 11, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAINUGF2JSOSUY76KYA", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccess", 
+                "UpdateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 12, 
+                    "minute": 17
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSESReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAINV2XPFRMWJJNSCGI", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSESReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSWAFReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 43
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAINZVDMX2SBF7EU2OC", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSWAFReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 7, 
+                    "minute": 30
+                }
+            }, 
+            {
+                "PolicyName": "AutoScalingNotificationAccessRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIO2VMUPGDC5PZVXVA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AutoScalingNotificationAccessRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMechanicalTurkReadOnly", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 8
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIO5IY3G3WXSX5PPRM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMechanicalTurkReadOnly", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AmazonKinesisReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 30, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIOCMTDT5RLKZ2CAJO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonKinesisReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 30, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeDeployFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 13
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIONKN3TJZUKXCHXWC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeDeployFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 13
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchActionsEC2Access", 
+                "CreateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 0
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIOWD4E3FVSORSZTGU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudWatchActionsEC2Access", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 0
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaDynamoDBExecutionRole", 
+                "CreateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 9
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIP7WNAGMIPYNW4WQG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaDynamoDBExecutionRole", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 9
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRoute53DomainsFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIPAFBMIYUILMOKL6G", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRoute53DomainsFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElastiCacheReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIPDACSNQHSENWAKM2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElastiCacheReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonAthenaFullAccess", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 46
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIPJMLMD4C7RYZ6XCK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonAthenaFullAccess", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 46
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticFileSystemReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIPN5S4NE5JJOKVC4Y", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElasticFileSystemReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "CloudFrontFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIPRV52SH6HDCCFY6U", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudFrontFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 3
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMachineLearningRoleforRedshiftDataSource", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 5
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIQ5UDYYMNN42BM4AK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonMachineLearningRoleforRedshiftDataSource", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 5
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMobileAnalyticsNon-financialReportAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIQLKQ4RXPUBBVVRDE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMobileAnalyticsNon-financialReportAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSCloudTrailFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 58, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIQNUJTQYDRJPC3BNK", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCloudTrailFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 16, 
+                    "minute": 31
+                }
+            }, 
+            {
+                "PolicyName": "AmazonCognitoDeveloperAuthenticatedIdentities", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 22
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIQOKZ5BGKLCMTXH4W", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonCognitoDeveloperAuthenticatedIdentities", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 22
+                }
+            }, 
+            {
+                "PolicyName": "AWSConfigRole", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 2, 
+                    "minute": 36
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIQRXRDRGJUA33ELIO", 
+                "DefaultVersionId": "v8", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSConfigRole", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 23
+                }
+            }, 
+            {
+                "PolicyName": "AmazonAppStreamServiceAccess", 
+                "CreateDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 19, 
+                    "minute": 17
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAISBRZ7LMMCBYEF3SE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonAppStreamServiceAccess", 
+                "UpdateDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 19, 
+                    "minute": 17
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRedshiftFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAISEKCHH4YDB46B5ZO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRedshiftFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonZocaloReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAISRCSSJNS3QPKZJPM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonZocaloReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSCloudHSMReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 52, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAISVCBSY7YDBOT67KE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCloudHSMReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 52, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "SystemAdministrator", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 23
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAITJPEZXCYCBXANDSW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/job-function/", 
+                "Arn": "arn:aws:iam::aws:policy/job-function/SystemAdministrator", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 23
+                }
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b01972b6-dbff-11e6-b613-05b3b1c605e8", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b01972b6-dbff-11e6-b613-05b3b1c605e8", 
+                "date": "Mon, 16 Jan 2017 15:23:09 GMT", 
+                "content-length": "48997", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_policy_allow_all/iam.ListPolicies_2.json
+++ b/tests/data/placebo/test_iam_policy_allow_all/iam.ListPolicies_2.json
@@ -1,0 +1,2920 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "AAYXCGrTO3t3uuoX/XL/kFEVjLlRDP6zmuLh2jBedqAPjkl9I/bRUhgQl6K7PqIVZA4E1z2GLHf5R6uNwb+faoDNHkrwNonV1vxKtaloiS0Wdw==", 
+        "IsTruncated": true, 
+        "Policies": [
+            {
+                "PolicyName": "AmazonRoute53ReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAITOYK2ZAOQFXV2JNC", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRoute53ReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 15, 
+                    "minute": 15
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ReportsAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIU6NBZVF2PCRW36ZW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonEC2ReportsAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ContainerServiceAutoscaleRole", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 12, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIUAP3EGGGXXCPDQKK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceAutoscaleRole", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 12, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "AWSBatchServiceRole", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 36
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIUETIXPCKASQJURFE", 
+                "DefaultVersionId": "v2", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSBatchServiceRole", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 13, 
+                    "minute": 38
+                }
+            }, 
+            {
+                "PolicyName": "AWSElasticBeanstalkWebTier", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 8, 
+                    "minute": 8
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIUF4325SJYOREKW3A", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSElasticBeanstalkWebTier", 
+                "UpdateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 6
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSQSReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 8, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIUGSSQY362XGCM6KW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSQSReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 8, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSMobileHub_ServiceUseOnly", 
+                "CreateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 10, 
+                    "minute": 4
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIUHPQXBDZUWOP3PSK", 
+                "DefaultVersionId": "v15", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSMobileHub_ServiceUseOnly", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 6
+                }
+            }, 
+            {
+                "PolicyName": "AmazonKinesisFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIVF32HAMOXCUYRAYE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonKinesisFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMachineLearningReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIW5VYBCGEX56JCINC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMachineLearningReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRekognitionFullAccess", 
+                "CreateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIWDAOK6AIFDVX6TT6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRekognitionFullAccess", 
+                "UpdateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "RDSCloudHsmAuthorizationRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIWKFXRLQG2ROKKXLE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/RDSCloudHsmAuthorizationRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMachineLearningFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIWKW6AGSGYOQ5ERHC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMachineLearningFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "AdministratorAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 2, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIWMBCKSKIEE64ZLYK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AdministratorAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMachineLearningRealTimePredictionOnlyAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 44
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIWMCNQPRWMWT36GVQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMachineLearningRealTimePredictionOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 44
+                }
+            }, 
+            {
+                "PolicyName": "AWSConfigUserAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 18, 
+                    "minute": 38
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIWTTSFJ7KKJE3MWGA", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSConfigUserAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 15
+                }
+            }, 
+            {
+                "PolicyName": "AWSIoTConfigAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 52
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIWWGD4LM4EMXNRL7I", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSIoTConfigAccess", 
+                "UpdateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 27, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "SecurityAudit", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIX2T3QCXHR2OGGCTO", 
+                "DefaultVersionId": "v9", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/SecurityAudit", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 11, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 51
+                }
+            }, 
+            {
+                "PolicyName": "AmazonDynamoDBReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIY2XFNA232XJ6J7X2", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonDynamoDBReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AutoScalingConsoleFullAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 43
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIYEN6FJGYYWJFFCZW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AutoScalingConsoleFullAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 43
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSNSReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIZGQCQTFOFPMHSB6W", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSNSReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticMapReduceFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIZP5JFP3AMSGINBB2", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElasticMapReduceFullAccess", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 21, 
+                    "minute": 20
+                }
+            }, 
+            {
+                "PolicyName": "AmazonS3ReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIZTJ4DXE7G6AGAE6M", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonS3ReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSElasticBeanstalkFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAIZYX2YLLBW2LJVUFW", 
+                "DefaultVersionId": "v5", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSElasticBeanstalkFullAccess", 
+                "UpdateDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 13, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 0
+                }
+            }, 
+            {
+                "PolicyName": "AmazonWorkSpacesAdmin", 
+                "CreateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 15, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 22, 
+                    "minute": 21
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ26AU6ATUQCT5KVJU", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonWorkSpacesAdmin", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 18, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeDeployRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 4, 
+                    "minute": 5
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ2NKMKD73QS5NBFLA", 
+                "DefaultVersionId": "v3", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSCodeDeployRole", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 11
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSESFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ2P4NXCHAT7NDPNR4", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSESFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchLogsReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ2YIYDYSNNEHK3VKW", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudWatchLogsReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 3, 
+                    "minute": 59
+                }
+            }, 
+            {
+                "PolicyName": "AmazonKinesisFirehoseReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 39, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 43
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ36NT645INW4K24W6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonKinesisFirehoseReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 39, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 43
+                }
+            }, 
+            {
+                "PolicyName": "AWSOpsWorksRegisterCLI", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ3AB5ZBFPCQGTVDU4", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSOpsWorksRegisterCLI", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonDynamoDBFullAccesswithDataPipeline", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ3ORT7KDISSXGHJXA", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonDynamoDBFullAccesswithDataPipeline", 
+                "UpdateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 12, 
+                    "minute": 17
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2RoleforDataPipelineRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ3Z5I2WAJE5DN2J36", 
+                "DefaultVersionId": "v3", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2RoleforDataPipelineRole", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 24
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchLogsFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ3ZGNWK2R5HW5BQFO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudWatchLogsFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSElasticBeanstalkMulticontainerDocker", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 8, 
+                    "minute": 15
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ45SBYG72SD6SHJEY", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSElasticBeanstalkMulticontainerDocker", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 45
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticTranscoderFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ4D5OJU75P5ZJZVNY", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElasticTranscoderFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "IAMUserChangePassword", 
+                "CreateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 15, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ4L4MM2A7QIEB56MS", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/IAMUserChangePassword", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 15, 
+                    "minute": 18
+                }
+            }, 
+            {
+                "PolicyName": "AmazonAPIGatewayAdministrator", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 34
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ4PT6VY5NLKTNUYSI", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonAPIGatewayAdministrator", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 34
+                }
+            }, 
+            {
+                "PolicyName": "ServiceCatalogEndUserAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ56OMCO72RI4J5FSA", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ServiceCatalogEndUserAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 12, 
+                    "minute": 45
+                }
+            }, 
+            {
+                "PolicyName": "AmazonPollyReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 59
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ5FENL3CVPL2FPDLA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonPollyReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 59
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMobileAnalyticsWriteOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ5TAWBBQC2FAL3G6G", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMobileAnalyticsWriteOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "DataScientist", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 28
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ5YHI2BQW7EQFYDXS", 
+                "DefaultVersionId": "v1", 
+                "Path": "/job-function/", 
+                "Arn": "arn:aws:iam::aws:policy/job-function/DataScientist", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 28
+                }
+            }, 
+            {
+                "PolicyName": "AWSMarketplaceMeteringFullAccess", 
+                "CreateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 17, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ65YJPG7CC7LDXNA6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSMarketplaceMeteringFullAccess", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 17, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AWSOpsWorksCMServiceRole", 
+                "CreateDate": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 49
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ6I6MPGJE62URSHCO", 
+                "DefaultVersionId": "v3", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSOpsWorksCMServiceRole", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 25, 
+                    "minute": 12
+                }
+            }, 
+            {
+                "PolicyName": "AWSConnector", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 14
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ6YATONJHICG3DJ3U", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSConnector", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 28, 
+                    "minute": 50
+                }
+            }, 
+            {
+                "PolicyName": "AWSBatchFullAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 35
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ7K2KIWB3HZVK3CUO", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSBatchFullAccess", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 13, 
+                    "minute": 38
+                }
+            }, 
+            {
+                "PolicyName": "ServiceCatalogAdminReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJ7XOUSS75M4LIPKO4", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ServiceCatalogAdminReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 13, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 21
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2AutomationRole", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 4
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJA3JHNJSR2PZZHOI6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2AutomationRole", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 4
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSSMFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 47, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJA7V6HI4ISQFMDYAG", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSSMFullAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 7, 
+                    "minute": 9
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeCommitReadOnly", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 5
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJACNSXR7Z2VLJW3D6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeCommitReadOnly", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 5
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ContainerServiceFullAccess", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 54
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJALOYVTPDZEMIACSM", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerServiceFullAccess", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 22, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AmazonCognitoReadOnly", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 6
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJBFTRZD2GQGJHSVQK", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonCognitoReadOnly", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 2, 
+                    "minute": 30
+                }
+            }, 
+            {
+                "PolicyName": "AmazonDMSCloudWatchLogsRole", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 7, 
+                    "minute": 44
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJBG7UXZZXUJD3TDJE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonDMSCloudWatchLogsRole", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 7, 
+                    "minute": 44
+                }
+            }, 
+            {
+                "PolicyName": "AWSApplicationDiscoveryServiceFullAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 30
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJBNJEA6ZXM2SBOPDU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSApplicationDiscoveryServiceFullAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 30
+                }
+            }, 
+            {
+                "PolicyName": "AmazonVPCFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJBWPGNOVKZD3JI2P2", 
+                "DefaultVersionId": "v5", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonVPCFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 17, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "AWSImportExportFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJCQCT4JGTLC6722MQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSImportExportFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMechanicalTurkFullAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 8
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJDGCL5BET73H5QIQC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMechanicalTurkFullAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ContainerRegistryPowerUser", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 21, 
+                    "minute": 5
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJDNE5PIHROIBGGDDW", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonEC2ContainerRegistryPowerUser", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 28
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMachineLearningCreateOnlyAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 9, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 18
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJDRUNIC2RYAMAT3CK", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMachineLearningCreateOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 3, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 29, 
+                    "minute": 55
+                }
+            }, 
+            {
+                "PolicyName": "AWSCloudTrailReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJDU7KJADWBSEQ3E7S", 
+                "DefaultVersionId": "v6", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCloudTrailReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 52, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaExecute", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJE5FX7FQZSU5XAKGO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSLambdaExecute", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSIoTRuleActions", 
+                "CreateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 8, 
+                    "minute": 14
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJEZ6FS7BUZVUHMOKY", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSIoTRuleActions", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 8, 
+                    "minute": 14
+                }
+            }, 
+            {
+                "PolicyName": "AWSQuickSightDescribeRedshift", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 10, 
+                    "minute": 25
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJFEM6MLSLTW4ZNBW2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSQuickSightDescribeRedshift", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 10, 
+                    "minute": 25
+                }
+            }, 
+            {
+                "PolicyName": "VMImportExportRoleForAWSConnector", 
+                "CreateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 3, 
+                    "minute": 48
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJFLQOOJ6F5XNX4LAW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/VMImportExportRoleForAWSConnector", 
+                "UpdateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 3, 
+                    "minute": 48
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodePipelineCustomActionAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 2
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJFW5Z32BTVF76VCYC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodePipelineCustomActionAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 2
+                }
+            }, 
+            {
+                "PolicyName": "AWSOpsWorksInstanceRegistration", 
+                "CreateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 15, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 3, 
+                    "minute": 23
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJG3LCPVNI4WDZCIMU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSOpsWorksInstanceRegistration", 
+                "UpdateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 15, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 3, 
+                    "minute": 23
+                }
+            }, 
+            {
+                "PolicyName": "AWSStorageGatewayFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 9, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJG5SSPAVOGK3SIDGU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSStorageGatewayFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 9, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticTranscoderReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJGPP7GPMJRRJMEP3Q", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElasticTranscoderReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSIoTConfigReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 52
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJHENEMXGX4XMFOIOI", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSIoTConfigReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 27, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonWorkMailReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJHF7J65E2QFKCWAJM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonWorkMailReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonDMSVPCManagementRole", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 18, 
+                    "minute": 33
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJHKIGMBQI4AEFFSYO", 
+                "DefaultVersionId": "v3", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonDMSVPCManagementRole", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 23, 
+                    "minute": 29
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaKinesisExecutionRole", 
+                "CreateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 14
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJHOLKJPXV4GBRMJUQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaKinesisExecutionRole", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 14
+                }
+            }, 
+            {
+                "PolicyName": "ResourceGroupsandTagEditorReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJHXQTPI5I5JKAIU74", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ResourceGroupsandTagEditorReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSSMAutomationRole", 
+                "CreateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 5, 
+                    "minute": 9
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJIBQCTBCXD2XRNB6W", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonSSMAutomationRole", 
+                "UpdateDate": {
+                    "hour": 22, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 5, 
+                    "minute": 9
+                }
+            }, 
+            {
+                "PolicyName": "ServiceCatalogEndUserFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJIW7AFFOONVKW75KU", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ServiceCatalogEndUserFullAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 12, 
+                    "minute": 55
+                }
+            }, 
+            {
+                "PolicyName": "AWSStepFunctionsConsoleFullAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 54
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJIYC52YWRX6OSMJWK", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSStepFunctionsConsoleFullAccess", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 12, 
+                    "minute": 19
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeBuildReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 3
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJIZZWN6557F5HVP2K", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeBuildReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 3
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMachineLearningManageRealTimeEndpointOnlyAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 32
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJJL3PC3VCSVZP6OCI", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMachineLearningManageRealTimeEndpointOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 32
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchEventsInvocationAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 36
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJJXD6JKJLK2WDLZNO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/CloudWatchEventsInvocationAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 33, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 36
+                }
+            }, 
+            {
+                "PolicyName": "CloudFrontReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJJZMNYOTZCNQP36LG", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudFrontReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 3
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSNSRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 30, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJK5GQB7CIK7KHY2GA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonSNSRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 30, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonMobileAnalyticsFinancialReportAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJKJHO2R27TXKCWBU4", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonMobileAnalyticsFinancialReportAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSElasticBeanstalkService", 
+                "CreateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 23, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 27
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJKQ5SN74ZQ4WASXBM", 
+                "DefaultVersionId": "v8", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSElasticBeanstalkService", 
+                "UpdateDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 55
+                }
+            }, 
+            {
+                "PolicyName": "IAMReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 39, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJKSO7NDY4T57MWDSQ", 
+                "DefaultVersionId": "v3", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/IAMReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 37, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 6
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRDSReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJKTTTYV2IIHKLZ346", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRDSReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 30, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 16, 
+                    "minute": 58
+                }
+            }, 
+            {
+                "PolicyName": "AmazonCognitoPowerUser", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 14
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJKW5H2HNCPGCYGR6Y", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonCognitoPowerUser", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 2, 
+                    "minute": 57
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticFileSystemFullAccess", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 22
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJKXTMNVQGIDNCKPBC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonElasticFileSystemFullAccess", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 22
+                }
+            }, 
+            {
+                "PolicyName": "ServerMigrationConnector", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 45
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJKZRWXIPK5HSG3QDQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ServerMigrationConnector", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 45
+                }
+            }, 
+            {
+                "PolicyName": "AmazonZocaloFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 13, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJLCDXYRINDMUXEVL6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonZocaloFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 13, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJLDG7J3CGUHFN4YN6", 
+                "DefaultVersionId": "v5", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSLambdaReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 47, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AWSAccountUsageReportAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJLIB4VSBVO47ZSBB6", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSAccountUsageReportAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ContainerServiceforEC2Role", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 45
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJLYJCVHC7TQHCSQDS", 
+                "DefaultVersionId": "v4", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceforEC2Role", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 4, 
+                    "minute": 56
+                }
+            }, 
+            {
+                "PolicyName": "AmazonAppStreamFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 9, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJLZZXU2YQVGL4QDNC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonAppStreamFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 9, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSIoTDataAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 51
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJM2KI2UJDR24XPS2K", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSIoTDataAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 27, 
+                    "minute": 51
+                }
+            }, 
+            {
+                "PolicyName": "AmazonESFullAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 1, 
+                    "minute": 14
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJM6ZTCU24QL5PZCGC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonESFullAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 1, 
+                    "minute": 14
+                }
+            }, 
+            {
+                "PolicyName": "ServerMigrationServiceRole", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 19
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJMBH3M6BO63XFW2D4", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/ServerMigrationServiceRole", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 19
+                }
+            }, 
+            {
+                "PolicyName": "AWSWAFFullAccess", 
+                "CreateDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 44
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJMIKIAFXZEGOLRH7C", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSWAFFullAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 25, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 7, 
+                    "minute": 33
+                }
+            }, 
+            {
+                "PolicyName": "AmazonKinesisFirehoseFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 45
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJMZQMTZ7FRBFHHAHI", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonKinesisFirehoseFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 45
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJN23PDQP7SZQAE3QE", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudWatchReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaBasicExecutionRole", 
+                "CreateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 3
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJNCQGXC42545SKXIK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaBasicExecutionRole", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 3
+                }
+            }, 
+            {
+                "PolicyName": "ResourceGroupsandTagEditorFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJNOS54ZFXN4T2Y34A", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/ResourceGroupsandTagEditorFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AWSKeyManagementServicePowerUser", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 40, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJNPP7PPPPMJRV2SA4", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSKeyManagementServicePowerUser", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 40, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b04eb3cf-dbff-11e6-b613-05b3b1c605e8", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b04eb3cf-dbff-11e6-b613-05b3b1c605e8", 
+                "date": "Mon, 16 Jan 2017 15:23:09 GMT", 
+                "content-length": "49019", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_policy_allow_all/iam.ListPolicies_3.json
+++ b/tests/data/placebo/test_iam_policy_allow_all/iam.ListPolicies_3.json
@@ -1,0 +1,1382 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b07e016e-dbff-11e6-b613-05b3b1c605e8", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b07e016e-dbff-11e6-b613-05b3b1c605e8", 
+                "date": "Mon, 16 Jan 2017 15:23:09 GMT", 
+                "content-length": "23023", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "IsTruncated": false, 
+        "Policies": [
+            {
+                "PolicyName": "AWSImportExportReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJNTV4OG52ESYZHCNK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSImportExportReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticTranscoderRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJNW3WMKVXFJ2KPIQ2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonElasticTranscoderRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonEC2ContainerServiceRole", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 14
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJO53W2XHNACG7V77Q", 
+                "DefaultVersionId": "v2", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonEC2ContainerServiceRole", 
+                "UpdateDate": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AWSDeviceFarmFullAccess", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 13, 
+                    "minute": 37
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJO7KEDP4VYJPNT5UW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSDeviceFarmFullAccess", 
+                "UpdateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 13, 
+                    "minute": 37
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSSMReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 44
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJODSKQGGJTHRYZ5FC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSSMReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 29, 
+                    "minute": 44
+                }
+            }, 
+            {
+                "PolicyName": "AWSStepFunctionsReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 46
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJONHB2TJQDJPFW5TM", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSStepFunctionsReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 46
+                }
+            }, 
+            {
+                "PolicyName": "AWSMarketplaceRead-only", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJOOM6LETKURTJ3XZ2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSMarketplaceRead-only", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodePipelineFullAccess", 
+                "CreateDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 58
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJP5LH77KSAT2KHQGG", 
+                "DefaultVersionId": "v5", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodePipelineFullAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 46, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 59
+                }
+            }, 
+            {
+                "PolicyName": "NetworkAdministrator", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 31
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJPNMADZFJCVPJVZA2", 
+                "DefaultVersionId": "v1", 
+                "Path": "/job-function/", 
+                "Arn": "arn:aws:iam::aws:policy/job-function/NetworkAdministrator", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 10, 
+                    "minute": 31
+                }
+            }, 
+            {
+                "PolicyName": "AmazonWorkSpacesApplicationManagerAdminAccess", 
+                "CreateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 3
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJPRL4KYETIH7XGTSS", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonWorkSpacesApplicationManagerAdminAccess", 
+                "UpdateDate": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 3
+                }
+            }, 
+            {
+                "PolicyName": "AmazonDRSVPCManagement", 
+                "CreateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 2, 
+                    "minute": 9
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJPXIBTTZMBEFEX6UA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonDRSVPCManagement", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 2, 
+                    "minute": 9
+                }
+            }, 
+            {
+                "PolicyName": "AWSXrayFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 30
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQBYG45NSJMVQDB2K", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSXrayFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 30
+                }
+            }, 
+            {
+                "PolicyName": "AWSElasticBeanstalkWorkerTier", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 2, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 8, 
+                    "minute": 12
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQDLBRSJVKVF4JMSK", 
+                "DefaultVersionId": "v4", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSElasticBeanstalkWorkerTier", 
+                "UpdateDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 55, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 1
+                }
+            }, 
+            {
+                "PolicyName": "AWSDirectConnectFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQF2QKZSK74KTIHOW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSDirectConnectFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 7, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeBuildAdminAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 4
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQJGIOIE3CD2TQXDS", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeBuildAdminAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 44, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 4
+                }
+            }, 
+            {
+                "PolicyName": "AmazonKinesisAnalyticsFullAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 1
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQOSKHTXP43R7P5AC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonKinesisAnalyticsFullAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 1
+                }
+            }, 
+            {
+                "PolicyName": "AWSAccountActivityAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQRYCWMFX5J3E333K", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSAccountActivityAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonGlacierFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQSTZJWB2AXXAKHVQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonGlacierFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonWorkMailFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 41, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJQVKNMT7SVATQ4AUY", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonWorkMailFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 18, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 24, 
+                    "minute": 16
+                }
+            }, 
+            {
+                "PolicyName": "AWSMarketplaceManageSubscriptions", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJRDW2WIFN7QLUAKBQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSMarketplaceManageSubscriptions", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSSupportAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 11, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJSNKQX2OW67GF4S7E", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSSupportAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 11, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AmazonElasticMapReduceforAutoScalingRole", 
+                "CreateDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 10, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 18, 
+                    "minute": 9
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJSVXG6QHPE6VHDZ4Q", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonElasticMapReduceforAutoScalingRole", 
+                "UpdateDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 10, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 18, 
+                    "minute": 9
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaInvocation-DynamoDB", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 47, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJTHQ3EKCQALQDYG5G", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSLambdaInvocation-DynamoDB", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 47, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "IAMUserSSHKeys", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 8
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJTSHUA4UXGXU7ANUA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/IAMUserSSHKeys", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 8
+                }
+            }, 
+            {
+                "PolicyName": "AWSIoTFullAccess", 
+                "CreateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 8, 
+                    "minute": 19
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJU2FPGG6PQWN72V2G", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSIoTFullAccess", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 8, 
+                    "minute": 19
+                }
+            }, 
+            {
+                "PolicyName": "AWSQuickSightDescribeRDS", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 10, 
+                    "minute": 24
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJU5J6OAMCJD3OO76O", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSQuickSightDescribeRDS", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 50, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 10, 
+                    "minute": 24
+                }
+            }, 
+            {
+                "PolicyName": "AWSConfigRulesExecutionRole", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 25, 
+                    "minute": 59
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJUB3KIKTA4PU4OYAA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSConfigRulesExecutionRole", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 25, 
+                    "minute": 59
+                }
+            }, 
+            {
+                "PolicyName": "AmazonESReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 1, 
+                    "minute": 18
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJUDMRLOQ7FPAR46FQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonESReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 1, 
+                    "minute": 18
+                }
+            }, 
+            {
+                "PolicyName": "AWSCodeDeployDeployerAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 18
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJUWEPOMGLMVXJAPUI", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCodeDeployDeployerAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 43, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 19, 
+                    "minute": 18
+                }
+            }, 
+            {
+                "PolicyName": "AmazonPollyFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 59
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJUZOYQU6XQYPR7EWS", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonPollyFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 30, 
+                    "minute": 59
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSSMMaintenanceWindowRole", 
+                "CreateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 57
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJV3JNYSTZ47VOXYME", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonSSMMaintenanceWindowRole", 
+                "UpdateDate": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 1, 
+                    "minute": 57
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRDSEnhancedMonitoringRole", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 58
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJV7BS425S4PTSSVGK", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AmazonRDSEnhancedMonitoringRole", 
+                "UpdateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 29, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 11, 
+                    "minute": 58
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaVPCAccessExecutionRole", 
+                "CreateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 15
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJVTME3YLVNL72YR2K", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaVPCAccessExecutionRole", 
+                "UpdateDate": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 26, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 11, 
+                    "minute": 15
+                }
+            }, 
+            {
+                "PolicyName": "AWSDataPipelinePowerUser", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJW53AHN6ZWYGU2GNO", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSDataPipelinePowerUser", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AmazonSNSFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJWEKLCXXUNT2SOLSG", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonSNSFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "CloudSearchReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJWPLX7N7BCC3RZLHW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudSearchReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AWSCloudFormationReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJWVBEE4I2POWLODLW", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCloudFormationReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 49, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }
+            }, 
+            {
+                "PolicyName": "AmazonRoute53FullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJWVDLG5RPST6PHQ3A", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonRoute53FullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaRole", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJX4DPCRGTC4NFDUXI", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaRole", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 28, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 41
+                }
+            }, 
+            {
+                "PolicyName": "AWSLambdaENIManagementAccess", 
+                "CreateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 37
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJXAW2Q3KPTURUT2QC", 
+                "DefaultVersionId": "v1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::aws:policy/service-role/AWSLambdaENIManagementAccess", 
+                "UpdateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 37
+                }
+            }, 
+            {
+                "PolicyName": "AmazonAppStreamReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 10, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJXIFDGB4VBX23DX7K", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonAppStreamReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 7, 
+                    "minute": 0
+                }
+            }, 
+            {
+                "PolicyName": "AWSStepFunctionsFullAccess", 
+                "CreateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 51
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJXKA6VP3UFBVHDPPA", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSStepFunctionsFullAccess", 
+                "UpdateDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 32, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 51
+                }
+            }, 
+            {
+                "PolicyName": "AmazonInspectorReadOnlyAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 7, 
+                    "minute": 8
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJXQNTHTEJ2JFRN2SE", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AmazonInspectorReadOnlyAccess", 
+                "UpdateDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 9, 
+                    "minute": 6
+                }
+            }, 
+            {
+                "PolicyName": "AWSCertificateManagerFullAccess", 
+                "CreateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 2
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJYCHABBP6VQIVBCBQ", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSCertificateManagerFullAccess", 
+                "UpdateDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 21, 
+                    "minute": 2
+                }
+            }, 
+            {
+                "PolicyName": "PowerUserAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 47, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 39
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJYRXTHIB4FOVS3ZXS", 
+                "DefaultVersionId": "v2", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/PowerUserAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 16, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 11
+                }
+            }, 
+            {
+                "PolicyName": "CloudWatchEventsFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 8, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 37
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJZLOYLNHESMYOJAFU", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/CloudWatchEventsFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 8, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 14, 
+                    "minute": 37
+                }
+            }, 
+            {
+                "PolicyName": "AWSDataPipelineFullAccess", 
+                "CreateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }, 
+                "AttachmentCount": 0, 
+                "IsAttachable": true, 
+                "PolicyId": "ANPAJZVYL5DGR3IHUEA2O", 
+                "DefaultVersionId": "v1", 
+                "Path": "/", 
+                "Arn": "arn:aws:iam::aws:policy/AWSDataPipelineFullAccess", 
+                "UpdateDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 6, 
+                    "minute": 40
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -27,6 +27,7 @@ from c7n.mu import LambdaManager, LambdaFunction, PythonPackageArchive
 from c7n.resources.sns import SNS
 from c7n.resources.iam import (UserMfaDevice,
                                UsedIamPolicies, UnusedIamPolicies,
+                               AllowAllIamPolicies,
                                UsedInstanceProfiles,
                                UnusedInstanceProfiles,
                                UsedIamRole, UnusedIamRole,
@@ -233,6 +234,23 @@ class IamPolicyFilterUsage(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 203)
 
+class IamPolicyHasAllowAll(BaseTest):
+
+    def test_iam_has_allow_all_policies(self):
+        session_factory = self.replay_flight_data('test_iam_policy_allow_all')
+        self.patch(
+            UnusedIamPolicies, 'executor_factory', MainThreadExecutor)
+        p = self.load_policy({
+            'name': 'iam-has-allow-all',
+            'resource': 'iam-policy',
+            'filters': [
+                {'type': 'value',
+                'key': 'PolicyName',
+                'value': 'AdministratorAccess'},
+                'has-allow-all'
+            ]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
 
 class IamGroupFilterUsage(BaseTest):
 


### PR DESCRIPTION
This adds support so that CIS 1.24 (Scored) with the following title can be executed:
> Ensure IAM policies that allow full "*:*" administrative privileges are not created.

This scans policies for statement blocks that have the following characteristics:
> IAM policies that have a statement with "Effect": "Allow" with "Action": "*"
over "Resource": "*" should be removed.

Currently the default `AdministratorAccess` policy provided by AWS has this block and the intent by CIS is to remove these policies to ensure no global access can be assigned.


The following is an example where the user also specifies that the policy must also be in use.

```yaml
     - name: iam-no-used-all-all-policy
       description: |
         Verify that used policies have no allow-all+       resource: iam-policy
       filters:
         - type: used
         - type: has-allow-all
```

Tests have been made to specify the AdministratorAccess which is default provided by AWS so that not all policies are downloaded and stored.
