### PR TITLE
Documentation - improvements to filters docs

### DIFF
--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -33,6 +33,7 @@ scalar operators:
     - ``not-in`` or ``ni``
     - ``or`` or ``Or``
     - ``and`` or ``And``
+    - ``not``
 - Special operators:
     - ``glob`` - Provides Glob matching support
     - ``regex`` - Provides Regex matching support but ignores case
@@ -73,7 +74,7 @@ JMESPath Filter
   - ``normalize`` - convert the value to lowercase
   - ``resource_count`` - compare against the number of matched resources
   - ``size`` - the length of an element
-  - ``swap`` - swap the sentinel and the value
+  - ``swap`` - swap the value and the evaluated key
 
   Examples:
 

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -62,6 +62,58 @@ JMESPath Filter
        actions:
          - unmark
 
+  Transformations on the value can be done using the ``value_type`` keyword.  The
+  following value types are supported:
+
+  - ``age`` - convert to a datetime (for past date comparisons)
+  - ``cidr`` - parse an ipaddress
+  - ``cidr_size`` - the length of the network prefix
+  - ``expiration`` - convert to a datetime (for future date comparisons)
+  - ``integer`` - convert the value to an integer
+  - ``normalize`` - convert the value to lowercase
+  - ``resource_count`` - compare against the number of matched resources
+  - ``size`` - the length of an element
+  - ``swap`` - swap the sentinel and the value
+
+  Examples:
+
+  .. code-block:: yaml
+
+     # Get the size of a group
+     - type: value
+       key: SecurityGroups[].GroupId
+       value_type: size
+       value: 2
+       
+     # Membership example using swap
+     - type: value
+       key: SecurityGroups[].GroupId
+       value_type: swap
+       op: in
+       value: sg-49b87f44
+
+     # Convert to integer before comparison
+     - type: value
+       key: tag:Count
+       op: greater-than
+       value_type: integer
+       value: 0
+
+     # Find instances launched within the last 31 days
+     - type: value
+       key: LaunchTime
+       op: less-than
+       value_type: age
+       value: 32
+
+     # Use `resource_count` to filter resources based on the number that matched
+     # Note that no `key` is used for this value_type since it is matching on
+     # the size of the list of resources and not a specific field.
+     - type: value
+       value_type: resource_count
+       op: lt
+       value: 2
+
 
 `EventFilter`
   Filter against a CloudWatch event JSON associated to a resource type

--- a/docs/source/filters.rst
+++ b/docs/source/filters.rst
@@ -16,21 +16,26 @@ mixing and combining those with a boolean conditional operators that
 are nest-able. Comparison between values is configurable supporting
 scalar operators:
 
-- ``absent``
-- ``not-null``
-- ``equal`` or ``eq``
-- ``not-equal`` or ``ne``
-- ``greater-than`` or ``gt``
-- ``gte`` or ``ge``
-- ``less-than`` or ``lt``
-- ``lte`` or ``le``
-- collection operators against user supplied lists:
+- Comparison operators:
+    - ``equal`` or ``eq``
+    - ``not-equal`` or ``ne``
+    - ``greater-than`` or ``gt``
+    - ``gte`` or ``ge``
+    - ``less-than`` or ``lt``
+    - ``lte`` or ``le``
+- Other operators
+    - ``absent``
+    - ``present``
+    - ``not-null``
+    - ``empty``
+- Collection operators against user supplied lists:
     - ``in``
     - ``not-in`` or ``ni``
     - ``or`` or ``Or``
     - ``and`` or ``And``
-- `glob` - Provides Glob matching support
-- `regex` - Provides Regex matching support but ignores case
+- Special operators:
+    - ``glob`` - Provides Glob matching support
+    - ``regex`` - Provides Regex matching support but ignores case
 
 `AgeFilter`
   Automatically filter resources older than a given date in Days (see `Dateutil Parser <http://dateutil.readthedocs.org/en/latest/parser.html#dateutil.parser.parse>`_)


### PR DESCRIPTION
Improvements to the filters documentation:

 - added in some missing operators (present, empty, and not)
 - added in list of `value_type` transformations plus some examples