### PR TITLE
Add timezone abbreviations for every AWS region

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -186,7 +186,17 @@ class Time(Filter):
         'ct': 'America/Chicago',
         'mt': 'America/Denver',
         'gmt': 'Europe/London',
-        'gt': 'Europe/London'}
+        'gt': 'Europe/London',
+        'bst': 'Europe/London',
+        'ist': 'Europe/Dublin',
+        'cet': 'Europe/Berlin',
+        'it': 'Asia/Kolkata', # Technically IST (Indian Standard Time), but that's the same as Ireland
+        'jst': 'Asia/Tokyo',
+        'kst': 'Asia/Seoul',
+        'sgt': 'Asia/Singapore',
+        'aet': 'Australia/Sydney',
+        'brt': 'America/Sao_Paulo'
+        }
 
     def __init__(self, data, manager=None):
         super(Time, self).__init__(data, manager)


### PR DESCRIPTION
This is in response to [this github issue](https://github.com/capitalone/cloud-custodian/issues/942).

Cloud Custodian only supported a limited number of regions for offhours. I dug into Python's `tzdata` and found the timezone abbreviations for each region, and added them.