### PR TITLE
Correct return object of check-cloudtrail

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -151,7 +151,7 @@ class CloudTrailEnabled(Filter):
                     running.append(t)
             trails = running
         if trails:
-            return []
+            return trails
         return resources
 
 


### PR DESCRIPTION
Function currently returns [] regardless of result