### PR TITLE
Fix example to pass validation

### DIFF
--- a/docs/source/usecases/ec2offhours.rst
+++ b/docs/source/usecases/ec2offhours.rst
@@ -6,25 +6,27 @@ EC2 - Offhours Support
 .. code-block:: yaml
 
    policies:
-     - name: offhour-stop-19
+     - name: offhour_stop_19
        resource: ec2
        comments: |
          Daily stoppage at 7pm
        filters:
          - type: offhour
            tag: c7n_downtime
-           hour: 22
+           offhour: 22
+           default_tz: est
        actions:
          - stop
    
-     - name: onhour-start-10
+     - name: onhour_start_10
        resource: ec2
        comments: |
          Daily start at 10am
        filters:
          - type: onhour
            tag: c7n_downtime
-           hour: 10
+           onhour: 10
+           default_tz: est
        actions:
          - start
          


### PR DESCRIPTION
Policy `name` is not allowed to contain `-`.
Filter name `hour` is incorrect. Requires `offhour`/`onhour`.
For `offhour`/`onhour` setting `default_tz` is a requirement.

Version being used:
```
❯ custodian version                  
0.8.23.2
```

Missing `default_tz` when validating.
```
❯ custodian validate c7n-offhours.yml
2017-03-05 14:07:51,741: custodian.commands:ERROR Configuration invalid: c7n-offhours.yml
2017-03-05 14:07:51,742: custodian.commands:ERROR 'default_tz' is a required property

Failed validating 'required' in schema[11]:
    {'additionalProperties': False,
     'properties': {'debug': {'type': 'boolean'},
                    'default_tz': {'type': 'string'},
                    'offhour': {'maximum': 24,
                                'minimum': 0,
                                'type': 'integer'},
                    'opt-out': {'type': 'boolean'},
                    'tag': {'type': 'string'},
                    'type': {'enum': ['offhour']},
                    'weekends': {'type': 'boolean'},
                    'weekends-only': {'type': 'boolean'}},
     'required': ['offhour', 'default_tz', 'type'],
     'type': 'object'}

On instance:
    {'offhour': 22, 'tag': 'c7n_downtime', 'type': 'offhour'}
2017-03-05 14:07:51,742: custodian.commands:ERROR offhour_stop_19
```

Property `hour` incorrect.
```
❯ custodian validate c7n-offhours.yml
2017-03-05 14:09:31,916: custodian.commands:ERROR Configuration invalid: c7n-offhours.yml
2017-03-05 14:09:31,917: custodian.commands:ERROR Additional properties are not allowed ('hour' was unexpected)

Failed validating 'additionalProperties' in schema[11]:
    {'additionalProperties': False,
     'properties': {'debug': {'type': 'boolean'},
                    'default_tz': {'type': 'string'},
                    'offhour': {'maximum': 24,
                                'minimum': 0,
                                'type': 'integer'},
                    'opt-out': {'type': 'boolean'},
                    'tag': {'type': 'string'},
                    'type': {'enum': ['offhour']},
                    'weekends': {'type': 'boolean'},
                    'weekends-only': {'type': 'boolean'}},
     'required': ['offhour', 'default_tz', 'type'],
     'type': 'object'}

On instance:
    {'default_tz': 'est',
     'hour': 22,
     'tag': 'c7n_downtime',
     'type': 'offhour'}
2017-03-05 14:09:31,917: custodian.commands:ERROR offhour_stop_19
```

`-` is not allowed in property name.
```
❯ custodian validate c7n-offhours.yml
2017-03-05 14:13:43,635: custodian.commands:ERROR Configuration invalid: c7n-offhours.yml
2017-03-05 14:13:43,636: custodian.commands:ERROR 'offhour-stop-19' does not match '^[A-z][A-z0-9]*(-[A-z0-9]*[A-z][A-z0-9]*)*$'

Failed validating 'pattern' in schema[24]['allOf'][0]['properties']['name']:
    {'pattern': '^[A-z][A-z0-9]*(-[A-z0-9]*[A-z][A-z0-9]*)*$',
     'type': 'string'}

On instance['name']:
    'offhour-stop-19'
2017-03-05 14:13:43,636: custodian.commands:ERROR offhour-stop-19
```

Thanks for a great open source project! :)