### PR TITLE
Updated docs to not use -c (or --config) flag, which is deprecated

### DIFF
--- a/docs/source/policy/lambda.rst
+++ b/docs/source/policy/lambda.rst
@@ -146,7 +146,7 @@ Now deploy the policy:
 
 .. code-block:: bash
 
-    custodian run -c custodian.yml -s .
+    custodian run -s . custodian.yml
 
 That should give you log output like this::
 

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -58,7 +58,7 @@ Now, run Custodian:
 
 .. code-block:: bash
 
-    AWS_ACCESS_KEY_ID="foo" AWS_SECRET_ACCESS_KEY="bar" custodian run --output-dir=. --config=custodian.yml
+    AWS_ACCESS_KEY_ID="foo" AWS_SECRET_ACCESS_KEY="bar" custodian run --output-dir=. custodian.yml
 
 If successful, you should see output similar to the following on the command line::
 
@@ -98,14 +98,14 @@ validate it separately:
 
 .. code-block:: bash
 
-  $ custodian validate -c custodian.yml
+  $ custodian validate custodian.yml
 
 You can also check which resources are identified by the policy, without
 running any actions on the resources:
 
 .. code-block:: bash
 
-  $ custodian run --dryrun -c custodian.yml -s .
+  $ custodian run --dryrun -s . custodian.yml
 
 
 .. _explore-cc:
@@ -176,15 +176,15 @@ Additional commands let you monitor your services in detail.
 
 You can generate metrics by specifying the boolean metrics flag::
 
-  $ custodian run -c <policyfile>.yml -s <output_directory> --metrics
+  $ custodian run -s <output_directory> --metrics <policyfile>.yml
 
 You can also upload Cloud Custodian logs to CloudWatch logs::
 
-  $ custodian run -c <policyfile>.yml --log-group=/cloud-custodian/<dev-account>/<region>
+  $ custodian run --log-group=/cloud-custodian/<dev-account>/<region> <policyfile>.yml
 
 And you can output logs and resource records to S3::
 
-  $ custodian run -c <policyfile>.yml -s s3://<my-bucket><my-prefix>
+  $ custodian run -s s3://<my-bucket><my-prefix> <policyfile>.yml
 
 For details, see :ref:`usage`.
 

--- a/docs/source/quickstart/usage.rst
+++ b/docs/source/quickstart/usage.rst
@@ -31,7 +31,7 @@ Additionally some filters and actions may generate their own metrics.
 In order to enable metrics output, the boolean metrics
 flag needs to be specified when running Cloud Custodian::
 
-  $ custodian run -c <policyfile>.yml -s <output_directory> --metrics
+  $ custodian run -s <output_directory> --metrics <policyfile>.yml
 
 
 CloudWatch Logs
@@ -43,7 +43,7 @@ separate stream.
 
 Usage example::
 
-  $ custodian run -c <policyfile>.yml --log-group=/cloud-custodian/<dev-account>/<region>
+  $ custodian run --log-group=/cloud-custodian/<dev-account>/<region> <policyfile>.yml
 
 
 If enabled, it is recommended to set a log subscription on the group to
@@ -61,7 +61,7 @@ with its log files for archival purposes.
 
 The S3 bucket and prefix can be specified via parameters::
 
-  $ custodian run -c <policyfile>.yml --output-dir s3://<my-bucket>/<my-prefix>
+  $ custodian run --output-dir s3://<my-bucket>/<my-prefix> <policyfile>.yml
 
 Reports
 -------


### PR DESCRIPTION
This goes along with PR #906 - but I forgot to update the documentation in that one.  I removed references to using `-c` or `--config` from the quickstart and other docs.