### PR TITLE
Filter Accounts by Missing Password Policies

### DIFF
--- a/tests/data/placebo/test_account_missing_password_policy/iam.GetAccountPasswordPolicy_1.json
+++ b/tests/data/placebo/test_account_missing_password_policy/iam.GetAccountPasswordPolicy_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 404, 
+            "RequestId": "04b2c98b-f97e-11e6-9355-bd102ebfc486", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "04b2c98b-f97e-11e6-9355-bd102ebfc486", 
+                "date": "Thu, 23 Feb 2017 04:10:32 GMT", 
+                "content-length": "310", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The Password Policy with domain name xyz cannot be found.", 
+            "Code": "NoSuchEntity", 
+            "Type": "Sender"
+        }
+    }
+}

--- a/tests/data/placebo/test_account_missing_password_policy/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_missing_password_policy/iam.ListAccountAliases_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "3a7df3cf-5cf3-11e6-aa11-47a89bac11fb", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3a7df3cf-5cf3-11e6-aa11-47a89bac11fb", 
+                "date": "Sun, 07 Aug 2016 23:04:00 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_missing_password_policy/iam.ListRoles_1.json
+++ b/tests/data/placebo/test_account_missing_password_policy/iam.ListRoles_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "ACmY0OT8q88xR699RuuS9E6qwxXQwGWIhQnZjU16IzdmgaWXj7iYvXustk4dFA6hLNfsoevJq8hTHCvbeSRLoScN", 
+        "IsTruncated": true, 
+        "Roles": [
+            {
+                "AssumeRolePolicyDocument": "%7B%22Version%22%3A%222012-10-17%22%2C%22Statement%22%3A%5B%7B%22Sid%22%3A%22%22%2C%22Effect%22%3A%22Allow%22%2C%22Principal%22%3A%7B%22Service%22%3A%22config.amazonaws.com%22%7D%2C%22Action%22%3A%22sts%3AAssumeRole%22%7D%5D%7D", 
+                "RoleId": "AROAJUQKESVQ5AAKMZYH4", 
+                "CreateDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 12, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "RoleName": "config-role-us-east-1", 
+                "Path": "/service-role/", 
+                "Arn": "arn:aws:iam::644160558196:role/service-role/config-role-us-east-1"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RequestId": "385288c8-5cf3-11e6-aa11-47a89bac11fb", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "385288c8-5cf3-11e6-aa11-47a89bac11fb", 
+                "date": "Sun, 07 Aug 2016 23:03:57 GMT", 
+                "content-length": "1003", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -159,4 +159,15 @@ class AccountTests(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 0)
 
+    def test_missing_password_policy(self):
+        session_factory = self.replay_flight_data('test_account_missing_password_policy')
+        p = self.load_policy({
+            'name': 'missing-password-policy',
+            'resource': 'account',
+            'filters': [{
+                'type': 'has-password-policy', 'value': False}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
 

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -165,7 +165,7 @@ class AccountTests(BaseTest):
             'name': 'missing-password-policy',
             'resource': 'account',
             'filters': [{
-                'type': 'has-password-policy', 'value': False}]},
+                'type': 'password-policy', 'key': 'PasswordPolicyConfigured', 'value': False}]},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)


### PR DESCRIPTION
Requesting a non-existant password policy causes an exception when used with the existing `password-policy` - but serves as a good check "do they have a password policy at all?

The existing `password-policy` filter is based on the `ValueFilter` - and so I can't easily add an extra flag to is (as far as I know?). I could modify the data it returns to have a single value (configured or the like) not present in the actual response, and check that value - but that risks breaking backwards compatibility by catching the edge case (but unlikely).

This adds a new, simple filter that just checks for the presence of a password policy and is intended to be easily combinable . Tests included.

Please note: This may hit the object twice in the process of getting it, so may be worth also adding the password policy on to the object given we're fetching it?