### PR TITLE
Improve Lambda packaging

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -31,7 +31,6 @@ import platform
 import tempfile
 import zipfile
 
-import ipaddress
 from boto3.s3.transfer import S3Transfer, TransferConfig
 from botocore.exceptions import ClientError
 
@@ -61,17 +60,14 @@ class PythonPackageArchive(object):
     See http://docs.aws.amazon.com/lambda/latest/dg/with-s3-example-deployment-pkg.html#with-s3-example-deployment-pkg-python
     """
 
-    def __init__(self, src_path, virtualenv_dir=None, skip=None,
-                 lib_filter=None, src_filter=None):
+    def __init__(self, src_path, skip=None, lib_paths=None, lib_filter=None,
+                 src_filter=None):
 
         self.src_path = src_path
-        if virtualenv_dir is None:
-            virtualenv_dir = os.path.abspath(
-                os.path.join(os.path.dirname(sys.executable), '..'))
-        self.virtualenv_dir = virtualenv_dir
         self._temp_archive_file = None
         self._zip_file = None
         self._closed = False
+        self.lib_paths = lib_paths or []
         self.lib_filter = lib_filter
         self.src_filter = src_filter
         self.skip = skip
@@ -118,16 +114,18 @@ class PythonPackageArchive(object):
                     self.add_file(f_path, dest_path)
 
         # Library Source
-        venv_lib_path = os.path.dirname(ipaddress.__file__)
-        for root, dirs, files in os.walk(venv_lib_path):
-            if self.lib_filter:
-                dirs, files = self.lib_filter(root, dirs, files)
-            arc_prefix = os.path.relpath(root, venv_lib_path)
-            files = self.filter_files(files)
-            for f in files:
-                f_path = os.path.join(root, f)
-                dest_path = os.path.join(arc_prefix, f)
-                self.add_file(f_path, dest_path)
+        for lib_path in self.lib_paths:
+            if not os.path.exists(lib_path):
+                continue
+            for root, dirs, files in os.walk(lib_path):
+                if self.lib_filter:
+                    dirs, files = self.lib_filter(root, dirs, files)
+                arc_prefix = os.path.relpath(root, lib_path)
+                files = self.filter_files(files)
+                for f in files:
+                    f_path = os.path.join(root, f)
+                    dest_path = os.path.join(arc_prefix, f)
+                    self.add_file(f_path, dest_path)
 
     def add_file(self, src, dest):
         info = zipfile.ZipInfo(dest)
@@ -185,6 +183,15 @@ def custodian_archive(skip=None):
     required = ["pkg_resources", "ipaddress.py"]
     host_platform = platform.uname()[0]
 
+    # We need to locate the Lambda's dependencies, but the location where
+    # dependencies will have been installed varies widely across systems,
+    # and is somewhat complicated to solve generically. As an 80% hack,
+    # let's install a known third-party dependency of custodian, and assume
+    # that it's in the place where the rest of the needed dependencies will
+    # be as well.
+    import ipaddress
+    lib_path = os.path.dirname(ipaddress.__file__)
+
     def lib_filter(root, dirs, files):
         for f in list(files):
             # Don't bother with shared libs across platforms
@@ -198,9 +205,8 @@ def custodian_archive(skip=None):
 
     return PythonPackageArchive(
         os.path.dirname(inspect.getabsfile(c7n)),
-        os.path.abspath(os.path.join(
-            os.path.dirname(sys.executable), '..')),
         skip=skip,
+        lib_paths=[lib_path],
         lib_filter=lib_filter)
 
 

--- a/c7n/ufuncs/logsub.py
+++ b/c7n/ufuncs/logsub.py
@@ -118,9 +118,7 @@ def get_function(session_factory, name, role, sns_topic, log_groups,
     archive = PythonPackageArchive(
         # Directory to lambda file
         os.path.join(
-            os.path.dirname(inspect.getabsfile(c7n)), 'ufuncs', 'logsub.py'),
-        # Don't include virtualenv deps
-        lib_filter=lambda x, y, z: ([], []))
+            os.path.dirname(inspect.getabsfile(c7n)), 'ufuncs', 'logsub.py'))
     archive.create()
     archive.add_contents(
         'config.json', json.dumps({

--- a/tests/data/helloworld.py
+++ b/tests/data/helloworld.py
@@ -23,7 +23,7 @@ def main(event, context):
 
 def get_function(session_factory, name, role, events):
     import os
-    from c7n.mu import (LambdaFunction, PythonPackageArchive)
+    from c7n.mu import LambdaFunction, PythonPackageArchive
 
     config = dict(
         name=name,
@@ -35,11 +35,7 @@ def get_function(session_factory, name, role, events):
         description='Hello World',
         events=events)
 
-    archive = PythonPackageArchive(
-        # Directory to lambda file
-        os.path.abspath(__file__),
-        # Don't include virtualenv deps
-        lib_filter=lambda x, y, z: ([], []))
+    archive = PythonPackageArchive(os.path.abspath(__file__))
     archive.create()
     archive.close()
 

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -511,8 +511,7 @@ class LambdaCrossAccount(BaseTest):
 
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(os.rmdir, tmp_dir)
-        exclude_all = lambda a,b,c: ([], [])
-        archive = PythonPackageArchive(tmp_dir, tmp_dir, lib_filter=exclude_all)
+        archive = PythonPackageArchive(tmp_dir)
         archive.create()
         archive.add_contents('handler.py', LAMBDA_SRC)
         archive.close()

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -511,7 +511,8 @@ class LambdaCrossAccount(BaseTest):
 
         tmp_dir = tempfile.mkdtemp()
         self.addCleanup(os.rmdir, tmp_dir)
-        archive = PythonPackageArchive(tmp_dir, tmp_dir)
+        exclude_all = lambda a,b,c: ([], [])
+        archive = PythonPackageArchive(tmp_dir, tmp_dir, lib_filter=exclude_all)
         archive.create()
         archive.add_contents('handler.py', LAMBDA_SRC)
         archive.close()

--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -51,11 +51,7 @@ def get_archive(config):
                     dirs.remove(n)
         return dirs, files
 
-    archive = PythonPackageArchive(
-        os.path.dirname(__file__),
-        skip='*.pyc',
-        lib_filter=lib_filter)
-
+    archive = PythonPackageArchive(os.path.dirname(__file__), skip='*.pyc')
     archive.create()
 
     template_dir = os.path.abspath(

--- a/tools/c7n_sentry/c7n_sentry/c7nsentry.py
+++ b/tools/c7n_sentry/c7n_sentry/c7nsentry.py
@@ -342,11 +342,7 @@ def get_function(session_factory, name, handler, role,
             CloudWatchLogSubscription(
                 session_factory, log_groups, pattern)])
 
-    archive = PythonPackageArchive(
-        os.path.dirname(__file__),
-        skip='*.pyc',
-        lib_filter=lambda x, y, z: ([], []))
-
+    archive = PythonPackageArchive(os.path.dirname(__file__), skip='*.pyc')
     archive.create()
     archive.add_contents(
         'config.json', json.dumps({


### PR DESCRIPTION
Proposed fix for https://github.com/capitalone/cloud-custodian/issues/193. Rather than guessing where library dependencies reside, just sniff an actual dependency. Hopefully this provides the greatest portability?