### PR TITLE
Clarify Lambda docs

### DIFF
--- a/docs/source/policy/lambda.rst
+++ b/docs/source/policy/lambda.rst
@@ -10,72 +10,50 @@ different Amazon services can be used as event sources.
 CloudWatch Events
 #################
 
-CloudWatch Events (CWE) is a general event bus for AWS infrastructure. Currently,
-it covers several major sources of information: CloudTrail API calls
-over a poll period on CloudTrail delivery, real-time instance status
-events, autoscale group notifications, and scheduled/periodic events.
+`CloudWatch Events
+<http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/WhatIsCloudWatchEvents.html>`_
+(CWE) is a general event bus for AWS infrastructure. Currently, it covers
+several major sources of information:
 
-CloudTrail provides a very rich data source over the entire range
-of AWS services exposed via the audit trail that allows Custodian to define effective
-realtime policies against any AWS product.
+#. CloudTrail API calls over a poll period on CloudTrail delivery,
+#. real-time instance status events,
+#. autoscale group notifications, and
+#. scheduled/periodic events.
 
-Additionally, for EC2 instances we can provide mandatory policy
-compliance - this means the non-compliant resources never
-became available.
+CloudTrail provides a very rich data source over the entire range of AWS
+services exposed via the audit trail that allows Custodian to define effective
+realtime policies against any AWS product. Additionally, for EC2 instances we
+can provide mandatory policy compliance - this means the non-compliant
+resources never became available.
 
 Cloud Custodian Integration
 ===========================
 
-Custodian provides for policy level execution against any CWE event
-stream. Each Custodian policy can be deployed as an independent Lambda
-function. The only difference between a Custodian policy that runs in
-Lambda and one that runs directly from the CLI in poll mode
-is the specification of the subscription of the events in the mode config block of the policy.
+Custodian provides for policy level execution against any CWE event stream.
+Each Custodian policy can be deployed as an independent Lambda function. The
+only difference between a Custodian policy that runs in Lambda and one that
+runs directly from the CLI in poll mode is the specification of the
+subscription of the events in the mode config block of the policy.
 
 Internally Custodian will reconstitute current state for all the resources
 in the event, execute the policy against them, match against the
 policy filters, and apply the policy actions to matching resources.
 
-:ref:`Mu<mu>` is the letter after Lambda, Lambda is a keyword in python.
 
-Configuration
-=============
+CloudTrail API Calls
+++++++++++++++++++++
 
-Examples
+Lambdas can receive CWE over CloudTrail API calls with a 1-15m delay.
 
 .. code-block:: yaml
 
    policies:
-
-     # Cloud Watch Events over CloudTrail api calls (1-15m trailing)
      - name: ec2-tag-compliance
        resource: ec2
-
-       # The mode block is the only difference between a Custodian policy that
-       # runs in reactive/push mode via lambda and one that runs in poll mode.
        mode:
          type: cloudtrail
          events:
           - RunInstances
-
-         # Note because the total AWS API surface area is so large
-         # most CloudTrail API event subscriptions need two additional
-         # fields.
-         #
-         # For CloudTrail events we need to reference the source API call
-         # sources:
-         #  - ec2.amazonaws.com
-         #
-         # To work transparently with existing resource policies, we also
-         # need to specify how to extract the resource IDs from the event
-         # via JMESPath so that the resources can be queried.
-         # IDs: "detail.responseElements.instancesSet.items[].instanceId"
-         #
-         # For very common API calls for policies, some shortcuts have
-         # been defined to allow for easier policy writing as for the
-         # RunInstances API call above.
-         #
-
        filters:
          - or:
            - tag:required1: absent
@@ -83,7 +61,36 @@ Examples
        actions:
          - stop
 
-     # On EC2 Instance state events (real time, seconds)
+Because the total AWS API surface area is so large most CloudTrail API
+event subscriptions need two additional fields:
+
+#. For CloudTrail events we need to reference the source API call.
+
+#. To work transparently with existing resource policies, we also need to
+   specify how to extract the resource IDs from the event via JMESPath so that
+   the resources can be queried.
+
+For very common API calls for policies, some `shortcuts
+<https://github.com/capitalone/cloud-custodian/blob/master/c7n/cwe.py#L28-L69>`_
+have been defined to allow for easier policy writing as for the
+``RunInstances`` API call above, which expands to:
+
+.. code-block:: yaml
+
+     events:
+      - source: ec2.amazonaws.com
+        event: RunInstances
+        ids: "detail.responseElements.instancesSet.items[].instanceId"
+
+
+EC2 Instance State Events
++++++++++++++++++++++++++
+
+Lambdas can receive EC2 instance state events in real time (seconds delay).
+
+.. code-block:: yaml
+
+   policies:
      - name: ec2-require-encrypted-volumes
        resource: ec2
        mode:
@@ -96,20 +103,24 @@ Examples
            value: False
        actions:
          - mark
-         # TODO delete instance volumes that
-         # are not set to delete on terminate;
-         # currently we have a poll policy that
-         # handles this.
          - terminate
 
-     # Periodic Function
-     # Syntax for scheduler per http://goo.gl/x3oMQ4
-     # Supports both rate per unit time and cron expressions
+
+Periodic Function
++++++++++++++++++
+
+We support both rate per unit time and cron expressions, per `scheduler syntax
+<http://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html>`_.
+
+.. code-block:: yaml
+
+   policies:
      - name: s3-bucket-check
        resource: s3
        mode:
          type: periodic
          schedule: "rate(1 day)"
+
 
 Config Rules
 ############

--- a/docs/source/policy/lambda.rst
+++ b/docs/source/policy/lambda.rst
@@ -48,18 +48,16 @@ Lambdas can receive CWE over CloudTrail API calls with a 1-15m delay.
 .. code-block:: yaml
 
    policies:
-     - name: ec2-tag-compliance
+     - name: ec2-tag-running
        resource: ec2
        mode:
          type: cloudtrail
          events:
           - RunInstances
-       filters:
-         - or:
-           - tag:required1: absent
-           - tag:required2: absent
        actions:
-         - stop
+         - type: mark
+           tag: foo
+           msg: bar
 
 Because the total AWS API surface area is so large most CloudTrail API
 event subscriptions need two additional fields:

--- a/docs/source/policy/lambda.rst
+++ b/docs/source/policy/lambda.rst
@@ -43,7 +43,7 @@ policy filters, and apply the policy actions to matching resources.
 CloudTrail API Calls
 ++++++++++++++++++++
 
-Lambdas can receive CWE over CloudTrail API calls with a 1-15m delay.
+Lambdas can receive CWE over CloudTrail API calls with delay of 90s at P99.
 
 .. code-block:: yaml
 
@@ -127,7 +127,8 @@ Config Rules
 <http://docs.aws.amazon.com/config/latest/developerguide/evaluate-config_develop-rules.html>`_
 allow you to invoke logic in response to configuration changes in your AWS
 environment, and Cloud Custodian is the easiest way to write and provision
-Config rules.
+Config rules. Delay here is typically 1-15m (though the SLA on tag-only changes
+is a bit higher).
 
 In this section we'll look at how we would deploy the :ref:`quickstart
 <quickstart>` example using Config. Before you proceed, make sure you've


### PR DESCRIPTION
This is aimed at https://github.com/capitalone/cloud-custodian/issues/856. We already have [extensive](http://www.capitalone.io/cloud-custodian/docs/quickstart/tagCompliance.html) [documentation](http://www.capitalone.io/cloud-custodian/docs/usecases/tagcompliance.html) for tag compliance. The Lambda docs should be about Lambda config, not about tag compliance per se.