### PR TITLE
Support external id along side --assume-role

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -61,6 +61,8 @@ def _default_options(p, blacklist=""):
         help="AWS Account Config File Profile to utilize")
     provider.add_argument("--assume", default=None, dest="assume_role",
                           help="Role to assume")
+    provider.add_argument("--external-id", default=None, dest="external_id",
+                          help="External Id to provide when assuming a role")
 
     config = p.add_argument_group(
         "config", "Policy config file(s) and policy selectors")

--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -24,17 +24,18 @@ from c7n.utils import get_retry
 
 class SessionFactory(object):
 
-    def __init__(self, region, profile=None, assume_role=None):
+    def __init__(self, region, profile=None, assume_role=None, external_id=None):
         self.region = region
         self.profile = profile
         self.assume_role = assume_role
+        self.external_id = external_id
 
     def __call__(self, assume=True, region=None):
         if self.assume_role and assume:
             session = Session(profile_name=self.profile)
             session = assumed_session(
                 self.assume_role, "CloudCustodian", session,
-                region or self.region)
+                region or self.region, self.external_id)
         else:
             session = Session(
                 region_name=region or self.region, profile_name=self.profile)
@@ -44,7 +45,7 @@ class SessionFactory(object):
         return session
 
 
-def assumed_session(role_arn, session_name, session=None, region=None):
+def assumed_session(role_arn, session_name, session=None, region=None, external_id=None):
     """STS Role assume a boto3.Session
 
     With automatic credential renewal.
@@ -65,10 +66,14 @@ def assumed_session(role_arn, session_name, session=None, region=None):
     retry = get_retry(('Throttling',))
 
     def refresh():
+
+        parameters = {"RoleArn": role_arn, "RoleSessionName": session_name}
+
+        if not external_id is None:
+            parameters['ExternalId'] = external_id
+
         credentials = retry(
-            session.client('sts').assume_role,
-            RoleArn=role_arn,
-            RoleSessionName=session_name)['Credentials']
+            session.client('sts').assume_role, **parameters)['Credentials']
         return dict(
             access_key=credentials['AccessKeyId'],
             secret_key=credentials['SecretAccessKey'],

--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -69,7 +69,7 @@ def assumed_session(role_arn, session_name, session=None, region=None, external_
 
         parameters = {"RoleArn": role_arn, "RoleSessionName": session_name}
 
-        if not external_id is None:
+        if external_id is not None:
             parameters['ExternalId'] = external_id
 
         credentials = retry(

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -56,6 +56,7 @@ class Config(dict):
             'profile': None,
             'account_id': account_id,
             'assume_role': None,
+            'external_id': None,
             'log_group': None,
             'metrics_enabled': True,
             'output_dir': os.environ.get(

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -512,7 +512,8 @@ class Policy(object):
             session_factory = SessionFactory(
                 options.region,
                 options.profile,
-                options.assume_role)
+                options.assume_role,
+                options.external_id)
         self.session_factory = session_factory
         self.ctx = ExecutionContext(self.session_factory, self, self.options)
         self.resource_manager = self.get_resource_manager()

--- a/tests/common.py
+++ b/tests/common.py
@@ -206,6 +206,7 @@ class Config(Bag):
             'profile': None,
             'account_id': '644160558196',
             'assume_role': None,
+            'external_id': None,
             'log_group': None,
             'metrics_enabled': False,
             'output_dir': 's3://test-example/foo',


### PR DESCRIPTION
This pull request is a work in progress, but it aims to provide support for specifying the ExternalId parameter used alongside an assumed token with STS. This is an important part of cross-account role assumption, and pretty well documented here: http://docs.aws.amazon.com/IAM/latest/UserGuide/id_roles_create_for-user_externalid.html

As a work in progress, current questions I'd love some feedback on include:

1. How do we generate / capture test fixtures for web requests?
2. Is there any other places in the codebase where we need to support this? Currently we just pass the flag through to the appropriate place inside the SessionFactory.

Thanks! Let me know especially if you have any comments / suggestions around with fitting in with the code base, I'm fairly new to contributing to Python OSS.