### PR TITLE
Custodian #550 s3 encryption policy filter

### DIFF
--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "T3OjwwmGi5h8SK5ba6RBGG3kNUmXpOJAq5KNNt0bj042YnoT5YiVMkFhItrJ1h80XqGj4sHY+0M=", 
+            "RequestId": "C7072968D47A1EF4", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "T3OjwwmGi5h8SK5ba6RBGG3kNUmXpOJAq5KNNt0bj042YnoT5YiVMkFhItrJ1h80XqGj4sHY+0M=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "C7072968D47A1EF4", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_10.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "TNAvivALV177Xo+EV4H9cNQ5o0HJf4i7vXoMgCFJ6juxNcoJPi8N+f4UeGabqp/3eNrV1RJPyn4=", 
+            "RequestId": "38280B78C1351B7F", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "TNAvivALV177Xo+EV4H9cNQ5o0HJf4i7vXoMgCFJ6juxNcoJPi8N+f4UeGabqp/3eNrV1RJPyn4=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "38280B78C1351B7F", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_11.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_11.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "FP3ixtZY4IABEpDY0ZHgSn15z2dfGhTzBK3cetpJrGQbiU0yn6chj3m0EJyA/jIZoIkBj2MMfVI=", 
+            "RequestId": "4D873175734AE9BC", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "FP3ixtZY4IABEpDY0ZHgSn15z2dfGhTzBK3cetpJrGQbiU0yn6chj3m0EJyA/jIZoIkBj2MMfVI=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "4D873175734AE9BC", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_2.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "pDS/WGNwz1aANXaKPBNhQl9xTzEGuDmTRuIfijoCNLaOhj1LFWT30FBjGmXT7j0uhRkkK9WZt6o=", 
+            "RequestId": "41E36A412ADEC727", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "pDS/WGNwz1aANXaKPBNhQl9xTzEGuDmTRuIfijoCNLaOhj1LFWT30FBjGmXT7j0uhRkkK9WZt6o=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "41E36A412ADEC727", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_3.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "fAzQRjx9e38ozS06NJ1+46OVQ8f/kkEg+vTIEu2F9rwIB6HLEv8HNI/tamWl+KSZmGU9YR5SyKc=", 
+            "RequestId": "D89C0327B485C5AA", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "fAzQRjx9e38ozS06NJ1+46OVQ8f/kkEg+vTIEu2F9rwIB6HLEv8HNI/tamWl+KSZmGU9YR5SyKc=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "D89C0327B485C5AA", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_4.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "J2yDb/Ws3Hk8QZLLnUdZ8NQEFkytoeQHxiVcm4UVxw7tyImNvAiORzcrFERGBrSwyZYTd/qS9aE=", 
+            "RequestId": "5F10AFC4E7F7B9D9", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "J2yDb/Ws3Hk8QZLLnUdZ8NQEFkytoeQHxiVcm4UVxw7tyImNvAiORzcrFERGBrSwyZYTd/qS9aE=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "5F10AFC4E7F7B9D9", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_5.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "FK204c08RKaGHImfMEDhf9OKaSQtA91xZCU1IjSsksikzcB/IKWkHzACqRWO0d7E9FcaZ09odXQ=", 
+            "RequestId": "8730798A28F24641", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "FK204c08RKaGHImfMEDhf9OKaSQtA91xZCU1IjSsksikzcB/IKWkHzACqRWO0d7E9FcaZ09odXQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8730798A28F24641", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_6.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Opj6AWct8WLRj3t1bcFuxPF3+tRtXA8rsi5opGa8BIxLSU3RmVwZytFlacR0s4SdDloPO/Wse1o=", 
+            "RequestId": "ED6FC1E261D87124", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Opj6AWct8WLRj3t1bcFuxPF3+tRtXA8rsi5opGa8BIxLSU3RmVwZytFlacR0s4SdDloPO/Wse1o=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "ED6FC1E261D87124", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_7.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "MStnFLLdOcFd9eIc4HCQr4JdxzjQzlbVO8hJ1rZbg7D9hZRVW7LBpi6StxQiVLYLfE4wBbtRnFU=", 
+            "RequestId": "0C6CD61070AC5514", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "MStnFLLdOcFd9eIc4HCQr4JdxzjQzlbVO8hJ1rZbg7D9hZRVW7LBpi6StxQiVLYLfE4wBbtRnFU=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "0C6CD61070AC5514", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_8.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "gsyYAhV7G38GsBmdNBhiR12EnBXWK2Q4YqxS27tuwHbv/upyVaR7OQHTNyP+M3SUt8iAoOYBStQ=", 
+            "RequestId": "4C35864562A83F65", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "gsyYAhV7G38GsBmdNBhiR12EnBXWK2Q4YqxS27tuwHbv/upyVaR7OQHTNyP+M3SUt8iAoOYBStQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "4C35864562A83F65", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketAcl_9.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Grants": [
+            {
+                "Grantee": {
+                    "Type": "CanonicalUser", 
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Permission": "FULL_CONTROL"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "k6uIneO2HZgdmzcAQSMmvvAXByvvqVEscCZd5h3cyJGF1/hgjO0KP3lBOUJIluY5OZcMqXQiHX0=", 
+            "RequestId": "5717169F30A1083E", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "k6uIneO2HZgdmzcAQSMmvvAXByvvqVEscCZd5h3cyJGF1/hgjO0KP3lBOUJIluY5OZcMqXQiHX0=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "5717169F30A1083E", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "hVucKig2V3Z0ETBelVV2Ykc0KStvnT+Im0GUvOQT34TJoYpjLBpvZzTLCkOZ93jmoqnMxi/UTbk=", 
+            "RequestId": "6369D37C7C9BD82C", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "hVucKig2V3Z0ETBelVV2Ykc0KStvnT+Im0GUvOQT34TJoYpjLBpvZzTLCkOZ93jmoqnMxi/UTbk=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "6369D37C7C9BD82C", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_2.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "YP1URQljUeKHVk65dg//aUAq8REhBIxyiequuJvbKAnMjNon3L3fqElHl2TWdJz3SWgGSthLOR4=", 
+            "RequestId": "DB73614D2EE20985", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "YP1URQljUeKHVk65dg//aUAq8REhBIxyiequuJvbKAnMjNon3L3fqElHl2TWdJz3SWgGSthLOR4=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "DB73614D2EE20985", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_3.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "YNeAN2whPaOBrDsIfxUkyrSyd7JFlk39N+W1EJiAAVZOiNgW5z+tepgl7PSzkAZC/PG/PdriE/Q=", 
+            "RequestId": "A3B809CE4F99304F", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "YNeAN2whPaOBrDsIfxUkyrSyd7JFlk39N+W1EJiAAVZOiNgW5z+tepgl7PSzkAZC/PG/PdriE/Q=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "A3B809CE4F99304F", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_4.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "UvuMQA87hoGCafyLJXEBiab/sUNJLFED5pYM9z5epGEETTqJcauEh5E5y4xF+1zYMMM3YpZRP8c=", 
+            "RequestId": "6F50FF1A412172D2", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "UvuMQA87hoGCafyLJXEBiab/sUNJLFED5pYM9z5epGEETTqJcauEh5E5y4xF+1zYMMM3YpZRP8c=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "6F50FF1A412172D2", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_5.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Lace+OXBYh5oHKxtHwJYKFQ+uNr2TKntMxdQ+9TFh6aSJ27KQTEZDBomOlV9Y21zPqdSB7nSNCw=", 
+            "RequestId": "0CF2D6E64BD9F423", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Lace+OXBYh5oHKxtHwJYKFQ+uNr2TKntMxdQ+9TFh6aSJ27KQTEZDBomOlV9Y21zPqdSB7nSNCw=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "0CF2D6E64BD9F423", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_6.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Qs2ogrzI7+AmhFJy7Igp5SLhlNG3t40e1dKDKCFWNYI/mvt2xDusEEC3KgA0UQCMLlBHjNWGh+Q=", 
+            "RequestId": "7AC22B7870262AE3", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Qs2ogrzI7+AmhFJy7Igp5SLhlNG3t40e1dKDKCFWNYI/mvt2xDusEEC3KgA0UQCMLlBHjNWGh+Q=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "7AC22B7870262AE3", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_7.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "OlH3lsQB4+PTTeslBs7TSQ2RL0ZfCUnTaSTvIY2AoLK4LTojbzQSvGOFPJ8U42zAB0WvY3jFwmE=", 
+            "RequestId": "BE96BA9500A9B772", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "OlH3lsQB4+PTTeslBs7TSQ2RL0ZfCUnTaSTvIY2AoLK4LTojbzQSvGOFPJ8U42zAB0WvY3jFwmE=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BE96BA9500A9B772", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_8.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "cR6umPi9q1jnnNMpv9x2rH8SvmPmMiQnAhINP/Rwx2JQJ87So0hFeP+tz6/O38ZAXNJpRvK238k=", 
+            "RequestId": "9525D7D7CEB37463", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "cR6umPi9q1jnnNMpv9x2rH8SvmPmMiQnAhINP/Rwx2JQJ87So0hFeP+tz6/O38ZAXNJpRvK238k=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "9525D7D7CEB37463", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLocation_9.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "OEr6jo2wOUIkSttnsEW/YSjhC5y+gML3/rHUPYK8/MR8+h1ga7brkp9g0cGBzzv9X/bXLWGVxQ4=", 
+            "RequestId": "8F4AD4C76A713FFE", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "OEr6jo2wOUIkSttnsEW/YSjhC5y+gML3/rHUPYK8/MR8+h1ga7brkp9g0cGBzzv9X/bXLWGVxQ4=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8F4AD4C76A713FFE", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "fqgMPn69W4ravtEdDzqPdXk9fQourItAyKwbQzoXuzRQlm2ryGVvonaTV/9rICFh+VbdpaNAOLc=", 
+            "RequestId": "7EA132AAC568D851", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "fqgMPn69W4ravtEdDzqPdXk9fQourItAyKwbQzoXuzRQlm2ryGVvonaTV/9rICFh+VbdpaNAOLc=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "7EA132AAC568D851", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_10.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "c6zOk8gO5ix1SNTr5y1EUvIIQNqj3iT/c1VKYauaeXomT9XxeLp7PJHlVINwiZE/ytqNO0091kI=", 
+            "RequestId": "B4ACD229A68D0F43", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "c6zOk8gO5ix1SNTr5y1EUvIIQNqj3iT/c1VKYauaeXomT9XxeLp7PJHlVINwiZE/ytqNO0091kI=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "B4ACD229A68D0F43", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_11.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_11.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "/WJBHz8b0Pv/4al8zyIADmPzpl9GiQ/C07k7HRYpJh0rIUqQ9oPeTJM++luB7bG1y6D2ow3BWQI=", 
+            "RequestId": "F877FA47E01460E1", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "/WJBHz8b0Pv/4al8zyIADmPzpl9GiQ/C07k7HRYpJh0rIUqQ9oPeTJM++luB7bG1y6D2ow3BWQI=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "F877FA47E01460E1", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_2.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "PiBXuru0lPenod6YSYkRo1Tc29sRNQhGzaQdnML6siHzPXy3ycIuDjwFoNXyySoZH8pHTKg359Y=", 
+            "RequestId": "4378F3EC849EFBE3", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "PiBXuru0lPenod6YSYkRo1Tc29sRNQhGzaQdnML6siHzPXy3ycIuDjwFoNXyySoZH8pHTKg359Y=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "4378F3EC849EFBE3", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_3.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "RHmrRSUbPddKWjobQGE23shxOHOoAKtxsmYvySQM0Tl5UVPCP1gmxl0bwEDq62Qrnx2yAlrJtGw=", 
+            "RequestId": "766ACFF4AB92183A", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "RHmrRSUbPddKWjobQGE23shxOHOoAKtxsmYvySQM0Tl5UVPCP1gmxl0bwEDq62Qrnx2yAlrJtGw=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "766ACFF4AB92183A", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_4.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "LwB9bUP8j+BTK/KK9cQTya5rjF2KgWj5TERvdijYmuB/wvULcfKAQzMlMu0w2vdPvsLiyWjpZ2c=", 
+            "RequestId": "08A588EFCA088372", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "LwB9bUP8j+BTK/KK9cQTya5rjF2KgWj5TERvdijYmuB/wvULcfKAQzMlMu0w2vdPvsLiyWjpZ2c=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "08A588EFCA088372", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_5.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "W0I+SnSMJ6DlJdBOjDY78qfW9VBvQ+nrjLLt3G5XlrqJk/MrKWIdw0dBTLWFgH52unoIs6RdN/A=", 
+            "RequestId": "2DB51E4A3F448DB8", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "W0I+SnSMJ6DlJdBOjDY78qfW9VBvQ+nrjLLt3G5XlrqJk/MrKWIdw0dBTLWFgH52unoIs6RdN/A=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "2DB51E4A3F448DB8", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_6.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Mlqe8FdvMTdiQfH0Tc5pPLXbtPlivLJIsBvifU5jVyqVv3dxmY7n1NdjDI4Dun3Z9FRhwK3ihC8=", 
+            "RequestId": "098A54970F2951E9", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "Mlqe8FdvMTdiQfH0Tc5pPLXbtPlivLJIsBvifU5jVyqVv3dxmY7n1NdjDI4Dun3Z9FRhwK3ihC8=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "098A54970F2951E9", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_7.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "raOZ1e+VTfar6TSv4HOBxL1dt6VwpGGwUyMq0WwXjXcQpqvd4FUQM0rCRWsx0PpBbZrNGuE/7gE=", 
+            "RequestId": "D73E0ECFE0C127ED", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "raOZ1e+VTfar6TSv4HOBxL1dt6VwpGGwUyMq0WwXjXcQpqvd4FUQM0rCRWsx0PpBbZrNGuE/7gE=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "D73E0ECFE0C127ED", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_8.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "NCVwfLQCA1mgPl2F1kSUBFkh88ON8CLO6nVnK6L4/1WtROiOIkcHyyL6Mq79FdtR/K94CTkx3SI=", 
+            "RequestId": "E3EFB0E39F69B891", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "NCVwfLQCA1mgPl2F1kSUBFkh88ON8CLO6nVnK6L4/1WtROiOIkcHyyL6Mq79FdtR/K94CTkx3SI=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "E3EFB0E39F69B891", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketLogging_9.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "vJwRJCWhlhm9oEzU5vhcymGPbDHx8W6Po3a5GOs7/vbzus4crdG+mJdxpjMCcC6I3PhoCJHl4Xc=", 
+            "RequestId": "11C6332A3B7310D3", 
+            "HTTPHeaders": {
+                "content-length": "289", 
+                "x-amz-id-2": "vJwRJCWhlhm9oEzU5vhcymGPbDHx8W6Po3a5GOs7/vbzus4crdG+mJdxpjMCcC6I3PhoCJHl4Xc=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "11C6332A3B7310D3", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "wZsybpAuv3nJdGgcMs6+EARu865mJKINx9nwaTq+SlQXjhZkSy6ixkB8nFcxhtkGReKmY8uglGg=", 
+            "RequestId": "19AF611B150EAB6C", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "wZsybpAuv3nJdGgcMs6+EARu865mJKINx9nwaTq+SlQXjhZkSy6ixkB8nFcxhtkGReKmY8uglGg=", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "19AF611B150EAB6C", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_10.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Mcs9hl+CyyUnuvWd8e+340ZRIgl5ydtWGH+G9I+dxfr/0syKQM8KRVHo0hGXG00PfkTAPceE3+I=", 
+            "RequestId": "180BCEB6B70C1F1D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Mcs9hl+CyyUnuvWd8e+340ZRIgl5ydtWGH+G9I+dxfr/0syKQM8KRVHo0hGXG00PfkTAPceE3+I=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "180BCEB6B70C1F1D", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_11.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_11.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "IzO6eKnsHkCeJfxjHkucWDSAPmTKewLcZyrN/HeeUPuOw4hfsN3AKOHneLNBsz+uBeoyd02dsvs=", 
+            "RequestId": "02834C40734564B5", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "IzO6eKnsHkCeJfxjHkucWDSAPmTKewLcZyrN/HeeUPuOw4hfsN3AKOHneLNBsz+uBeoyd02dsvs=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "02834C40734564B5", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "ROp71CDie/i2Tw+a37l8wM76mUR6e5qFEWMEMjTuS5jJ/yf/wvFJvJVF7HSQ7kz+6lC2rxfe+Sg=", 
+            "RequestId": "81DA551EC27C7601", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "ROp71CDie/i2Tw+a37l8wM76mUR6e5qFEWMEMjTuS5jJ/yf/wvFJvJVF7HSQ7kz+6lC2rxfe+Sg=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "81DA551EC27C7601", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_3.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "YpXJVE3Bez41ECXVLCX56bva9VcUAj9dWU2/igbmfdp6BxvLwa20ucU/9Ez6PPgH+xbvOxLkt8Y=", 
+            "RequestId": "336926DEC649E35D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "YpXJVE3Bez41ECXVLCX56bva9VcUAj9dWU2/igbmfdp6BxvLwa20ucU/9Ez6PPgH+xbvOxLkt8Y=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "336926DEC649E35D", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_4.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "bKqJF8IqDZOImrMePRtZo67svEGouA05PvfmxMTTF+L/uBV48Tv1UqVEzBa0wQrBk/1vQMqn6Gc=", 
+            "RequestId": "5E3F1D6156169D7E", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "bKqJF8IqDZOImrMePRtZo67svEGouA05PvfmxMTTF+L/uBV48Tv1UqVEzBa0wQrBk/1vQMqn6Gc=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "5E3F1D6156169D7E", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_5.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "p3ZrpuN3SK9NP4Eazh7TFrmQ6HG1WX7F/GRstDx/pjyrj6hyZuNfjIZNhhC/dOUkWqxhBHNBfxg=", 
+            "RequestId": "502453C377E03717", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "p3ZrpuN3SK9NP4Eazh7TFrmQ6HG1WX7F/GRstDx/pjyrj6hyZuNfjIZNhhC/dOUkWqxhBHNBfxg=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "502453C377E03717", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_6.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "oZPBp6G3RQ/yxp9mc/rDXFwMeAT1xDYTEYrnw79ubqRjVZr8aWIMm2QbShuzUW6y8B0H14I53zM=", 
+            "RequestId": "EE060947FD00836C", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "oZPBp6G3RQ/yxp9mc/rDXFwMeAT1xDYTEYrnw79ubqRjVZr8aWIMm2QbShuzUW6y8B0H14I53zM=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "EE060947FD00836C", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_7.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "xVa+Latb2mhsn1RNdNv6+7BBx3A6mxK57EA4GRUpYML6CwARV59O6201FbkfliA3qaoeLT2YekI=", 
+            "RequestId": "BF0163D57AEB61F4", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "xVa+Latb2mhsn1RNdNv6+7BBx3A6mxK57EA4GRUpYML6CwARV59O6201FbkfliA3qaoeLT2YekI=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BF0163D57AEB61F4", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_8.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "10tcboj8U0uum+xuJjrQ7pHqJ0AobVqo8QK/EuVYrptgTT7runuErfgN2svbA2GwPbGFWvarCbM=", 
+            "RequestId": "2C652E795B63DA57", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "10tcboj8U0uum+xuJjrQ7pHqJ0AobVqo8QK/EuVYrptgTT7runuErfgN2svbA2GwPbGFWvarCbM=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "2C652E795B63DA57", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketNotificationConfiguration_9.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "UCcyfhQxebLLwUipTUMQJBqRGXLBIgf8zkapXMMpZbK246QjvkxeiAJEZ5NwSo51u+SbHTJDkSQ=", 
+            "RequestId": "BC881331EAADBA95", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "UCcyfhQxebLLwUipTUMQJBqRGXLBIgf8zkapXMMpZbK246QjvkxeiAJEZ5NwSo51u+SbHTJDkSQ=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BC881331EAADBA95", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "i3P772MG9h6UmAojmfK92Eo7u8N2PtddKj7Aj2nk8xyIPajW/j9JOoyFMn99v79oay8m+MweCZc=", 
+            "RequestId": "B84A0AA7A6B41737", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "i3P772MG9h6UmAojmfK92Eo7u8N2PtddKj7Aj2nk8xyIPajW/j9JOoyFMn99v79oay8m+MweCZc=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "B84A0AA7A6B41737", 
+                "date": "Tue, 28 Mar 2017 21:12:11 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "config-bucket-644160558196"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_10.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "d+MURnXsLq62Uee7TSvA3rz3igIpojG80QEcw+EhVXmJbgmK2NmxsnlxgkL2aDUMTd5iHZ3siYc=", 
+            "RequestId": "E97CC2D56DA0F204", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "d+MURnXsLq62Uee7TSvA3rz3igIpojG80QEcw+EhVXmJbgmK2NmxsnlxgkL2aDUMTd5iHZ3siYc=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "E97CC2D56DA0F204", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "sphere11-dev-us-west-2"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_11.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_11.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "yTDo6InRjx3wVtQch/Mdh62gcwJe4fRt1UyqW3RTLqhiWs1QnKCuWDUbExSRLF16o6Dx0GEwTng=", 
+            "RequestId": "EBA9B9790EE1E695", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "yTDo6InRjx3wVtQch/Mdh62gcwJe4fRt1UyqW3RTLqhiWs1QnKCuWDUbExSRLF16o6Dx0GEwTng=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "EBA9B9790EE1E695", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "sphere11-us-west-2-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_2.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "i1z9/2jZ5hUqEkaqoNQsYBJUFX1Q4ctZ2ruthp5UjV5TxKs1sCL4WGCo+bj1zYhttWIHb4AHqYU=", 
+            "RequestId": "873F665A4CCAA535", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "i1z9/2jZ5hUqEkaqoNQsYBJUFX1Q4ctZ2ruthp5UjV5TxKs1sCL4WGCo+bj1zYhttWIHb4AHqYU=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "873F665A4CCAA535", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "scot-test"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_3.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "gDyAKEAG5Ruc7C8xcI7FVwnTC8ggto5f5lmSTNT4t0xlshoWmdPZHwTxBgk2SMdllgNYWkHNorw=", 
+            "RequestId": "8A34A7FBA3CDE2BB", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "gDyAKEAG5Ruc7C8xcI7FVwnTC8ggto5f5lmSTNT4t0xlshoWmdPZHwTxBgk2SMdllgNYWkHNorw=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8A34A7FBA3CDE2BB", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "custodian-replicated-west"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_4.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "gyE5Wly2znA1XZCCFFptL8r0r/xBCiC1K/CLxvDvHy8518ri4eyJvEOZZ/nMgzOl1wxvkYW1kuQ=", 
+            "RequestId": "C3EB2DB220FCDB9A", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "gyE5Wly2znA1XZCCFFptL8r0r/xBCiC1K/CLxvDvHy8518ri4eyJvEOZZ/nMgzOl1wxvkYW1kuQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "C3EB2DB220FCDB9A", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "config-rule-sanity"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_5.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2008-10-17\",\"Id\":\"Policy1335892530063\",\"Statement\":[{\"Sid\":\"Stmt1335892150622\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::386209384616:root\"},\"Action\":[\"s3:GetBucketAcl\",\"s3:GetBucketPolicy\"],\"Resource\":\"arn:aws:s3:::custodian-skunk-billing\"},{\"Sid\":\"Stmt1335892526596\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::386209384616:root\"},\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-skunk-billing/*\"}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "eU9vnCu6cf6Z9xRyxCR+6KBn8POTO2yS8fUDN0EDdsWH0JvS/vKbP5X6o81/dH/kHKako8rmz+0=", 
+            "RequestId": "D92A283E58559C09", 
+            "HTTPHeaders": {
+                "content-length": "437", 
+                "x-amz-id-2": "eU9vnCu6cf6Z9xRyxCR+6KBn8POTO2yS8fUDN0EDdsWH0JvS/vKbP5X6o81/dH/kHKako8rmz+0=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "D92A283E58559C09", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_6.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"RequiredEncryptedPutObject\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::ocampo-test/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "XiSdfoQIwWrwXUSJIsz9bDuKJt4kTH6rvUhbdrf4UqTxwSE77+fCuXHniYgSzbxRETNgVWwoT9k=", 
+            "RequestId": "A934B4A990F8EE3B", 
+            "HTTPHeaders": {
+                "content-length": "260", 
+                "x-amz-id-2": "XiSdfoQIwWrwXUSJIsz9bDuKJt4kTH6rvUhbdrf4UqTxwSE77+fCuXHniYgSzbxRETNgVWwoT9k=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "A934B4A990F8EE3B", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_7.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"Policy1487362419260\",\"Statement\":[{\"Sid\":\"Stmt1487362416163\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:DeleteBucket\",\"Resource\":\"arn:aws:s3:::scot-test2\"}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "BJ0bV4IzsroOWvFl/oR0Cl7hjedR5Gep4yed5TVKAw+PQhx2iao2B1bTX7cRMnLx9oqUaE9RIM8=", 
+            "RequestId": "FCC4BC45801C73D3", 
+            "HTTPHeaders": {
+                "content-length": "189", 
+                "x-amz-id-2": "BJ0bV4IzsroOWvFl/oR0Cl7hjedR5Gep4yed5TVKAw+PQhx2iao2B1bTX7cRMnLx9oqUaE9RIM8=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "FCC4BC45801C73D3", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_8.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "65ziw4CYh3qg7fk5H6J0pvsDE6rpgvqiv9C+/pzJHrnqE2xK9R9Ba8z32uYwuy4ZZEhXeuOxvAA=", 
+            "RequestId": "D88BC026D8959C95", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "65ziw4CYh3qg7fk5H6J0pvsDE6rpgvqiv9C+/pzJHrnqE2xK9R9Ba8z32uYwuy4ZZEhXeuOxvAA=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "D88BC026D8959C95", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "sphere11-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketPolicy_9.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"AWSCloudTrailAclCheck20150319\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudtrail.amazonaws.com\"},\"Action\":\"s3:GetBucketAcl\",\"Resource\":\"arn:aws:s3:::custodian-skunk-trails\"},{\"Sid\":\"AWSCloudTrailWrite20150319\",\"Effect\":\"Allow\",\"Principal\":{\"Service\":\"cloudtrail.amazonaws.com\"},\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-skunk-trails/AWSLogs/644160558196/*\",\"Condition\":{\"StringEquals\":{\"s3:x-amz-acl\":\"bucket-owner-full-control\"}}}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "FRLMZYXmCRELIs3qMbazg+3ggN4e0RCeLFe1mx0d5gHmBk898J++2ki6woGpAf4xKHgBZgiMYOY=", 
+            "RequestId": "E6480D58AE644D18", 
+            "HTTPHeaders": {
+                "content-length": "497", 
+                "x-amz-id-2": "FRLMZYXmCRELIs3qMbazg+3ggN4e0RCeLFe1mx0d5gHmBk898J++2ki6woGpAf4xKHgBZgiMYOY=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "E6480D58AE644D18", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "uUtcEEfsTPiu8aIdxDvyXbSGWFYblQfZ2DxQzlepGlVT4IsBpX9mgeVbqNfHm0xr7Qm5M+g8lKQ=", 
+            "RequestId": "FF86F3408E52E7C8", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "uUtcEEfsTPiu8aIdxDvyXbSGWFYblQfZ2DxQzlepGlVT4IsBpX9mgeVbqNfHm0xr7Qm5M+g8lKQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "FF86F3408E52E7C8", 
+                "date": "Tue, 28 Mar 2017 21:12:11 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "config-bucket-644160558196"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_10.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "PCN/9crr3zNCRgJvyTMwpFcyGavHmV0k90rffgooGFwbIa+pywKZ1dHiBlFMjCN4qce6akIAEOA=", 
+            "RequestId": "83B8CD4D0DF037D8", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "PCN/9crr3zNCRgJvyTMwpFcyGavHmV0k90rffgooGFwbIa+pywKZ1dHiBlFMjCN4qce6akIAEOA=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "83B8CD4D0DF037D8", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "sphere11-us-west-2-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_2.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "R9eKcgLBWW74jFayhd2WLuOOZ9W2jUJm0TvS5jQniJsiwQRTW7LvqyMpcCQwEA05rDDhAIROhDs=", 
+            "RequestId": "FA519B5B1B4B2DCF", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "R9eKcgLBWW74jFayhd2WLuOOZ9W2jUJm0TvS5jQniJsiwQRTW7LvqyMpcCQwEA05rDDhAIROhDs=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "FA519B5B1B4B2DCF", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "custodian-replicated-west"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_3.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "t9ciAa4YZv+WuzZbAHXmaeGvhtMVFVe7TA+VCnuHtqhFXwaVqI5qxm6tjXQD0KlOjNo+7AoxX14=", 
+            "RequestId": "3BCCC4FD19573425", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "t9ciAa4YZv+WuzZbAHXmaeGvhtMVFVe7TA+VCnuHtqhFXwaVqI5qxm6tjXQD0KlOjNo+7AoxX14=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "3BCCC4FD19573425", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "config-rule-sanity"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_4.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "JPkijavTYiczpw3yUJ4lZ/z/qcdMS+i3tLRindUUJ2RA1pzRDc6UOEXKnGy91s4UtkTZSvBsJhQ=", 
+            "RequestId": "4DBB37CA30B61610", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "JPkijavTYiczpw3yUJ4lZ/z/qcdMS+i3tLRindUUJ2RA1pzRDc6UOEXKnGy91s4UtkTZSvBsJhQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "4DBB37CA30B61610", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "custodian-skunk-billing"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_5.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "isFulDkq2mjg0FBXdcdVhFRx7BzkxndV861qz/AHHLthzIFxp2xbkOuZrWblehEwtMz2u52V7cs=", 
+            "RequestId": "352935DC05897854", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "isFulDkq2mjg0FBXdcdVhFRx7BzkxndV861qz/AHHLthzIFxp2xbkOuZrWblehEwtMz2u52V7cs=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "352935DC05897854", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "ocampo-test"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_6.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "cIzD3shbGDhQ2++gV4XiwWxidgLlzFx07F4v8PgPVlZ7x5n8WpT61Weob2v7vJsK6fuZCMLqbnk=", 
+            "RequestId": "E6DCBA0809DF2ED7", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "cIzD3shbGDhQ2++gV4XiwWxidgLlzFx07F4v8PgPVlZ7x5n8WpT61Weob2v7vJsK6fuZCMLqbnk=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "E6DCBA0809DF2ED7", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "sphere11-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_7.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "PT99CUxbBh4XDeSt4dkRyHS47OSkS11d93IOh5i0g3oQOoGtQJyJs7bn5mReB+08okHAIkjVh8s=", 
+            "RequestId": "74E45375F7A9B3D9", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "PT99CUxbBh4XDeSt4dkRyHS47OSkS11d93IOh5i0g3oQOoGtQJyJs7bn5mReB+08okHAIkjVh8s=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "74E45375F7A9B3D9", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "scot-test2"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_8.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "CjOrJd/WRAT7a8JX2nVwW0VDrml0+U++vQtETDjMsvaT1Pqsx181s+xsEIaTZyr0C8f21vIIhEM=", 
+            "RequestId": "3797B57AFEE41F95", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "CjOrJd/WRAT7a8JX2nVwW0VDrml0+U++vQtETDjMsvaT1Pqsx181s+xsEIaTZyr0C8f21vIIhEM=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "3797B57AFEE41F95", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "custodian-skunk-trails"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketReplication_9.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "+8ToPdcGMo1EtRl+7tBeKeW/msGiHR5V8h+TphZL/mk9lwmTQ1OX1q0mEoAcHIHp0PYyXYfxMGE=", 
+            "RequestId": "378E0C9598482827", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "+8ToPdcGMo1EtRl+7tBeKeW/msGiHR5V8h+TphZL/mk9lwmTQ1OX1q0mEoAcHIHp0PYyXYfxMGE=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "378E0C9598482827", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The replication configuration was not found", 
+            "Code": "ReplicationConfigurationNotFoundError", 
+            "BucketName": "sphere11-dev-us-west-2"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "zPJsnjepz0VqG3Y8hSffFAk/Dv5lYbKXmRFUCEG0RnMGvY3wAJv0oaOvAzWImzVF3CHyCZOt/hU=", 
+            "RequestId": "580C78D9E566A498", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "zPJsnjepz0VqG3Y8hSffFAk/Dv5lYbKXmRFUCEG0RnMGvY3wAJv0oaOvAzWImzVF3CHyCZOt/hU=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "580C78D9E566A498", 
+                "date": "Tue, 28 Mar 2017 21:12:11 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "config-bucket-644160558196"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_10.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "762tUWQBzK3ugtefn6vjksXBvF75McSQCnaCYvozjf6THgChS93qQ/u0/0B8qsmQ+SVLKBdQlWo=", 
+            "RequestId": "76373CC3C6550366", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "762tUWQBzK3ugtefn6vjksXBvF75McSQCnaCYvozjf6THgChS93qQ/u0/0B8qsmQ+SVLKBdQlWo=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "76373CC3C6550366", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "sphere11-us-west-2-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_2.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "ucO8+vSjNyqcwMaA39BAEP84bYGI8glhu+DXyiXjffs9/56HMLH8XPBWu9gtGasSSjjmRlBesqo=", 
+            "RequestId": "1F31353DA8E67372", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "ucO8+vSjNyqcwMaA39BAEP84bYGI8glhu+DXyiXjffs9/56HMLH8XPBWu9gtGasSSjjmRlBesqo=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "1F31353DA8E67372", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "scot-test"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_3.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "tO9olCAhTDz6U95bJ0nThaKRCjwY/nPT187RloVOz8ibmnXhp+csNzhu/WLQazgiPb1p07bOlj4=", 
+            "RequestId": "9721E1FDDDEECD2A", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "tO9olCAhTDz6U95bJ0nThaKRCjwY/nPT187RloVOz8ibmnXhp+csNzhu/WLQazgiPb1p07bOlj4=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "9721E1FDDDEECD2A", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "custodian-replicated-west"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_4.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "OCw+YkiUyoQC5EuKqnJwgfwggh1zMEf3SetNofF1RjUS2gLPDQZAsDrNEGLe4YEr5aFBFRWYOzs=", 
+            "RequestId": "BD15A6A9ADA5C64B", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "OCw+YkiUyoQC5EuKqnJwgfwggh1zMEf3SetNofF1RjUS2gLPDQZAsDrNEGLe4YEr5aFBFRWYOzs=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BD15A6A9ADA5C64B", 
+                "date": "Tue, 28 Mar 2017 21:12:11 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "scot-test2"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_5.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "Oj5WKjVfbcknFP9ZN5btDnKPgEUNatNJvO6stwvi6Y5N+cxuGh35O3M3jPXeD43q6aRwWpv/EPY=", 
+            "RequestId": "95E41412B2E3CA07", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Oj5WKjVfbcknFP9ZN5btDnKPgEUNatNJvO6stwvi6Y5N+cxuGh35O3M3jPXeD43q6aRwWpv/EPY=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "95E41412B2E3CA07", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "custodian-skunk-billing"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_6.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "1VSpnGLBDnx5ALjPZeABypmVGjVPiHaY7gf7wDwTmCMzEuiZ637SJ/lNWDyl9nDMYXOm7NzUcWM=", 
+            "RequestId": "CC268C4D9D9750D4", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "1VSpnGLBDnx5ALjPZeABypmVGjVPiHaY7gf7wDwTmCMzEuiZ637SJ/lNWDyl9nDMYXOm7NzUcWM=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "CC268C4D9D9750D4", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "ocampo-test"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_7.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "JfCO54Y0/+v2PsqoqsoUJ2BcVuS2pG+cwLbxe/VqjYERRbYCih4F7EDIvItptiX8wSLPpRrp7/A=", 
+            "RequestId": "3FB34BE9BDCB2C5E", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "JfCO54Y0/+v2PsqoqsoUJ2BcVuS2pG+cwLbxe/VqjYERRbYCih4F7EDIvItptiX8wSLPpRrp7/A=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "3FB34BE9BDCB2C5E", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "sphere11-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_8.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "P5+eqJQXz+Wi4b+04FdkWcXANTyZlMS2THg1j4Ulc2fF6xKIH033Gzavr3+sAeE4v8fx6A01xWw=", 
+            "RequestId": "4E606CCF470DE0B2", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "P5+eqJQXz+Wi4b+04FdkWcXANTyZlMS2THg1j4Ulc2fF6xKIH033Gzavr3+sAeE4v8fx6A01xWw=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "4E606CCF470DE0B2", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "custodian-skunk-trails"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketTagging_9.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "QFychzBPnBP1yGTJBbAfDzUUAFNGxDDU/tKKQMp2pykHofFQ85DASeKZWZPya1hE5UUU3fVf44o=", 
+            "RequestId": "414103A1AE8F0632", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "QFychzBPnBP1yGTJBbAfDzUUAFNGxDDU/tKKQMp2pykHofFQ85DASeKZWZPya1hE5UUU3fVf44o=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "414103A1AE8F0632", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The TagSet does not exist", 
+            "Code": "NoSuchTagSet", 
+            "BucketName": "sphere11-dev-us-west-2"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "HTm/VCyhhIByN/c9yMBocqTzfgO8GQRpPV+myP/LM7PLXFChZ3a7i//2257caGlX5oyOqQJWFFI=", 
+            "RequestId": "90611D57A97787FA", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "HTm/VCyhhIByN/c9yMBocqTzfgO8GQRpPV+myP/LM7PLXFChZ3a7i//2257caGlX5oyOqQJWFFI=", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "90611D57A97787FA", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_10.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "EZ6F3Ep4Ujx6J8ulYYlSlY/pW1ND18fwfkUVJbIbX+vG4cMiMObUda2SB9WuxcqNlRXT1HDkDx4=", 
+            "RequestId": "BE56C2F202372492", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "EZ6F3Ep4Ujx6J8ulYYlSlY/pW1ND18fwfkUVJbIbX+vG4cMiMObUda2SB9WuxcqNlRXT1HDkDx4=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BE56C2F202372492", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_11.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_11.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "pCoVXieHrwZuTlQpfQFwnboYxodbxltDQaAaiZtTrigRzlUxYSTJtf0VXiSsc3q3W2WUcj4ekBo=", 
+            "RequestId": "4BAFDD7798E89061", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "pCoVXieHrwZuTlQpfQFwnboYxodbxltDQaAaiZtTrigRzlUxYSTJtf0VXiSsc3q3W2WUcj4ekBo=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "4BAFDD7798E89061", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_2.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Status": "Enabled", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "ks7Dt6Ho9GXGH04wAjpl62MMtJC6zeak+01Gf6CRTxGKu7k+AjQ4XrnqUuvHKYkiG7c6Ya0JEHE=", 
+            "RequestId": "97F19115E9EAF62E", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "ks7Dt6Ho9GXGH04wAjpl62MMtJC6zeak+01Gf6CRTxGKu7k+AjQ4XrnqUuvHKYkiG7c6Ya0JEHE=", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "97F19115E9EAF62E", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_3.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "gfkHKQp/z1gVatY1UbkTCOCAQDkswZit/kyCPsZB7l7tpJOTAUOy2gVxtHAO75Z/NM3U+xcmat0=", 
+            "RequestId": "E2AE23FEC8A15FDD", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "gfkHKQp/z1gVatY1UbkTCOCAQDkswZit/kyCPsZB7l7tpJOTAUOy2gVxtHAO75Z/NM3U+xcmat0=", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "E2AE23FEC8A15FDD", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_4.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "JDVNlf7Zj4gc/N/VraSc5DbYrWpwIuAOJeys5Ph8OQ4B4LI4Vmaq2S8LNGcg0PT3jB1iCj3U09c=", 
+            "RequestId": "B16D85B624AC9B3A", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "JDVNlf7Zj4gc/N/VraSc5DbYrWpwIuAOJeys5Ph8OQ4B4LI4Vmaq2S8LNGcg0PT3jB1iCj3U09c=", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "B16D85B624AC9B3A", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_5.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "dlA5bfpj7sGTc2uOlOmRi2PCFfHyVz/9rKUiiW1jpmFV4nKkiU4X8C3EdbFkDGWwQ+tTj7O/cpc=", 
+            "RequestId": "8E78B788C7887F3F", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "dlA5bfpj7sGTc2uOlOmRi2PCFfHyVz/9rKUiiW1jpmFV4nKkiU4X8C3EdbFkDGWwQ+tTj7O/cpc=", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8E78B788C7887F3F", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_6.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "kPnF9vRwS0Q0NpD9Zf56smhgDl/5DZQbBHNt//2GOEFEEK/IwifcXSefnGZqbmuNZE/al7AsLeg=", 
+            "RequestId": "F0A470268E1B7F69", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "kPnF9vRwS0Q0NpD9Zf56smhgDl/5DZQbBHNt//2GOEFEEK/IwifcXSefnGZqbmuNZE/al7AsLeg=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "F0A470268E1B7F69", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_7.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "psI+564ZxSXI9djDExrjEf1mr87F9YVP3Lc+yG8grVWk23nIKMbM3GipVg8D+SdrZPWm7WRkDjE=", 
+            "RequestId": "B6B6005F53E36866", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "psI+564ZxSXI9djDExrjEf1mr87F9YVP3Lc+yG8grVWk23nIKMbM3GipVg8D+SdrZPWm7WRkDjE=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "B6B6005F53E36866", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_8.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Gu03w2+iXPouzLbhJCaePRj1olqm5DeaXxPEyLxJKYkFCwjihMl7SxGXsX0tbFjBMYFkcQfqmj4=", 
+            "RequestId": "C0C219A1D6F1C6FC", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Gu03w2+iXPouzLbhJCaePRj1olqm5DeaXxPEyLxJKYkFCwjihMl7SxGXsX0tbFjBMYFkcQfqmj4=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "C0C219A1D6F1C6FC", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketVersioning_9.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Status": "Enabled", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "s7wE+GEY3eOfPa6bvBsBtlDnvPIr3UdGLa8L558HktptD3Bos26VG1DZI3w66CBI4lJGSpmPWoU=", 
+            "RequestId": "E52266DBC4F72AD1", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "s7wE+GEY3eOfPa6bvBsBtlDnvPIr3UdGLa8L558HktptD3Bos26VG1DZI3w66CBI4lJGSpmPWoU=", 
+                "date": "Tue, 28 Mar 2017 21:12:14 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "E52266DBC4F72AD1", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "SRU6ZqcA5RjL1OJUMqzZXEIqesZwJI/Hgfl0FyR/8PBsYcI1wA7LJyAv8imY1wFg6FfeuhXCJp8=", 
+            "RequestId": "771F71B5BF7F1E3D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "SRU6ZqcA5RjL1OJUMqzZXEIqesZwJI/Hgfl0FyR/8PBsYcI1wA7LJyAv8imY1wFg6FfeuhXCJp8=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "771F71B5BF7F1E3D", 
+                "date": "Tue, 28 Mar 2017 21:12:11 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "config-bucket-644160558196"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_10.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_10.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "bbrCt92sHMbGTtTPsc2MDu54M/+dRu/6XC/6kkh593WAVdIratEZfbCWIVuasBqMAgblnI/mTpU=", 
+            "RequestId": "07F22994510E62CD", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "bbrCt92sHMbGTtTPsc2MDu54M/+dRu/6XC/6kkh593WAVdIratEZfbCWIVuasBqMAgblnI/mTpU=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "07F22994510E62CD", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "scot-test2"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_11.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_11.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "H/FIg1vOvswEnGfq/JRDKX+Ipi1zmN52pfOm9UKBT4UrNgsInJxhCk7QyBWe+ECGN6BPmuzurds=", 
+            "RequestId": "BE5D65ECD4762FED", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "H/FIg1vOvswEnGfq/JRDKX+Ipi1zmN52pfOm9UKBT4UrNgsInJxhCk7QyBWe+ECGN6BPmuzurds=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BE5D65ECD4762FED", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "sphere11-us-west-2-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_2.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_2.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "ubbC3H/ukz7sM0m2i4zT7buO/0iqfTLyAk+cNYPoznLZxHXnqVu2BFkiNY4JkVvXhFvLjNFC0yA=", 
+            "RequestId": "16B4AAA1AA935459", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "ubbC3H/ukz7sM0m2i4zT7buO/0iqfTLyAk+cNYPoznLZxHXnqVu2BFkiNY4JkVvXhFvLjNFC0yA=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "16B4AAA1AA935459", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "custodian-replicated-west"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_3.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_3.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "vEpgZy9qVjGBv9xDDb3BrMwlKj0SCgihBzl9flkAmwTIz60YglyRiZ2Y1nd3s3HzAEWMDldKHD0=", 
+            "RequestId": "6A9E6E3B14C2E34D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "vEpgZy9qVjGBv9xDDb3BrMwlKj0SCgihBzl9flkAmwTIz60YglyRiZ2Y1nd3s3HzAEWMDldKHD0=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "6A9E6E3B14C2E34D", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "config-rule-sanity"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_4.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_4.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "ecMV+IF6INfAFW0Bvy3djB+WaIUpTGI/dLwNiYWzRTcykG0XdFCcyygCXr5UzGiOvSI4+7zZU0Y=", 
+            "RequestId": "5710A277F94F361D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "ecMV+IF6INfAFW0Bvy3djB+WaIUpTGI/dLwNiYWzRTcykG0XdFCcyygCXr5UzGiOvSI4+7zZU0Y=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "5710A277F94F361D", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "scot-test"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_5.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_5.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "IVN+QG2Ec/A8z1npHF5qYtQCuOvCc8+xFE6cGDwZZli4Ipo9dkqMkYJxyPEGSfOeAThVb6CnQoQ=", 
+            "RequestId": "90177D8E915B2127", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "IVN+QG2Ec/A8z1npHF5qYtQCuOvCc8+xFE6cGDwZZli4Ipo9dkqMkYJxyPEGSfOeAThVb6CnQoQ=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "90177D8E915B2127", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "custodian-skunk-billing"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_6.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_6.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "DVFdhsjS3OmhQP9EFQWQv+hIZNQrxmPG10wvhwKykquR42b/SJrfeI0+cu/aemmIiLDeDx3x9II=", 
+            "RequestId": "CCC6E4EBC8D2F9A4", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "DVFdhsjS3OmhQP9EFQWQv+hIZNQrxmPG10wvhwKykquR42b/SJrfeI0+cu/aemmIiLDeDx3x9II=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "CCC6E4EBC8D2F9A4", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "ocampo-test"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_7.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_7.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "kwYEtBJmA7taecPD//DQmoPx+enBFHW/cAebadk2K16MeFirPPIxkGWnxauw6KSlBCmNXvxWf4Y=", 
+            "RequestId": "B818E803704BE3D5", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "kwYEtBJmA7taecPD//DQmoPx+enBFHW/cAebadk2K16MeFirPPIxkGWnxauw6KSlBCmNXvxWf4Y=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "B818E803704BE3D5", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "sphere11-dev"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_8.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_8.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "S87Gg/R5ZGFoN2hXteUF2evSqwwkZT68Mzewnvko0Kpn3Hv0zeBui0KmGUCxhiDese2lvIgzJ1U=", 
+            "RequestId": "8AB2050C9A83FA15", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "S87Gg/R5ZGFoN2hXteUF2evSqwwkZT68Mzewnvko0Kpn3Hv0zeBui0KmGUCxhiDese2lvIgzJ1U=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8AB2050C9A83FA15", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "custodian-skunk-trails"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_9.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.GetBucketWebsite_9.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "RetryAttempts": 0, 
+            "HostId": "+SoDiyPBLtMe8dpPfTsV2ahgFAw+ahOr8YisebzBO5qzTMr53XD2wmMkX3x9O9FC3AUOg4jBNfc=", 
+            "RequestId": "17A1DF0E630EFD8B", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "+SoDiyPBLtMe8dpPfTsV2ahgFAw+ahOr8YisebzBO5qzTMr53XD2wmMkX3x9O9FC3AUOg4jBNfc=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "17A1DF0E630EFD8B", 
+                "date": "Tue, 28 Mar 2017 21:12:13 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified bucket does not have a website configuration", 
+            "Code": "NoSuchWebsiteConfiguration", 
+            "BucketName": "sphere11-dev-us-west-2"
+        }
+    }
+}

--- a/tests/data/placebo/s3encryptionmissingtest/s3.ListBuckets_1.json
+++ b/tests/data/placebo/s3encryptionmissingtest/s3.ListBuckets_1.json
@@ -1,0 +1,168 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 11, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 6
+                }, 
+                "Name": "config-rule-sanity"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 22, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 7, 
+                    "minute": 57
+                }, 
+                "Name": "custodian-replicated-west"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 19
+                }, 
+                "Name": "custodian-skunk-billing"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 6, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 7, 
+                    "minute": 53
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 22, 
+                    "minute": 18
+                }, 
+                "Name": "ocampo-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 24, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 19, 
+                    "minute": 32
+                }, 
+                "Name": "scot-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 17, 
+                    "minute": 16
+                }, 
+                "Name": "scot-test2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 4, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 9, 
+                    "minute": 46
+                }, 
+                "Name": "sphere11-dev"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 34, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 15
+                }, 
+                "Name": "sphere11-dev-us-west-2"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 48, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 14
+                }, 
+                "Name": "sphere11-us-west-2-dev"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "spEks3dJ1Sh4K/7p8yrUktIU5gDCHzjKkITua+yKbcxtS3b8qmQbJuuq1aiw8zbc94wNMpdTZeM=", 
+            "RequestId": "8DEFC787296E221F", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "spEks3dJ1Sh4K/7p8yrUktIU5gDCHzjKkITua+yKbcxtS3b8qmQbJuuq1aiw8zbc94wNMpdTZeM=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "8DEFC787296E221F", 
+                "date": "Tue, 28 Mar 2017 21:12:12 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/test_s3encryptionmissing_filter.py
+++ b/tests/test_s3encryptionmissing_filter.py
@@ -1,0 +1,64 @@
+# Copyright 2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common import BaseTest
+import yaml
+
+from c7n.resources.s3 import S3EncryptionMissingFilter
+
+
+class TestS3EncryptionMissingFilter(BaseTest):
+    def test_an_encryptionrequired_resource(self):
+        f = S3EncryptionMissingFilter({})
+        res = f({'Policy': '{"name":"testbucket", "Statement": [{"Sid":"RequiredEncryptedPutObject"}]}'})
+        self.assertFalse(res, "testbucket should have been recognized for omission.")
+
+    def test_a_nonencryptionrequired_resource(self):
+        f = S3EncryptionMissingFilter({})
+        res = f({'Policy': '{"name":"testbucket", "Statement": [{"Sid":"RequiredSomethingUnrelated"}]}'})
+        self.assertTrue(res, "testbucket should NOT have been recognized.")
+
+    def test_a_nonencryptionrequired_resource_with_no_policy(self):
+        f = S3EncryptionMissingFilter({})
+        res = f({'Policy': None})
+        self.assertTrue(res, "testbucket should have been recognized as missing the encryption policy.")
+
+    def _get_test_policy(self, name, yaml_doc, record=False):
+        if record:
+            print "Test is RECORDING"
+            session_factory = self.record_flight_data(name)
+        else:
+            print "Test is replaying"
+            session_factory = self.replay_flight_data(name)
+
+        policy = self.load_policy( yaml.load(yaml_doc)['policies'][0], session_factory=session_factory)
+
+        return policy
+
+    def test_against_sandbox(self):
+        yml = '''
+            policies:
+              - name: find-buckets_missing_encryption
+                resource: s3
+                filters:
+                  - s3-encryption-missing
+                actions:
+                  - type: no-op
+        '''
+        policy = self._get_test_policy(name="s3encryptionmissingtest", yaml_doc=yml, record=False)
+        resources = policy.run()
+        from pprint import pprint
+        pprint(resources)
+        self.assertEqual(len(resources), 10, "10 out of 11 buckets should be returned for not having the requisite"
+                         " encryption policy statement.")


### PR DESCRIPTION
Here's the filter and test code.    The filter's name is 's3-encryption-missing'
Can be used with a policy like so:

policies:
  - name: find-buckets_missing_encryption
    resource: s3
    filters:
      - s3-encryption-missing
    actions:
      - type: no-op
