### PR TITLE
Add Filter/Action for S3 static website hosting

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1380,12 +1380,12 @@ def _query_elb_attrs(session_factory, elb_set):
 
 
 @actions.register('remove-website-hosting')
-class AOLRemoveWebsiteHosting(BucketActionBase):
+class RemoveWebsiteHosting(BucketActionBase):
     """Action that removes website hosting configuration."""
 
     schema = type_schema('remove-website-hosting')
 
-    permissions = ('s3:*',)
+    permissions = ('s3:DeleteBucketWebsite',)
 
     def process(self, buckets):
         session = local_session(self.manager.session_factory)

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -448,18 +448,6 @@ class MissingPolicyStatementFilter(Filter):
         return True
 
 
-@filters.register('static-website-hosting')
-class StaticWebsiteHosting(Filter):
-    """Finds if bucket is hosting a static website."""
-
-    schema = type_schema('static-website-hosting')
-
-    permissions = ('s3:*',)
-
-    def process(self, buckets, event=None):
-        return [b for b in buckets if b['Website']]
-
-
 @actions.register('no-op')
 class NoOp(BucketActionBase):
 

--- a/tests/data/placebo/test_s3_delete_website_config/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_delete_website_config/s3.CreateBucket_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-static-website-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "zA5WL87PAOhO3e0i4G7OTD1FyzxFJ73xw//P258CUXysszQv9S4LlRbspiqYa36nKMTvNhTDXUo=", 
+            "RequestId": "744920B94C9D72A3", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "zA5WL87PAOhO3e0i4G7OTD1FyzxFJ73xw//P258CUXysszQv9S4LlRbspiqYa36nKMTvNhTDXUo=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "744920B94C9D72A3", 
+                "location": "/custodian-static-website-test", 
+                "date": "Sat, 04 Mar 2017 02:54:31 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_website_config/s3.DeleteBucketWebsite_1.json
+++ b/tests/data/placebo/test_s3_delete_website_config/s3.DeleteBucketWebsite_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "YvQJevDIbZdmWypdih4xnwKWfCeU4S2Va3czet4MHAQABDdLQCLgbT3jTUXJUkhHIQ4t74Tdr+A=", 
+            "RequestId": "D31CDDEF1764B459", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "YvQJevDIbZdmWypdih4xnwKWfCeU4S2Va3czet4MHAQABDdLQCLgbT3jTUXJUkhHIQ4t74Tdr+A=", 
+                "date": "Sat, 04 Mar 2017 02:54:31 GMT", 
+                "x-amz-request-id": "D31CDDEF1764B459", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_website_config/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_delete_website_config/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "PmKC+bXSMzMWktKQOcjaI+mh2qTR+LRUg2DZ6UvDdYcS87BNtHtUB7w/XF6qEnCVOVRXVPBBfuk=", 
+            "RequestId": "2BFFF515FDF5584B", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "PmKC+bXSMzMWktKQOcjaI+mh2qTR+LRUg2DZ6UvDdYcS87BNtHtUB7w/XF6qEnCVOVRXVPBBfuk=", 
+                "date": "Sat, 04 Mar 2017 02:54:31 GMT", 
+                "x-amz-request-id": "2BFFF515FDF5584B", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_website_config/s3.GetBucketWebsite_1.json
+++ b/tests/data/placebo/test_s3_delete_website_config/s3.GetBucketWebsite_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200, 
+    "data": {
+        "IndexDocument": {
+            "Suffix": "index.html"
+        }, 
+        "ErrorDocument": {
+            "Key": "error.html"
+        }, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "RI1tew4sDteJFtf/NmU+UaVaT+QMFMiudHKr7IOmEzpMT9iPcBjaNsWvfXvKj3i0cdDAzXuhLnI=", 
+            "RequestId": "8D69E2BF135FDDD1", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "RI1tew4sDteJFtf/NmU+UaVaT+QMFMiudHKr7IOmEzpMT9iPcBjaNsWvfXvKj3i0cdDAzXuhLnI=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8D69E2BF135FDDD1", 
+                "date": "Sat, 04 Mar 2017 02:54:31 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_website_config/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_delete_website_config/s3.ListBuckets_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "test", 
+            "ID": "f4f4c9ae2b9027b24750ee4e0b6fdc9877662cb4c6b9bc2108c752b919b9f78c"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 31, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 54
+                }, 
+                "Name": "custodian-static-website-test"
+            } 
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "w/m3oUeVaCDWwdrVQ8zS86aqOR9/05C3Ewy/7NZMJedMNTs5FdmraylAxg4gjxKUPSquw/aWPVo=", 
+            "RequestId": "1CD87F6027CAAD5E", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "w/m3oUeVaCDWwdrVQ8zS86aqOR9/05C3Ewy/7NZMJedMNTs5FdmraylAxg4gjxKUPSquw/aWPVo=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "1CD87F6027CAAD5E", 
+                "date": "Sat, 04 Mar 2017 02:54:31 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_website_config/s3.PutBucketWebsite_1.json
+++ b/tests/data/placebo/test_s3_delete_website_config/s3.PutBucketWebsite_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "+ujeUjzB0QBOC+IJOfxSVujTebi1podCJ3fxxn6HkLtRHgDKelMlHsDz+GBsGSX3zfqJ1aAjYow=", 
+            "RequestId": "F2E2F626751D33A0", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "+ujeUjzB0QBOC+IJOfxSVujTebi1podCJ3fxxn6HkLtRHgDKelMlHsDz+GBsGSX3zfqJ1aAjYow=", 
+                "date": "Sat, 04 Mar 2017 02:54:31 GMT", 
+                "content-length": "0", 
+                "x-amz-request-id": "F2E2F626751D33A0", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_hosts_website/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_hosts_website/s3.CreateBucket_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-static-website-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "1op79FZVYgBRzHaCddFsOKOZFJ89l/k7sBD06rA91s/J72p2H/+R4Cr/90iWfuRXYl5zESWo+XI=", 
+            "RequestId": "096716284106DA51", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "1op79FZVYgBRzHaCddFsOKOZFJ89l/k7sBD06rA91s/J72p2H/+R4Cr/90iWfuRXYl5zESWo+XI=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "096716284106DA51", 
+                "location": "/custodian-static-website-test", 
+                "date": "Wed, 08 Mar 2017 03:37:05 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_hosts_website/s3.DeleteBucketWebsite_1.json
+++ b/tests/data/placebo/test_s3_hosts_website/s3.DeleteBucketWebsite_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "jm+cSw4vZB5jlUxfLjIjAtOqKkxjdKqGTZ17h68pn/przOpkpN2tu5sVoR+jR6qwkw/J+W69jGc=", 
+            "RequestId": "0933899B4FB65CFB", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "jm+cSw4vZB5jlUxfLjIjAtOqKkxjdKqGTZ17h68pn/przOpkpN2tu5sVoR+jR6qwkw/J+W69jGc=", 
+                "date": "Wed, 08 Mar 2017 03:37:06 GMT", 
+                "x-amz-request-id": "0933899B4FB65CFB", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_hosts_website/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_hosts_website/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "c4IaXxkDFVDduGRj8DushKbGwCXuaAelU3C9kDJkijPAJ5t4CfnnN5slg+rsxymSrpD5cTVK2vU=", 
+            "RequestId": "3F0DD596074B743A", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "c4IaXxkDFVDduGRj8DushKbGwCXuaAelU3C9kDJkijPAJ5t4CfnnN5slg+rsxymSrpD5cTVK2vU=", 
+                "date": "Wed, 08 Mar 2017 03:37:06 GMT", 
+                "x-amz-request-id": "3F0DD596074B743A", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_hosts_website/s3.GetBucketWebsite_1.json
+++ b/tests/data/placebo/test_s3_hosts_website/s3.GetBucketWebsite_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200, 
+    "data": {
+        "IndexDocument": {
+            "Suffix": "index.html"
+        }, 
+        "ErrorDocument": {
+            "Key": "error.html"
+        }, 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "UkqcJXTE2vmd3DF1/3Fj42AcPyHvT0h5dDm0sC3c6vPWJA7PAQ0Drh57ptwAtkxG7t/b3OPcTPw=", 
+            "RequestId": "05C977F9553D46A1", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "UkqcJXTE2vmd3DF1/3Fj42AcPyHvT0h5dDm0sC3c6vPWJA7PAQ0Drh57ptwAtkxG7t/b3OPcTPw=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "05C977F9553D46A1", 
+                "date": "Wed, 08 Mar 2017 03:37:06 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_hosts_website/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_hosts_website/s3.ListBuckets_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "onecloud-aws", 
+            "ID": "f4f4c9ae2b9027b24750ee4e0b6fdc9877662cb4c6b9bc2108c752b919b9f78c"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 5, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 8, 
+                    "minute": 37
+                }, 
+                "Name": "custodian-static-website-test"
+            }
+       ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "ZmTFv7oUOYWWXGj8KsUiV+semzrwQs1pQ1TnS3UTuJSsfcVMSRxGYMiBNshBUtO1FIFR6RC4Yt0=", 
+            "RequestId": "1477DEBEAF488E33", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "ZmTFv7oUOYWWXGj8KsUiV+semzrwQs1pQ1TnS3UTuJSsfcVMSRxGYMiBNshBUtO1FIFR6RC4Yt0=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "1477DEBEAF488E33", 
+                "date": "Wed, 08 Mar 2017 03:37:06 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_hosts_website/s3.ListBuckets_2.json
+++ b/tests/data/placebo/test_s3_hosts_website/s3.ListBuckets_2.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "onecloud-aws", 
+            "ID": "f4f4c9ae2b9027b24750ee4e0b6fdc9877662cb4c6b9bc2108c752b919b9f78c"
+        }, 
+        "Buckets": [], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "ZmTFv7oUOYWWXGj8KsUiV+semzrwQs1pQ1TnS3UTuJSsfcVMSRxGYMiBNshBUtO1FIFR6RC4Yt0=", 
+            "RequestId": "1477DEBEAF488E33", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "ZmTFv7oUOYWWXGj8KsUiV+semzrwQs1pQ1TnS3UTuJSsfcVMSRxGYMiBNshBUtO1FIFR6RC4Yt0=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "1477DEBEAF488E33", 
+                "date": "Wed, 08 Mar 2017 03:37:06 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_hosts_website/s3.PutBucketWebsite_1.json
+++ b/tests/data/placebo/test_s3_hosts_website/s3.PutBucketWebsite_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "5XPM7X+SP1nALJ9u26dlNQFIfSgTg4/vcM5z04a+fKC+5zO6NMQkJpvr2Cy1xOD7Zt26+QK0hmY=", 
+            "RequestId": "9C698775ECF2A27F", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "5XPM7X+SP1nALJ9u26dlNQFIfSgTg4/vcM5z04a+fKC+5zO6NMQkJpvr2Cy1xOD7Zt26+QK0hmY=", 
+                "date": "Wed, 08 Mar 2017 03:37:06 GMT", 
+                "content-length": "0", 
+                "x-amz-request-id": "9C698775ECF2A27F", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1059,3 +1059,30 @@ class S3Test(BaseTest):
         tags = client.get_bucket_tagging(Bucket=bname)
         tag_map = {t['Key']: t['Value'] for t in tags.get('TagSet', {})}
         self.assertTrue('maid_status' not in tag_map)
