### PR TITLE
Fix Errata in EBS documentation

### DIFF
--- a/docs/source/policy/resources/ebs.rst
+++ b/docs/source/policy/resources/ebs.rst
@@ -18,7 +18,7 @@ Actions
 -------
 
 ``delete``
-  Delete CloudFormation Stack
+  Delete volume
 
   .. c7n-schema:: Delete
       :module: c7n.resources.ebs


### PR DESCRIPTION
The documentation states "Delete CloudFormation Stack" but it should read "Delete volume"