### PR TITLE
Fix CSV reports with integers

### DIFF
--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -103,7 +103,7 @@ def _get_values(record, field_list, tag_map):
             if value is None:
                 value = ''
             else:
-                value = ', '.join(value)
+                value = ', '.join([str(v) for v in value])
         elif field.startswith(count_prefix):
             count_field = field.replace(count_prefix, '', 1)
             value = jmespath.search(count_field, record)

--- a/tests/data/report.json
+++ b/tests/data/report.json
@@ -109,13 +109,13 @@
         "LaunchTime-1",
         "VpcId-1",
         "PrivateIpAddress-1",
-	"CustomValue",
-	"",
-	"Custom-1"
+      	"CustomValue",
+      	"",
+      	"Custom-1"
       ],
       "minimal_custom": [
         "CustomValue",
-	"",
+        "",
         "Custom-1"
       ]
     }
@@ -164,23 +164,98 @@
     "rows": {
       "full": [
           "AutoScalingGroupName-1",
-	  "",
-	  "",
+      	  "",
+      	  "",
           "3",
-	  "",
-	  "",
-	  ""
+          "",
+          "",
+      	  ""
       ],
       "minimal": [
           "AutoScalingGroupName-2",
-	  "",
-	  "",
+      	  "",
+      	  "",
           "0",
           "",
           "",
           ""
       ]
     }
+  },
+  "elb": {
+    "records": {
+      "full": {
+        "CustodianDate": "2015-12-23",
+        "LoadBalancerName": "LoadBalancerName-1",
+        "CreatedTime": "CreatedTime-1",
+        "VPCId": "VPCId-1",
+        "Instances": [{"InstanceId": "InstanceId-1"}],
+        "DNSName": "DNSName-1",
+        "ListenerDescriptions": [
+          {
+            "Listener": {
+              "InstancePort": 80,
+              "LoadBalancerPort": 80,
+              "Protocol": "TCP",
+              "InstanceProtocol": "TCP"
+            },
+            "PolicyNames": []
+          },
+          {
+            "Listener": {
+              "InstancePort": 443,
+              "LoadBalancerPort": 443,
+              "Protocol": "TCP",
+              "InstanceProtocol": "TCP"
+            },
+            "PolicyNames": []
+          }
+        ],
+        "PrivateIpAddress": "PrivateIpAddress-1",
+        "IgnoredField": "IgnoredValue",
+        "Tags": [{"Key": "Name", "Value": "Name-1"}]
+      },
+      "minimal": {
+        "CustodianDate": "2015-12-22",
+        "LoadBalancerName": "LoadBalancerName-2",
+        "Instances": [],
+        "DNSName": "DNSName-2",
+        "CreatedTime": "CreatedTime-2",
+        "Tags": [],
+        "IgnoredField": "IgnoredValue"
+      },
+      "duplicate": {
+        "CustodianDate": "2015-12-20",
+        "LoadBalancerName": "LoadBalancerName-2",
+        "Instances": [],
+        "DNSName": "DNSName-2",
+        "CreatedTime": "CreatedTime-2",
+        "Tags": [],
+        "IgnoredField": "IgnoredValue"
+      }
+    },
+    "headers": [
+      "LoadBalancerName",
+      "DNSName",
+      "VPCId",
+      "count:Instances",
+      "list:ListenerDescriptions[].Listener.LoadBalancerPort"
+    ],
+    "rows": {
+      "full": [
+          "LoadBalancerName-1",
+      	  "DNSName-1",
+      	  "VPCId-1",
+          "1",
+      	  "80, 443"
+      ],
+      "minimal": [
+          "LoadBalancerName-2",
+      	  "DNSName-2",
+      	  "",
+          "0",
+          ""
+      ]
+    }
   }
 }
-

--- a/tests/test_report.py
+++ b/tests/test_report.py
@@ -34,6 +34,13 @@ ASG_POLICY = Policy(
     },
     Config.empty(),
 )
+ELB_POLICY = Policy(
+    {
+        'name': 'report-test-elb',
+        'resource': 'elb',
+    },
+    Config.empty(),
+)
 
 
 class TestEC2Report(unittest.TestCase):
@@ -93,6 +100,26 @@ class TestASGReport(unittest.TestCase):
 
     def test_csv(self):
         formatter = Formatter(ASG_POLICY.resource_manager)
+        tests = [
+            (['full'], ['full']),
+            (['minimal'], ['minimal']),
+            (['full', 'minimal'], ['full', 'minimal']),
+            (['full', 'duplicate', 'minimal'], ['full', 'minimal'])]
+        for rec_ids, row_ids in tests:
+            recs = map(lambda x: self.records[x], rec_ids)
+            rows = map(lambda x: self.rows[x], row_ids)
+            self.assertEqual(formatter.to_csv(recs), rows)
+
+
+class TestELBReport(unittest.TestCase):
+    def setUp(self):
+        data = load_data('report.json')
+        self.records = data['elb']['records']
+        self.headers = data['elb']['headers']
+        self.rows = data['elb']['rows']
+
+    def test_csv(self):
+        formatter = Formatter(ELB_POLICY.resource_manager)
         tests = [
             (['full'], ['full']),
             (['minimal'], ['minimal']),


### PR DESCRIPTION
Running a simple report for ELBs throws a python exception. I'm not sure if this is limited to ELBs, as I wasn't able to reproduce with other resources:

### Policy:
```yaml
---
policies:
  - name: test
    resource: elb
    filters:
        - "tag:Name": absent
```

### Current Output:
```
$ custodian version
0.8.23.0

$ custodian run -c test.yml -s output
2017-02-15 13:18:23,716: custodian.policy:INFO Running policy test resource: elb region:us-east-1 c7n:0.8.23.0
2017-02-15 13:18:24,859: custodian.policy:INFO policy: test resource:elb has count:1 time:1.14

$ custodian report -c test.yml -s output
Traceback (most recent call last):
  File "/env/bin/custodian", line 11, in <module>
    sys.exit(main())
  File "/env/local/lib/python2.7/site-packages/c7n/cli.py", line 321, in main
    command(options)
  File "/env/local/lib/python2.7/site-packages/c7n/commands.py", line 81, in _load_policies
    return f(options, policies)
  File "/env/local/lib/python2.7/site-packages/c7n/commands.py", line 203, in report
    raw_output_fh=options.raw)
  File "/env/local/lib/python2.7/site-packages/c7n/reports/csvout.py", line 82, in report
    rows = formatter.to_csv(records)
  File "/env/local/lib/python2.7/site-packages/c7n/reports/csvout.py", line 185, in to_csv
    rows = map(self.extract_csv, uniq)
  File "/env/local/lib/python2.7/site-packages/c7n/reports/csvout.py", line 159, in extract_csv
    return _get_values(record, self.fields.values(), tag_map)
  File "/env/local/lib/python2.7/site-packages/c7n/reports/csvout.py", line 106, in _get_values
    value = ', '.join(value)
TypeError: sequence item 0: expected string, int found
```

### Output after Patch:
```
$ custodian version
0.8.23.0

$ custodian run -c test.yml -s output
2017-02-15 13:18:23,716: custodian.policy:INFO Running policy test resource: elb region:us-east-1 c7n:0.8.23.0
2017-02-15 13:18:24,859: custodian.policy:INFO policy: test resource:elb has count:1 time:1.14

$ custodian report -c test.yml -s output
LoadBalancerName,DNSName,VPCId,count:Instances,list:ListenerDescriptions[].Listener.LoadBalancerPort
name,internal-dns.us-east-1.elb.amazonaws.com,vpc-XXXXXXXX,1,"80, 443"
```