### PR TITLE
Modify mailer so that it can print out data (like policy) in yaml format.

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -34,7 +34,7 @@ def dispatch(event, context):
 
 def get_archive(config):
 
-    required = ['ldap3', 'pyasn1', 'jinja2', 'markupsafe']
+    required = ['ldap3', 'pyasn1', 'jinja2', 'markupsafe','yaml']
     remove = ['_yaml.so', 'c7n.egg-link']
 
     def lib_filter(root, dirs, files):

--- a/tools/c7n_mailer/c7n_mailer/processor.py
+++ b/tools/c7n_mailer/c7n_mailer/processor.py
@@ -26,6 +26,7 @@ import jinja2
 from address import get_user
 from record import resource_tag, resource_owner, resource_format, format_struct
 
+import yaml
 
 log = logging.getLogger('custodian.mail')
 
@@ -49,6 +50,7 @@ class Processor(object):
         self.cache = cache
         self.env = jinja2.Environment(
             trim_blocks=True, autoescape=False)
+        self.env.filters['yaml_safe'] = yaml.safe_dump
 
         self.env.globals['format_resource'] = resource_format
         self.env.globals['format_struct'] = format_struct

--- a/tools/c7n_mailer/msg-templates/default.j2
+++ b/tools/c7n_mailer/msg-templates/default.j2
@@ -1,12 +1,12 @@
 
-The following {{ policy['resource'] }} resources 
+The following {{ policy['resource'] }} resources
 
 {% for resource in resources %}
    {{ format_resource(resource, policy['resource']) }}
 {% endfor %}
 
 in account: {{ account }}
- 
+
 Matched policy:
 
-{{ policy|pprint }}
+{{ policy|yaml_safe(default_flow_style=False) }}


### PR DESCRIPTION
By using yaml.safe_dump in an email template, the output is more user-friendly (looks like the original yaml rather than json).  I've included the default template and a sample below of what it looks like with the modification.  I've found this helpful with my HTML templates as well.

Sample output from default.js:
-------------------------------------------------------------------
The following ebs-snapshot resources

   name: snap-XXXX date: 2016-12-05T20:48:15+00:00
    
in account: X

Matched policy:

actions:
- subject: TEST in {{ account }}
  template: default
  to:
  - foo@gmail.com
  transport:
    queue: https://sqs.us-east-1.amazonaws.com/foobar/cloud-custodian-queue
    type: sqs
  type: notify
description: Notify if a snapshot does not comply with tagging best practices.
filters:
- or:
  - tag:Name: absent
  - tag:CostCenter: absent
name: snapshot-tag-compliance
resource: ebs-snapshot




