### PR TITLE
S3 Encryption filter

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -434,6 +434,10 @@ class EncryptionEnabledFilter(Filter):
     schema = type_schema(
         'no-encryption-statement')
 
+    def get_permissions(self):
+        perms = self.manager.get_resource_manager('s3').get_permissions()
+        return perms
+
     def process(self, buckets, event=None):
         return filter(None, map(self.process_bucket, buckets))
 

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -408,6 +408,62 @@ class HasStatementFilter(Filter):
         return None
 
 
+ENCRYPTION_STATEMENT_GLOB = {
+            'Effect': 'Deny',
+            'Principal': '*',
+            'Action': 's3:PutObject',
+            "Condition": {
+                "StringNotEquals": {
+                    "s3:x-amz-server-side-encryption": ["AES256", "aws:kms"]}}}
+
+
+@filters.register('no-encryption-statement')
+class EncryptionEnabledFilter(Filter):
+    """Find buckets with missing encryption policy statements.
+
+    :example:
+
+        .. code-block: yaml
+
+            policies:
+              - name: s3-bucket-not-encrypted
+                resource: s3
+                filters:
+                  - type: no-encryption-statement
+    """
+    schema = type_schema(
+        'no-encryption-statement')
+
+    def process(self, buckets, event=None):
+        return filter(None, map(self.process_bucket, buckets))
+
+    def process_bucket(self, b):
+        p = b.get('Policy')
+        if p is None:
+            return b
+        p = json.loads(p)
+        encryption_statement = ENCRYPTION_STATEMENT_GLOB
+
+        statements = p.get('Statement', [])
+        check = False
+        for s in list(statements):
+            try:
+                encryption_statement["Sid"] = s["Sid"]
+            except:
+                log.info("Bucket:%s doesn't have Sid" % b['Name'])
+
+            encryption_statement["Resource"] = s["Resource"]
+            if s == encryption_statement:
+                log.info(
+                    "Bucket:%s contains correct encryption policy", b['Name'])
+                check = True
+                break
+        if check:
+            return None
+        else:
+            return b
+
+
 @filters.register('missing-statement')
 @filters.register('missing-policy-statement')
 class MissingPolicyStatementFilter(Filter):

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.CreateBucket_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-policy-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "BUBh59aj1IUDmGhDTANjcVAPd0kHCZ7DmvkFeq87A8OXZl7+ab9EBeSu7lepEaih7fqQJVOIhhI=", 
+            "RequestId": "20062D9C9972D843"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.DeleteBucket_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "XdFLAsCakeeyIL0Jn4/SFlWmkIJCtZ4RqLxBZC8sggvLnWw2jTu0vxPEfibpmszCT1JvGRVZ+bw=", 
+            "RequestId": "3C297A1E9E733A21"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.GetBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.GetBucketPolicy_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "HostId": "N/r54UyuioFB+1JEh4nEgIfbuqiWpayzIIIpHtqGizi5RFZcXhibOGyarc8hJgvg2LB+JsU1L4Q=", 
+            "RequestId": "8E4B0DD43705C703"
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "custodian-encryption-test"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.GetBucketPolicy_2.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.GetBucketPolicy_2.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "HostId": "dNEMxpHojUF874nF2mlg5ME/edI981nnx8hSN+Ite3NeaoKdqtRlyt+JfkeV/YuTpU/RVjEKdOc=", 
+            "RequestId": "7FEBB8E0DA3C7084"
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "custodian-encryption-test"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.GetBucketPolicy_3.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.GetBucketPolicy_3.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"RequiredEncryptedObject\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}}]}",
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "jL1IZT8BmFaliIyAn7834ng9hk11JPgxBLJYNMg2IPtcu8A6MVtzs/Yz6FMO5IVe4exEBQIGvGg=", 
+            "RequestId": "2592899758274ED6"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.ListBuckets_1.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "k_vertigo", 
+            "ID": "904fc4c4790937100e9eb293a15e6a0a1f265a064888055b43d030034f8881ee"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2013, 
+                    "day": 21, 
+                    "minute": 12
+                }, 
+                "Name": "custodian-encryption-test"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "N4Ka3KSZO3Y3s5B83Kspi9VvuUEVx9p6UaiQkBxmyslMUZtOQB/75F61oq9wsE1fHn07nK0sMKo=", 
+            "RequestId": "80ED9683CA2CAB57"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.ListObjects_1.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.ListObjects_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "MaxKeys": 1000, 
+        "Prefix": "", 
+        "Name": "custodian-policy-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "q5PdMSuJxDD6D9rEZMcXpasl5NTJP5CqDVwmQg23waLxzjW2RIS8D/in+ozutEQ0W/jZvMrMGv0=", 
+            "RequestId": "2CA9F6362A4E53BF"
+        }, 
+        "Marker": "", 
+        "EncodingType": "url", 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_s3_no_encryption_statement/s3.PutBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_no_encryption_statement/s3.PutBucketPolicy_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "DVtRLymbtCcgGHevhBN5d27KUXmZzFfpvdJkNIljMTOJ8zKt2qw517MPhNCSacULO0Yw12KXxzw=", 
+            "RequestId": "96D458223D9AF7EA"
+        }
+    }
+}

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -482,6 +482,44 @@ class S3Test(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
 
+    def test_no_encryption_statement(self):
+        self.patch(s3.S3, 'executor_factory', MainThreadExecutor)
+        self.patch(
+            s3.MissingPolicyStatementFilter, 'executor_factory',
+            MainThreadExecutor)
+        self.patch(s3, 'S3_AUGMENT_TABLE', [
+            ('get_bucket_policy',  'Policy', None, 'Policy'),
+        ])
+        session_factory = self.replay_flight_data('test_s3_no_encryption_statement')
+        bname = "custodian-encryption-test"
+        session = session_factory()
+        client = session.client('s3')
+        client.create_bucket(Bucket=bname)
+        self.addCleanup(destroyBucket, client, bname)
+        client.put_bucket_policy(
+            Bucket=bname,
+            Policy=json.dumps({
+                'Version': '2017-3-28',
+                'Statement': [{
+                    'Sid': 'RequiredEncryptedObject',
+                    'Effect': 'Allow',
+                    'Principal': '*',
+                    'Action': 's3:PutObject',
+                    'Resource': 'arn:aws:s3:::%s/*' % bname,
+                    'Condition': {
+                        'StringNotEquals': {
+                            's3:x-amz-server-side-encryption': [
+                                'AES256', 'aws:kms']}}}]}))
+        p = self.load_policy({
+            'name': 's3-no-encryption-policy',
+            'resource': 's3',
+            'filters': [
+                {'Name': bname},
+                {'type': 'no-encryption-statement'}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_missing_policy_statement(self):
         self.patch(s3.S3, 'executor_factory', MainThreadExecutor)
         self.patch(


### PR DESCRIPTION
Add "no-encryption-statement" filter to s3 to compare actual contents inside bucket statements and filter in buckets which allow uploads of unencrypted objects. Issue #550 