### PR TITLE
SES region configuration

### DIFF
--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -131,7 +131,7 @@ schema](./c7n_mailer/cli.py#L11-L41) to which the file must conform, here is
 |           | `ldap_bind_user`     | string           | ldap server for resolving users     |
 |           | `ldap_bind_password` | string           | ldap server for resolving users     |
 |           | `ldap_uri`           | string           | ldap server for resolving users     |
-
+|           | `ses_region`         | string           | AWS region that handles SES API calls |
 
 #### SDK Config
 

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -32,6 +32,7 @@ CONFIG_SCHEMA = {
         'ldap_bind_user': {'type': 'string'},
         'ldap_bind_password': {'type': 'string'},
         'cross_accounts': {'type': 'object'},
+        'ses_region': {'type': 'string'},
 
         # SDK Config
         'profile': {'type': 'string'},

--- a/tools/c7n_mailer/c7n_mailer/processor.py
+++ b/tools/c7n_mailer/c7n_mailer/processor.py
@@ -44,7 +44,7 @@ class Processor(object):
 
     def __init__(self, config, session, cache):
         self.config = config
-        self.ses = session.client('ses')
+        self.ses = session.client('ses', region_name=config['ses_region'])
         self.sts = session.client('sts')
         self.sns_cache = {}
         self.cache = cache

--- a/tools/c7n_mailer/c7n_mailer/processor.py
+++ b/tools/c7n_mailer/c7n_mailer/processor.py
@@ -44,7 +44,7 @@ class Processor(object):
 
     def __init__(self, config, session, cache):
         self.config = config
-        self.ses = session.client('ses', region_name=config['ses_region'])
+        self.ses = session.client('ses', region_name=config.get('ses_region'))
         self.sts = session.client('sts')
         self.sns_cache = {}
         self.cache = cache

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -23,7 +23,7 @@ def format_struct(struct):
 
 def setup_defaults(config):
     config.setdefault('region', 'us-east-1')
-    config.setdefault('region', config['region'])
+    config.setdefault('ses_region', config.get('region'))
     config.setdefault('memory', 1024)
     config.setdefault('timeout', 300)
     config.setdefault('subnets', None)

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -23,6 +23,7 @@ def format_struct(struct):
 
 def setup_defaults(config):
     config.setdefault('region', 'us-east-1')
+    config.setdefault('region', config['region'])
     config.setdefault('memory', 1024)
     config.setdefault('timeout', 300)
     config.setdefault('subnets', None)

--- a/tools/c7n_mailer/c7n_mailer/worker.py
+++ b/tools/c7n_mailer/c7n_mailer/worker.py
@@ -76,7 +76,7 @@ class Worker(object):
         self.processor = Processor(self.config, session, self.cache)
 
     def run(self):
-        self.ses = self.session.client('ses', region_name=self.config['ses_region'])
+        self.ses = self.session.client('ses', region_name=self.config.get('ses_region'))
 
         log.info("Queue poll loop")
         while True:

--- a/tools/c7n_mailer/c7n_mailer/worker.py
+++ b/tools/c7n_mailer/c7n_mailer/worker.py
@@ -76,7 +76,7 @@ class Worker(object):
         self.processor = Processor(self.config, session, self.cache)
 
     def run(self):
-        self.ses = self.session.client('ses')
+        self.ses = self.session.client('ses', region_name=self.config['ses_region'])
 
         log.info("Queue poll loop")
         while True:


### PR DESCRIPTION
Currently AWS SES only supports EU (Ireland), US East (N. Virginia) and US West (Oregon). The option `ses_region` sets the AWS region SES service calls will be going to. `region`-parameter will be used as default value.