### PR TITLE
VPC filtering for misconfigured flow logs

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -129,25 +129,27 @@ class FlowLogFilter(Filter):
             flogs = resource_map[r[m.id]]
             r['c7n:flow-logs'] = flogs
 
-            fl_matches = []
-            for fl in flogs:
-                status_match = (status is None) or op(fl['FlowLogStatus'], status.upper())
-                traffic_type_match = (traffic_type is None) or op(fl['TrafficType'], traffic_type.upper())
-                log_group_match = (log_group is None) or op(fl['LogGroupName'], log_group)
+            # config comparisons are pointless if we only want vpcs with no flow logs
+            if enabled:
+                fl_matches = []
+                for fl in flogs:
+                    status_match = (status is None) or op(fl['FlowLogStatus'], status.upper())
+                    traffic_type_match = (traffic_type is None) or op(fl['TrafficType'], traffic_type.upper())
+                    log_group_match = (log_group is None) or op(fl['LogGroupName'], log_group)
 
-                # combine all conditions to check if flow log matches the spec
-                fl_match = status_match and traffic_type_match and log_group_match
-                fl_matches.append(fl_match)
+                    # combine all conditions to check if flow log matches the spec
+                    fl_match = status_match and traffic_type_match and log_group_match
+                    fl_matches.append(fl_match)
 
-            if set_op == 'in':
-                if any(fl_matches):
-                    results.append(r)
-            elif set_op == 'not-in':
-                if not any(fl_matches):
-                    results.append(r)
-            elif set_op == 'all':
-                if all(fl_matches):
-                    results.append(r)
+                if set_op == 'in':
+                    if any(fl_matches):
+                        results.append(r)
+                elif set_op == 'not-in':
+                    if not any(fl_matches):
+                        results.append(r)
+                elif set_op == 'all':
+                    if all(fl_matches):
+                        results.append(r)
 
         return results
 

