### PR TITLE
Add an sns subscriber to mu

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -991,6 +991,86 @@ class CloudWatchLogSubscription(object):
                     raise
 
 
+class SimpleNotificationServiceSubscription(object):
+    """ Subscribe a lambda to one or more SNS topics.
+    """
+
+    iam_delay = 1.5
+
+    def __init__(self, session_factory, topic_arns):
+        self.topic_arns = topic_arns
+        self.session_factory = session_factory
+        self.session = session_factory()
+        self.client = self.session.client('sns')
+
+    @staticmethod
+    def _parse_arn(arn):
+        parts = arn.split(':')
+        region, topic_name = parts[3], parts[5]
+        statement_id = 'sns-topic-' + topic_name
+        return region, topic_name, statement_id
+
+    def add(self, func):
+        lambda_client = self.session.client('lambda')
+        for arn in self.topic_arns:
+            region, topic_name, statement_id = self._parse_arn(arn)
+
+            log.info("Subscribing %s to %s" % (func.name, topic_name))
+
+            # Add permission to lambda for sns invocation.
+            try:
+                lambda_client.add_permission(
+                    FunctionName=func.name,
+                    StatementId='sns-topic-' + topic_name,
+                    SourceArn=arn,
+                    Action='lambda:InvokeFunction',
+                    Principal='sns.amazonaws.com')
+                log.debug("Added permission for sns to invoke lambda")
+                # iam eventual consistency and propagation
+                time.sleep(self.iam_delay)
+            except ClientError as e:
+                if e.response['Error']['Code'] != 'ResourceConflictException':
+                    raise
+
+            # Subscribe the lambda to the topic.
+            topic = self.session.resource('sns').Topic(arn)
+            topic.subscribe(Protocol='lambda', Endpoint=func.arn) # idempotent
+
+    def remove(self, func):
+        lambda_client = self.session.client('lambda')
+        for topic_arn in self.topic_arns:
+            region, topic_name, statement_id = self._parse_arn(topic_arn)
+
+            try:
+                response = lambda_client.remove_permission(
+                    FunctionName=func.name,
+                    StatementId=statement_id)
+                log.debug("Removed lambda permission result: %s" % response)
+            except ClientError as e:
+                if e.response['Error']['Code'] != 'ResourceNotFoundException':
+                    raise
+
+            next_token = ''
+            while 1:
+                response = self.client.list_subscriptions_by_topic(
+                    TopicArn=topic_arn,
+                    NextToken=next_token)  # has to be str (not None)
+                for subscription in response['Subscriptions']:
+                    if subscription['Endpoint'] != func.arn:
+                        continue
+                    try:
+                        response = self.client.unsubscribe(
+                            SubscriptionArn=subscription['SubscriptionArn'])
+                        log.debug("Unsubscribed %s from %s" % (func.name, topic_name))
+                    except ClientError as e:
+                        code = e.response['Error']['Code']
+                        if code != 'ResourceNotFoundException':
+                            raise
+                next_token = response.get('NextToken', '')
+                if not next_token:
+                    break  # in lieu of do/while
+
+
 class ConfigRule(object):
     """Use a lambda as a custom config rule.
 

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -991,7 +991,7 @@ class CloudWatchLogSubscription(object):
                     raise
 
 
-class SimpleNotificationServiceSubscription(object):
+class SNSSubscription(object):
     """ Subscribe a lambda to one or more SNS topics.
     """
 

--- a/tests/data/helloworld.py
+++ b/tests/data/helloworld.py
@@ -1,0 +1,47 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""Hello world Lambda function for mu testing.
+"""
+
+
+def main(event, context):
+    for rec in event['Records']:
+        print(rec['Sns']['Message'])
+
+
+def get_function(session_factory, name, role, topic_arn):
+    import os
+    from c7n.mu import (LambdaFunction, PythonPackageArchive,
+        SimpleNotificationServiceSubscription)
+
+    config = dict(
+        name=name,
+        handler='helloworld.main',
+        runtime='python2.7',
+        memory_size=512,
+        timeout=15,
+        role=role,
+        description='Hello World',
+        events=[SimpleNotificationServiceSubscription(
+            session_factory, [topic_arn])])
+
+    archive = PythonPackageArchive(
+        # Directory to lambda file
+        os.path.abspath(__file__),
+        # Don't include virtualenv deps
+        lib_filter=lambda x, y, z: ([], []))
+    archive.create()
+    archive.close()
+
+    return LambdaFunction(config, archive)

