### PR TITLE
Botocore upgrade in requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 argcomplete>=1.8.2
 boto3>=1.4.4
-botocore>=1.5.13
+botocore>=1.5.43
 ipaddress>=1.0.16
 jsonschema>=2.5.1
 PyYAML>=3.12


### PR DESCRIPTION
We use lambda `list_tags` which is not available in the botocore version we had in the requirements file.  I updated it to the latest.