### PR TITLE
Notes around loading venv in the developer installation.

### DIFF
--- a/docs/source/developer.rst
+++ b/docs/source/developer.rst
@@ -38,6 +38,12 @@ Then build the software:
 
    $ make develop
 
+Once that completes, make sure you load the virtualenv into your current shell:
+
+.. code-block:: bash
+
+   $ source bin/activate
+
 You should have the ``custodian`` command available now:
 
 .. code-block:: bash


### PR DESCRIPTION
The current developer installation documentation skips a step - leaving all subsequent steps to fail.