### PR TITLE
add a default query for EMR clusters

### DIFF
--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -90,6 +90,14 @@ class EMRCluster(QueryResourceManager):
             else:
                 names.add(query_filter['Name'])
                 result.append(query_filter)
+        if 'ClusterStates' not in names:
+            # include default query
+            result.append(
+                {
+                    'Name': 'ClusterStates',
+                    'Values': ['waiting', 'running', 'bootstrapping'],
+                }
+            )
         return result
 
     def augment(self, resources):

--- a/tests/test_emr.py
+++ b/tests/test_emr.py
@@ -55,7 +55,34 @@ class TestEMR(BaseTest):
             mgr.consolidate_query_filter(),
             [
                 {'Values': ['val1', 'val2'], 'Name': 'tag:foo'},
-                {'Values': ['val3'], 'Name': 'tag:bar'}
+                {'Values': ['val3'], 'Name': 'tag:bar'},
+                # default query
+                {
+                    'Values': ['waiting', 'running', 'bootstrapping'],
+                    'Name': 'ClusterStates',
+                },
+            ]
+        )
+
+        query = {
+            'query': [
+                {'tag:foo': 'val1'},
+                {'tag:foo': 'val2'},
+                {'tag:bar': 'val3'},
+                {'ClusterStates': 'terminated'},
+            ]
+        }
+        mgr = emr.EMRCluster(ctx, query)
+        self.assertEqual(
+            mgr.consolidate_query_filter(),
+            [
+                {'Values': ['val1', 'val2'], 'Name': 'tag:foo'},
+                {'Values': ['val3'], 'Name': 'tag:bar'},
+                # verify default is overridden
+                {
+                    'Values': ['terminated'],
+                    'Name': 'ClusterStates',
+                },
             ]
         )
 


### PR DESCRIPTION
If no `ClusterStates` query is provided, default to `['waiting', 'running', 'bootstrapping']`, otherwise, respect the query defined in the policy.