--- a/tests/data/helloworld.py
+++ b/tests/data/helloworld.py
@@ -13,16 +13,17 @@
 # limitations under the License.
 """Hello world Lambda function for mu testing.
 """
+import json
+import sys
 
 
 def main(event, context):
-    for rec in event['Records']:
-        print(rec['Sns']['Message'])
+    json.dump(event, sys.stdout)
 
 
-def get_function(session_factory, name, role, topic_arn):
+def get_function(session_factory, name, role, events):
     import os
-    from c7n.mu import (LambdaFunction, PythonPackageArchive, SNSSubscription)
+    from c7n.mu import (LambdaFunction, PythonPackageArchive)
 
     config = dict(
         name=name,
@@ -32,7 +33,7 @@ def get_function(session_factory, name, role, topic_arn):
         timeout=15,
         role=role,
         description='Hello World',
-        events=[SNSSubscription(session_factory, [topic_arn])])
+        events=events)
 
     archive = PythonPackageArchive(
         # Directory to lambda file

--- a/tests/data/helloworld.py
+++ b/tests/data/helloworld.py
@@ -22,8 +22,7 @@ def main(event, context):
 
 def get_function(session_factory, name, role, topic_arn):
     import os
-    from c7n.mu import (LambdaFunction, PythonPackageArchive,
-        SimpleNotificationServiceSubscription)
+    from c7n.mu import (LambdaFunction, PythonPackageArchive, SNSSubscription)
 
     config = dict(
         name=name,
@@ -33,8 +32,7 @@ def get_function(session_factory, name, role, topic_arn):
         timeout=15,
         role=role,
         description='Hello World',
-        events=[SimpleNotificationServiceSubscription(
-            session_factory, [topic_arn])])
+        events=[SNSSubscription(session_factory, [topic_arn])])
 
     archive = PythonPackageArchive(
         # Directory to lambda file

--- a/tests/data/placebo/test_sns_subscriber/lambda.AddPermission_1.json
+++ b/tests/data/placebo/test_sns_subscriber/lambda.AddPermission_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 201, 
+    "data": {
+        "Statement": "{\"Sid\":\"sns-topic-custodian-test-sns-sub\",\"Resource\":\"arn:aws:lambda:us-west-2:644160558196:function:c7n-hello-world\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"sns.amazonaws.com\"},\"Action\":[\"lambda:InvokeFunction\"],\"Condition\":{\"ArnLike\":{\"AWS:SourceArn\":\"arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub\"}}}", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 201, 
+            "RequestId": "b899af4a-ec5a-11e6-8d20-bb44296dcfb9", 
+            "HTTPHeaders": {
+                "date": "Mon, 06 Feb 2017 10:55:06 GMT", 
+                "x-amzn-requestid": "b899af4a-ec5a-11e6-8d20-bb44296dcfb9", 
+                "content-length": "362", 
+                "content-type": "application/json", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/lambda.CreateFunction_1.json
+++ b/tests/data/placebo/test_sns_subscriber/lambda.CreateFunction_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 201, 
+    "data": {
+        "CodeSha256": "DcDjIPC9F9DzQGvb8oVx0kSNO9G21o+1gM0x1sqNXYQ=", 
+        "FunctionName": "c7n-hello-world", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 201, 
+            "RequestId": "b81cdd50-ec5a-11e6-82f3-4d8dfdb50093", 
+            "HTTPHeaders": {
+                "date": "Mon, 06 Feb 2017 10:55:05 GMT", 
+                "x-amzn-requestid": "b81cdd50-ec5a-11e6-82f3-4d8dfdb50093", 
+                "content-length": "487", 
+                "content-type": "application/json", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "CodeSize": 868, 
+        "MemorySize": 512, 
+        "FunctionArn": "arn:aws:lambda:us-west-2:644160558196:function:c7n-hello-world", 
+        "Version": "59", 
+        "Role": "arn:aws:iam::644160558196:role/custodian-mu", 
+        "Timeout": 15, 
+        "LastModified": "2017-02-06T10:55:06.174+0000", 
+        "Handler": "helloworld.main", 
+        "Runtime": "python2.7", 
+        "Description": "Hello World"
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/lambda.DeleteFunction_1.json
+++ b/tests/data/placebo/test_sns_subscriber/lambda.DeleteFunction_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 204, 
+            "RequestId": "c41fd162-ec5a-11e6-a835-0fbe2f40a852", 
+            "HTTPHeaders": {
+                "date": "Mon, 06 Feb 2017 10:55:25 GMT", 
+                "x-amzn-requestid": "c41fd162-ec5a-11e6-a835-0fbe2f40a852", 
+                "connection": "keep-alive", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_sns_subscriber/lambda.GetFunction_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 404, 
+            "RequestId": "b8049ab5-ec5a-11e6-a3e5-878059839077", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b8049ab5-ec5a-11e6-a3e5-878059839077", 
+                "content-length": "110", 
+                "connection": "keep-alive", 
+                "date": "Mon, 06 Feb 2017 10:55:05 GMT", 
+                "content-type": "application/json", 
+                "x-amzn-errortype": "ResourceNotFoundException"
+            }
+        }, 
+        "Error": {
+            "Message": "Function not found: arn:aws:lambda:us-west-2:644160558196:function:c7n-hello-world", 
+            "Code": "ResourceNotFoundException"
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/lambda.RemovePermission_1.json
+++ b/tests/data/placebo/test_sns_subscriber/lambda.RemovePermission_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 204, 
+            "RequestId": "c39f2f2f-ec5a-11e6-9804-ff2ac6e152ec", 
+            "HTTPHeaders": {
+                "date": "Mon, 06 Feb 2017 10:55:24 GMT", 
+                "x-amzn-requestid": "c39f2f2f-ec5a-11e6-9804-ff2ac6e152ec", 
+                "connection": "keep-alive", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/logs.DeleteLogGroup_1.json
+++ b/tests/data/placebo/test_sns_subscriber/logs.DeleteLogGroup_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c3586229-ec5a-11e6-9c6c-4587708f9c2e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c3586229-ec5a-11e6-9c6c-4587708f9c2e", 
+                "date": "Mon, 06 Feb 2017 10:55:24 GMT", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_sns_subscriber/logs.DescribeLogGroups_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c2d54fa4-ec5a-11e6-b953-a95b0340c111", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c2d54fa4-ec5a-11e6-b953-a95b0340c111", 
+                "date": "Mon, 06 Feb 2017 10:55:23 GMT", 
+                "content-length": "213", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "logGroups": [
+            {
+                "arn": "arn:aws:logs:us-west-2:644160558196:log-group:/aws/lambda/c7n-hello-world:*", 
+                "creationTime": 1486378508381, 
+                "metricFilterCount": 0, 
+                "logGroupName": "/aws/lambda/c7n-hello-world", 
+                "storedBytes": 0
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/logs.DescribeLogStreams_1.json
+++ b/tests/data/placebo/test_sns_subscriber/logs.DescribeLogStreams_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "logStreams": [
+            {
+                "firstEventTimestamp": 1486378508381, 
+                "lastEventTimestamp": 1486378509382, 
+                "creationTime": 1486378508458, 
+                "uploadSequenceToken": "49569295737703239608152950454482289012173719185437754322", 
+                "logStreamName": "2017/02/06/[$LATEST]5dfc93cb51db4294a0604d475fab6978", 
+                "lastIngestionTime": 1486378523491, 
+                "arn": "arn:aws:logs:us-west-2:644160558196:log-group:/aws/lambda/c7n-hello-world:log-stream:2017/02/06/[$LATEST]5dfc93cb51db4294a0604d475fab6978", 
+                "storedBytes": 0
+            }, 
+            {
+                "firstEventTimestamp": 1486378508371, 
+                "lastEventTimestamp": 1486378509373, 
+                "creationTime": 1486378508420, 
+                "uploadSequenceToken": "49559858976197458939048769100701934189038242510982350594", 
+                "logStreamName": "2017/02/06/[$LATEST]675757ae8d644f4dbfa3b7da0ccf6db9", 
+                "lastIngestionTime": 1486378523439, 
+                "arn": "arn:aws:logs:us-west-2:644160558196:log-group:/aws/lambda/c7n-hello-world:log-stream:2017/02/06/[$LATEST]675757ae8d644f4dbfa3b7da0ccf6db9", 
+                "storedBytes": 0
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c2e68d82-ec5a-11e6-b3c5-fbed5e9f6476", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c2e68d82-ec5a-11e6-b3c5-fbed5e9f6476", 
+                "date": "Mon, 06 Feb 2017 10:55:23 GMT", 
+                "content-length": "916", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/logs.GetLogEvents_1.json
+++ b/tests/data/placebo/test_sns_subscriber/logs.GetLogEvents_1.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c2fa63a1-ec5a-11e6-8255-e7e7955d808e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c2fa63a1-ec5a-11e6-8255-e7e7955d808e", 
+                "date": "Mon, 06 Feb 2017 10:55:23 GMT", 
+                "content-length": "2218", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "nextForwardToken": "f/33147348406099034576805600702842058803646248213897347075", 
+        "events": [
+            {
+                "ingestionTime": 1486378523439, 
+                "timestamp": 1486378508371, 
+                "message": "START RequestId: b93aa9e2-ec5a-11e6-a382-5756603a5159 Version: $LATEST\n"
+            }, 
+            {
+                "ingestionTime": 1486378523439, 
+                "timestamp": 1486378508372, 
+                "message": "END RequestId: b93aa9e2-ec5a-11e6-a382-5756603a5159\n"
+            }, 
+            {
+                "ingestionTime": 1486378523439, 
+                "timestamp": 1486378508372, 
+                "message": "REPORT RequestId: b93aa9e2-ec5a-11e6-a382-5756603a5159\tDuration: 0.50 ms\tBilled Duration: 100 ms \tMemory Size: 512 MB\tMax Memory Used: 15 MB\t\n"
+            }, 
+            {
+                "ingestionTime": 1486378523439, 
+                "timestamp": 1486378509373, 
+                "message": "{\"Records\": [{\"EventVersion\": \"1.0\", \"EventSubscriptionArn\": \"arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub:009d60f5-9817-41d0-9ce4-5fe5e8fd4663\", \"EventSource\": \"aws:sns\", \"Sns\": {\"SignatureVersion\": \"1\", \"Timestamp\": \"2017-02-06T10:55:08.002Z\", \"Signature\": \"QqHs3HEG8/cZgN/h5nkL0ivjzuNNpg6bphx9A0FbO3zGLKQBJER9G4lwk4e5EgxPEcsf8qbVeVp2zF55sX3Flbu2vjnpg1BSVDJr3dthA/KKu7bFRMosZ8LT6DTBX8qqUhcjz0Cm0xUuaHUua1NjLmr5WGoPFWO/Pp5K2/Xt3pWvlR4/xZXj0fywfSV/2MCWRUU6cGIS7veX/Kg23iEXcxAUxXURDGRoz5ztpBbe+sQQnPJ1f/h/Mrkwsbqu4S/QlIhfJbdPKzr8BI0VuHv0NaK7FO/aiPLfz+n4vJdNpYlCCvXF6pZRCZs/S0GzuLSVrtp0K5K6a8W4Vj6na9nUZQ==\", \"SigningCertUrl\": \"https://sns.us-west-2.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem\", \"MessageId\": \"226bbbc7-ed68-5804-b1e5-ead5b524d715\", \"Message\": \"Greetings, program!\", \"MessageAttributes\": {}, \"Type\": \"Notification\", \"UnsubscribeUrl\": \"https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub:009d60f5-9817-41d0-9ce4-5fe5e8fd4663\", \"TopicArn\": \"arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub\", \"Subject\": null}}]}"
+            }
+        ], 
+        "nextBackwardToken": "b/33147348383753687887877916315023269094452589984904970240"
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/logs.GetLogEvents_2.json
+++ b/tests/data/placebo/test_sns_subscriber/logs.GetLogEvents_2.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c30ed6d7-ec5a-11e6-8b07-cdeadf96a9c7", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c30ed6d7-ec5a-11e6-8b07-cdeadf96a9c7", 
+                "date": "Mon, 06 Feb 2017 10:55:24 GMT", 
+                "content-length": "2218", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "nextForwardToken": "f/33147348406299741283592376311178949882977636609035927555", 
+        "events": [
+            {
+                "ingestionTime": 1486378523491, 
+                "timestamp": 1486378508381, 
+                "message": "START RequestId: b93a34b6-ec5a-11e6-bbb2-5ffb02d1d8fe Version: $LATEST\n"
+            }, 
+            {
+                "ingestionTime": 1486378523491, 
+                "timestamp": 1486378508381, 
+                "message": "END RequestId: b93a34b6-ec5a-11e6-bbb2-5ffb02d1d8fe\n"
+            }, 
+            {
+                "ingestionTime": 1486378523491, 
+                "timestamp": 1486378508381, 
+                "message": "REPORT RequestId: b93a34b6-ec5a-11e6-bbb2-5ffb02d1d8fe\tDuration: 0.48 ms\tBilled Duration: 100 ms \tMemory Size: 512 MB\tMax Memory Used: 15 MB\t\n"
+            }, 
+            {
+                "ingestionTime": 1486378523491, 
+                "timestamp": 1486378509382, 
+                "message": "{\"Records\": [{\"EventVersion\": \"1.0\", \"EventSubscriptionArn\": \"arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub:fe3ce64d-8222-453a-934c-7f5d738ca1aa\", \"EventSource\": \"aws:sns\", \"Sns\": {\"SignatureVersion\": \"1\", \"Timestamp\": \"2017-02-06T10:55:08.002Z\", \"Signature\": \"QqHs3HEG8/cZgN/h5nkL0ivjzuNNpg6bphx9A0FbO3zGLKQBJER9G4lwk4e5EgxPEcsf8qbVeVp2zF55sX3Flbu2vjnpg1BSVDJr3dthA/KKu7bFRMosZ8LT6DTBX8qqUhcjz0Cm0xUuaHUua1NjLmr5WGoPFWO/Pp5K2/Xt3pWvlR4/xZXj0fywfSV/2MCWRUU6cGIS7veX/Kg23iEXcxAUxXURDGRoz5ztpBbe+sQQnPJ1f/h/Mrkwsbqu4S/QlIhfJbdPKzr8BI0VuHv0NaK7FO/aiPLfz+n4vJdNpYlCCvXF6pZRCZs/S0GzuLSVrtp0K5K6a8W4Vj6na9nUZQ==\", \"SigningCertUrl\": \"https://sns.us-west-2.amazonaws.com/SimpleNotificationService-b95095beb82e8f6a046b3aafc7f4149a.pem\", \"MessageId\": \"226bbbc7-ed68-5804-b1e5-ead5b524d715\", \"Message\": \"Greetings, program!\", \"MessageAttributes\": {}, \"Type\": \"Notification\", \"UnsubscribeUrl\": \"https://sns.us-west-2.amazonaws.com/?Action=Unsubscribe&SubscriptionArn=arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub:fe3ce64d-8222-453a-934c-7f5d738ca1aa\", \"TopicArn\": \"arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub\", \"Subject\": null}}]}"
+            }
+        ], 
+        "nextBackwardToken": "b/33147348383976695339863222546501695892056626741549531136"
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/sns.CreateTopic_1.json
+++ b/tests/data/placebo/test_sns_subscriber/sns.CreateTopic_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3e97ac62-a628-5bfc-8a67-fd70fe6034ed", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3e97ac62-a628-5bfc-8a67-fd70fe6034ed", 
+                "date": "Mon, 06 Feb 2017 10:55:04 GMT", 
+                "content-length": "329", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TopicArn": "arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub"
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/sns.DeleteTopic_1.json
+++ b/tests/data/placebo/test_sns_subscriber/sns.DeleteTopic_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cc27ab4a-efb2-5131-840c-fa58b7ecad43", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cc27ab4a-efb2-5131-840c-fa58b7ecad43", 
+                "date": "Mon, 06 Feb 2017 10:55:26 GMT", 
+                "content-length": "201", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/sns.ListSubscriptionsByTopic_1.json
+++ b/tests/data/placebo/test_sns_subscriber/sns.ListSubscriptionsByTopic_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "2795bb98-6be4-507f-a258-ea8a33b9c648", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2795bb98-6be4-507f-a258-ea8a33b9c648", 
+                "date": "Mon, 06 Feb 2017 10:55:25 GMT", 
+                "content-length": "759", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "Subscriptions": [
+            {
+                "Owner": "644160558196", 
+                "Endpoint": "arn:aws:lambda:us-west-2:644160558196:function:c7n-hello-world", 
+                "Protocol": "lambda", 
+                "TopicArn": "arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub", 
+                "SubscriptionArn": "arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub:009d60f5-9817-41d0-9ce4-5fe5e8fd4663"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/sns.Publish_1.json
+++ b/tests/data/placebo/test_sns_subscriber/sns.Publish_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cdd05b38-aa26-5500-8314-0a2af26d4a11", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cdd05b38-aa26-5500-8314-0a2af26d4a11", 
+                "date": "Mon, 06 Feb 2017 10:55:07 GMT", 
+                "content-length": "294", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "MessageId": "226bbbc7-ed68-5804-b1e5-ead5b524d715"
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/sns.Subscribe_1.json
+++ b/tests/data/placebo/test_sns_subscriber/sns.Subscribe_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "bcb99a70-58e9-5966-8dad-cb6200a213ad", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bcb99a70-58e9-5966-8dad-cb6200a213ad", 
+                "date": "Mon, 06 Feb 2017 10:55:07 GMT", 
+                "content-length": "372", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "SubscriptionArn": "arn:aws:sns:us-west-2:644160558196:custodian-test-sns-sub:009d60f5-9817-41d0-9ce4-5fe5e8fd4663"
+    }
+}

--- a/tests/data/placebo/test_sns_subscriber/sns.Unsubscribe_1.json
+++ b/tests/data/placebo/test_sns_subscriber/sns.Unsubscribe_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "564a6adc-942c-5796-9a2c-3bcecc7231a1", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "564a6adc-942c-5796-9a2c-3bcecc7231a1", 
+                "date": "Mon, 06 Feb 2017 10:55:26 GMT", 
+                "content-length": "201", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -96,7 +96,7 @@ class PolicyLambdaProvision(BaseTest):
 
     def test_sns_subscriber(self):
         self.patch(SNSSubscription, 'iam_delay', 0.01)
-        session_factory = self.record_flight_data('test_sns_subscriber')
+        session_factory = self.replay_flight_data('test_sns_subscriber')
         session = session_factory()
         client = session.client('sns')
 
@@ -119,7 +119,7 @@ class PolicyLambdaProvision(BaseTest):
 
         # now publish to the topic and look for lambda log output
         client.publish(TopicArn=topic_arn, Message='Greetings, program!')
-        time.sleep(15)
+        #time.sleep(15) -- turn this back on when recording flight data
         log_events = manager.logs(func, '1970-1-1', '9170-1-1')
         messages = [e['message'] for e in log_events
                     if e['message'].startswith('{"Records')]

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -21,7 +21,7 @@ import zipfile
 
 from c7n.mu import (
     custodian_archive, LambdaManager, PolicyLambda,
-    CloudWatchLogSubscription, SimpleNotificationServiceSubscription, RUNTIME)
+    CloudWatchLogSubscription, SNSSubscription, RUNTIME)
 from c7n.policy import Policy
 from c7n.ufuncs import logsub
 from common import BaseTest, Config, event_data
@@ -95,7 +95,7 @@ class PolicyLambdaProvision(BaseTest):
         #manager.publish(func)
 
     def test_sns_subscriber(self):
-        self.patch(SimpleNotificationServiceSubscription, 'iam_delay', 0.01)
+        self.patch(SNSSubscription, 'iam_delay', 0.01)
         session_factory = self.record_flight_data('test_sns_subscriber')
         session = session_factory()
         client = session.client('sns')
@@ -109,7 +109,7 @@ class PolicyLambdaProvision(BaseTest):
         params = dict(
             session_factory=session_factory,
             name='c7n-hello-world',
-            role=self.role,
+            role='arn:aws:iam::644160558196:role/custodian-mu',
             topic_arn=topic_arn)
 
         func = helloworld.get_function(**params)


### PR DESCRIPTION
For https://github.com/capitalone/cloud-custodian/issues/297, includes #904.

## Todo

- [x] get `test_sns_subscriber` working once with all API inline in the test
- [x] factor subscription API out into `SimpleNotificationServiceSubscriber` in `mu.py`
- [x] get removal working
- [x] assert something meaningful
- [x] sort out API (topic objects vs. arns?)
- [x] find a good lambda to use for testing, and wire it up with `events=[SubscriptionNotificationServiceSubscriber()]`
- [x] ~~figure out how to record flight data against 619193117841~~
- [x] ~~re-record `PolicyLambdaProvision` against 644160558196~~ &rarr; #904
- [x] add flight data and switch from `record_*` to `replay_*`
- [x] respond to review