+
+    def test_hosts_website(self):
+        self.patch(s3, 'S3_AUGMENT_TABLE', [
+            ('get_bucket_website', 'Website', None, None)])
+        session_factory = self.replay_flight_data('test_s3_hosts_website')
+        session = session_factory()
+        client = session.client('s3')
+        bname = 'custodian-static-website-test'
+        self.addCleanup(client.delete_bucket, Bucket=bname)
+        p = self.load_policy({
+            'name': 's3-website-hosting',
+            'resource': 's3',
+            'filters': ['static-website-hosting']},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        names = [b['Name'] for b in resources]
+        self.assertTrue(bname in names)
+
+        p = self.load_policy({
+            'name': 's3-website-hosting',
+            'resource': 's3',
+            'filters': ['static-website-hosting'],
+            'actions': ['remove-website-hosting']},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1067,6 +1067,17 @@ class S3Test(BaseTest):
         session = session_factory()
         client = session.client('s3')
         bname = 'custodian-static-website-test'
+        client.create_bucket(Bucket=bname)
+        client.put_bucket_website(
+          Bucket=bname,
+          WebsiteConfiguration={
+            'ErrorDocument': {
+                'Key': 'error.html'
+            },
+            'IndexDocument': {
+                'Suffix': 'index.html'
+            }
+          })
         self.addCleanup(client.delete_bucket, Bucket=bname)
         p = self.load_policy({
             'name': 's3-website-hosting',

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1071,7 +1071,7 @@ class S3Test(BaseTest):
         p = self.load_policy({
             'name': 's3-website-hosting',
             'resource': 's3',
-            'filters': ['static-website-hosting']},
+            'filters': ['Website: not-null']},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -1081,7 +1081,7 @@ class S3Test(BaseTest):
         p = self.load_policy({
             'name': 's3-website-hosting',
             'resource': 's3',
-            'filters': ['static-website-hosting'],
+            'filters': ['Website: not-null'],
             'actions': ['remove-website-hosting']},
             session_factory=session_factory)
         resources = p.run()

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1071,7 +1071,7 @@ class S3Test(BaseTest):
         p = self.load_policy({
             'name': 's3-website-hosting',
             'resource': 's3',
-            'filters': ['Website: not-null']},
+            'filters': [{'Website': 'not-null'}]},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -1081,7 +1081,7 @@ class S3Test(BaseTest):
         p = self.load_policy({
             'name': 's3-website-hosting',
             'resource': 's3',
-            'filters': ['Website: not-null'],
+            'filters': [{'Website': 'not-null'}],
             'actions': ['remove-website-hosting']},
             session_factory=session_factory)
         resources = p.run()


### PR DESCRIPTION
New Filter
----------
1. `static-website-hosting` - Filters for buckets that are configured to host static websites.

New Action
-----------
1. `remove-website-hosting` - Disables static website hosting for collected buckets.