--- a/tests/data/placebo/test_vpc_flow_logs_absent/ec2.DescribeFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_flow_logs_absent/ec2.DescribeFlowLogs_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200, 
+    "data": {
+        "FlowLogs": [
+            {
+                "ResourceId": "vpc-d0e386b7",
+                "CreationTime": {
+                    "hour": 23,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 52,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 18,
+                    "minute": 17
+                },
+                "LogGroupName": "/this/is/the/wrong/group",
+                "TrafficType": "REJECT",
+                "FlowLogStatus": "SOMETHINGBAD",
+                "FlowLogId": "fl-84d63aed",
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+            },
+            {
+                "ResourceId": "vpc-d0e386b7",
+                "CreationTime": {
+                    "hour": 23,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 52,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 18,
+                    "minute": 17
+                },
+                "LogGroupName": "/aws/lambda/myIOTFunction",
+                "TrafficType": "ALL",
+                "FlowLogStatus": "ACTIVE",
+                "FlowLogId": "fl-84d63aed",
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "2bb11182-8edf-4f73-a61c-84598d337e63", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sat, 18 Feb 2017 23:37:34 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_flow_logs_absent/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_flow_logs_absent/ec2.DescribeVpcs_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Vpcs": [
+            {
+                "VpcId": "vpc-d0e386b7", 
+                "InstanceTenancy": "default", 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-78ab4f1c", 
+                "CidrBlock": "10.4.0.0/16", 
+                "IsDefault": false
+            }, 
+            {
+                "VpcId": "vpc-4a9ff72e", 
+                "InstanceTenancy": "default", 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-78ab4f1c", 
+                "CidrBlock": "172.31.0.0/16", 
+                "IsDefault": true
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ce7ec47f-9f29-4bfc-bb87-d21e7fb380e0", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sat, 18 Feb 2017 23:37:33 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_flow_logs_misconfigured/ec2.DescribeFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_flow_logs_misconfigured/ec2.DescribeFlowLogs_1.json
@@ -1,0 +1,109 @@
+{
+    "status_code": 200, 
+    "data": {
+        "FlowLogs": [
+            {
+                "ResourceId": "vpc-4a9ff72e", 
+                "CreationTime": {
+                    "hour": 23, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 52, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 17
+                }, 
+                "LogGroupName": "/aws/lambda/myIOTFunction", 
+                "TrafficType": "REJECT",
+                "FlowLogStatus": "ACTIVE", 
+                "FlowLogId": "fl-84d63aed", 
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+            },
+            {
+                "ResourceId": "vpc-4a9ff72e",
+                "CreationTime": {
+                    "hour": 23,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 52,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 18,
+                    "minute": 17
+                },
+                "LogGroupName": "/aws/lambda/myIOTFunction",
+                "TrafficType": "ALL",
+                "FlowLogStatus": "SOMETHINGBAD",
+                "FlowLogId": "fl-84d63aed",
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+            },
+            {
+                "ResourceId": "vpc-4a9ff72e",
+                "CreationTime": {
+                    "hour": 23,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 52,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 18,
+                    "minute": 17
+                },
+                "LogGroupName": "/this/is/the/wrong/group",
+                "TrafficType": "ALL",
+                "FlowLogStatus": "ACTIVE",
+                "FlowLogId": "fl-84d63aed",
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+            },
+            {
+                "ResourceId": "vpc-d0e386b7",
+                "CreationTime": {
+                    "hour": 23,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 52,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 18,
+                    "minute": 17
+                },
+                "LogGroupName": "/this/is/the/wrong/group",
+                "TrafficType": "REJECT",
+                "FlowLogStatus": "SOMETHINGBAD",
+                "FlowLogId": "fl-84d63aed",
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+            },
+            {
+                "ResourceId": "vpc-d0e386b7",
+                "CreationTime": {
+                    "hour": 23,
+                    "__class__": "datetime",
+                    "month": 2,
+                    "second": 52,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 18,
+                    "minute": 17
+                },
+                "LogGroupName": "/aws/lambda/myIOTFunction",
+                "TrafficType": "ALL",
+                "FlowLogStatus": "ACTIVE",
+                "FlowLogId": "fl-84d63aed",
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "2bb11182-8edf-4f73-a61c-84598d337e63", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sat, 18 Feb 2017 23:37:34 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_flow_logs_misconfigured/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_flow_logs_misconfigured/ec2.DescribeVpcs_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Vpcs": [
+            {
+                "VpcId": "vpc-d0e386b7", 
+                "InstanceTenancy": "default", 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-78ab4f1c", 
+                "CidrBlock": "10.4.0.0/16", 
+                "IsDefault": false
+            }, 
+            {
+                "VpcId": "vpc-4a9ff72e", 
+                "InstanceTenancy": "default", 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-78ab4f1c", 
+                "CidrBlock": "172.31.0.0/16", 
+                "IsDefault": true
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ce7ec47f-9f29-4bfc-bb87-d21e7fb380e0", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Sat, 18 Feb 2017 23:37:33 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -87,7 +87,7 @@ class VpcTest(BaseTest):
         vpc_id2 = 'vpc-d0e386b7'
         traffic_type = 'ALL'
         log_group = '/aws/lambda/myIOTFunction'
-        status = 'ACTIVE'
+        status = 'active'
 
         p = self.load_policy({
             'name': 'net-find',

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -68,13 +68,38 @@ class VpcTest(BaseTest):
         self.assertEqual(len(resources), 1)
 
     @functional
+    def test_flow_logs_absent(self):
+        """Test that ONLY vpcs with no flow logs are retained
+
+        'vpc-4a9ff72e' - has no flow logs
+        'vpc-d0e386b7' - has flow logs
+        """
+        factory = self.replay_flight_data(
+            'test_vpc_flow_logs_absent')
+
+        vpc_id1 = 'vpc-4a9ff72e'
+
+        p = self.load_policy({
+            'name': 'net-find',
+            'resource': 'vpc',
+            'filters': [
+                {'VpcId': vpc_id1},
+                'flow-logs']},
+            session_factory=factory)
+
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['VpcId'], vpc_id1)
+
+    @functional
     def test_flow_logs_misconfiguration(self):
         """Validate that each VPC has at least one valid configuration
 
         In terms of filters, we then want to flag VPCs for which every
         flow log configuration has at least one invalid value
 
-        Here - return 2 vpcs, the first of which has three flow logs which each have different misconfigurations
+        Here - have 2 vpcs ('vpc-4a9ff72e','vpc-d0e386b7')
+        The first has three flow logs which each have different misconfigured properties
         The second has one correctly configured flow log, and one where all config is bad
 
         Only the first should be returned by the filter"""
@@ -82,9 +107,8 @@ class VpcTest(BaseTest):
         factory = self.replay_flight_data(
             'test_vpc_flow_logs_misconfigured')
 
-
         vpc_id1 = 'vpc-4a9ff72e'
-        vpc_id2 = 'vpc-d0e386b7'
+
         traffic_type = 'all'
         log_group = '/aws/lambda/myIOTFunction'
         status = 'active'
@@ -93,13 +117,17 @@ class VpcTest(BaseTest):
             'name': 'net-find',
             'resource': 'vpc',
             'filters': [
-                {'type': 'flow-logs',
-                 'enabled': True,
-                 'op': 'equal',
-                 'set-op': 'not-in',
-                 'status': status,
-                 'traffic-type': traffic_type,
-                 'log-group': log_group}]},
+                {'not': [{
+                        'type': 'flow-logs',
+                        'enabled': True,
+                        'op': 'equal',
+                        'set-op': 'or',
+                        'status': status,
+                        'traffic-type': traffic_type,
+                        'log-group': log_group
+                    }]
+                }
+            ]},
             session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -85,7 +85,7 @@ class VpcTest(BaseTest):
 
         vpc_id1 = 'vpc-4a9ff72e'
         vpc_id2 = 'vpc-d0e386b7'
-        traffic_type = 'ALL'
+        traffic_type = 'all'
         log_group = '/aws/lambda/myIOTFunction'
         status = 'active'
 


### PR DESCRIPTION
Story:
I want to filter VPCs such that I only get VPCs that don't have any valid flow log configuration.

Current behaviour:
There is an example filter which seemed to do what I wanted according to the comment:
```
type: flow-logs
enabled: true
op: not-equal
traffic-type: all
status: success
 log-group: vpc-logs
```
However this only works if *ALL* the fields are not equal. What I want to do is to look at the set of flow logs attached and only return those vpcs without any valid flow logs attached. I would guess that this is the most common use-case (??).

Solution:
Add set operator so that we can specify that a configuration must be found somewhere in the set, or not in it at all

Also:
'Status' from the flow logs response was giving a KeyError, it should be 'FlowLogStatus'