### PR TITLE
Support all images in EC2 Instance Image Filters

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -36,7 +36,7 @@ class AMI(QueryResourceManager):
         service = 'ec2'
         type = 'image'
         enum_spec = (
-            'describe_images', 'Images', {'Owners': ['self']})
+            'describe_images', 'Images', None)
         detail_spec = None
         id = 'ImageId'
         filter_name = 'ImageIds'
@@ -47,6 +47,12 @@ class AMI(QueryResourceManager):
 
     filter_registry = filters
     action_registry = actions
+
+    def resources(self, query=None):
+        query = query or {}
+        if query.get('Owners') is None:
+            query['Owners'] = ['self']
+        return super(AMI, self).resources(query=query)
 
 
 @actions.register('deregister')

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -44,7 +44,7 @@ class Snapshot(QueryResourceManager):
         service = 'ec2'
         type = 'snapshot'
         enum_spec = (
-            'describe_snapshots', 'Snapshots', {'OwnerIds': ['self']})
+            'describe_snapshots', 'Snapshots', None)
         detail_spec = None
         id = 'SnapshotId'
         filter_name = 'SnapshotIds'
@@ -64,6 +64,12 @@ class Snapshot(QueryResourceManager):
 
     filter_registry = FilterRegistry('ebs-snapshot.filters')
     action_registry = ActionRegistry('ebs-snapshot.actions')
+
+    def resources(self, query=None):
+        query = query or {}
+        if query.get('OwnerIds') is None:
+            query['OwnerIds'] = ['self']
+        return super(Snapshot, self).resources(query=query)
 
 
 @Snapshot.filter_registry.register('age')

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -289,9 +289,28 @@ class AttachedVolume(ValueFilter):
 
 class InstanceImageBase(object):
 
-    def get_image_mapping(self, resources):
+    def prefetch_instance_images(self, instances):
+        image_ids = [i['ImageId'] for i in instances if 'c7n:instance-image' not in i]
+        self.image_map = self.get_local_image_mapping(image_ids)
+
+    def get_base_image_mapping(self):
         return {i['ImageId']: i for i in
                 self.manager.get_resource_manager('ami').resources()}
+
+    def get_instance_image(self, instance):
+        image = instance.get('c7n:instance-image', None)
+        if not image:
+            image = instance['c7n:instance-image'] = self.image_map.get(instance['ImageId'], None)
+        return image
+
+    def get_local_image_mapping(self, image_ids):
+        base_image_map = self.get_base_image_mapping()
+        resources = {i: base_image_map[i] for i in image_ids if i in base_image_map}
+        missing = list(set(image_ids) - set(resources.keys()))
+        if missing:
+            loaded = self.manager.get_resource_manager('ami').get_resources(missing, False)
+            resources.update({image['ImageId']: image for image in loaded})
+        return resources
 
 
 @filters.register('image-age')
@@ -324,15 +343,15 @@ class ImageAge(AgeFilter, InstanceImageBase):
         return self.manager.get_resource_manager('ami').get_permissions()
 
     def process(self, resources, event=None):
-        self.image_map = self.get_image_mapping(resources)
+        self.prefetch_instance_images(resources)
         return super(ImageAge, self).process(resources, event)
 
     def get_resource_date(self, i):
-        if i['ImageId'] not in self.image_map:
-            # our image is no longer available
+        image = self.get_instance_image(i)
+        if image:
+            return parse(image['CreationDate'])
+        else:
             return parse("2000-01-01T01:01:01.000Z")
-        image = self.image_map[i['ImageId']]
-        return parse(image['CreationDate'])
 
 
 @filters.register('image')
@@ -344,11 +363,12 @@ class InstanceImage(ValueFilter, InstanceImageBase):
         return self.manager.get_resource_manager('ami').get_permissions()
 
     def process(self, resources, event=None):
-        self.image_map = self.get_image_mapping(resources)
+        self.prefetch_instance_images(resources)
         return super(InstanceImage, self).process(resources, event)
 
     def __call__(self, i):
-        image = self.image_map.get(i['ImageId'])
+        image = self.get_instance_image(i)
+        # Finally, if we have no image...
         if not image:
             self.log.warning(
                 "Could not locate image for instance:%s ami:%s" % (


### PR DESCRIPTION
This is an attempted solution at #979.

TL;DR: This changes the internals of ResourceQuery to allow "escaping" the Enum spec and adjusts how the instance
image filter works to take advantage of this. No more `Could not locate image for instance` simply because it's a public image.

## General Train of Thought

1. `DescribeImages` defaults to returning _all_ accessible images (ouch).
2. The current AMI resource thus scopes to `Owners: ["Self"]` for just our images (logical, right?)
3. the `ec2` instance image filter uses the current AMI resource, looking up via ID.
4. ... This is limited to our resources.
5. What if we call `get_resources` to fetch specific ids?
6. `enum_spec` specifies the filter, which is merged in on the `get_resources` call via the `ResourceQuery`.
7. Oh, what if we work around that?
8. ... and call get_resources
9. We need to avoid the cache!
10. ... but we'll needlessly invoke the API then.
11. Smartly batch them up and then save them on the resource.
12. Intelligently fetch them!

This uses the `c7n:key` style augment like in some of the account checks, to avoid needlessly refetching data.
We don't cache the AMI results on the AMI level, but this ins't an issue because the AMI resource is only for _our images_.

## Use Cases

* Find using public / market place images (we should use an internal hardened image)
* Using the microsoft / windows VMs

## TODO:

* [ ] Tests - May need to run in the custodian skunkworks?
* [x] How can we avoid the `skip_extra_args` argument? Maybe pull out to a higher level?