### PR TITLE
Updates lambda policy docs to reflect expanded cwe shortcut

### DIFF
--- a/docs/source/policy/lambda.rst
+++ b/docs/source/policy/lambda.rst
@@ -78,7 +78,7 @@ have been defined to allow for easier policy writing as for the
      events:
       - source: ec2.amazonaws.com
         event: RunInstances
-        ids: "detail.responseElements.instancesSet.items[].instanceId"
+        ids: "responseElements.instancesSet.items[].instanceId"
 
 
 EC2 Instance State Events


### PR DESCRIPTION
Updates the documentation for the cwe shortcut expansion (http://www.capitalone.io/cloud-custodian/docs/policy/lambda.html#cloudtrail-api-calls) to match the actual expansion (https://github.com/capitalone/cloud-custodian/blob/master/c7n/cwe.py#L68)