### PR TITLE
S3 bucket location restriction

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -230,6 +230,23 @@ class S3Metrics(MetricsFilter):
              'Value': 'AllStorageTypes'}]
 
 
+@filters.register('location-restriction')
+class LocationRestriction(Filter):
+    """
+    Filters for returning S3 buckets that do not match location restriction
+
+    - type: location-restriction
+      value: us-west-2
+
+    """
+    schema = type_schema('location-restriction', value={'type': 'string'})
+    permissions = ('s3:GetBucketLocation',)
+    def process(self, buckets, event=None):
+        if self.data.get('value'):
+            return [b for b in buckets if not self.data.get('value').lower() == b.get('Location').get('LocationConstraint') ]
+        return []
+
+
 @filters.register('cross-account')
 class S3CrossAccountFilter(CrossAccountAccessFilter):
     """Filters cross-account access to S3 buckets

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -232,18 +232,26 @@ class S3Metrics(MetricsFilter):
 
 @filters.register('location-restriction')
 class LocationRestriction(Filter):
-    """
-    Filters for returning S3 buckets that do not match location restriction
+    """ Filters for returning S3 buckets that are not in white-listed location
+    
+    For example, if the user wants to loop through all regions and identify buckets in non-whitelisted locations (Singapore, Oregon):
 
-    - type: location-restriction
-      value: us-west-2
+    .. code-block: yaml
+
+      - name: s3-identify-location
+        resource: s3
+        filters:
+          - type: location-restriction
+            value: 
+              - ap-southeast-1
+              - us-west-2
 
     """
-    schema = type_schema('location-restriction', value={'type': 'string'})
+    schema = type_schema('location-restriction', value={'type': 'array'})
     permissions = ('s3:GetBucketLocation',)
     def process(self, buckets, event=None):
         if self.data.get('value'):
-            return [b for b in buckets if not self.data.get('value').lower() == b.get('Location').get('LocationConstraint') ]
+            return [b for b in buckets if not b.get('Location').get('LocationConstraint') in self.data.get('value') ]
         return []
 
 

--- a/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_1.json
+++ b/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+	"IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+                "date": "Fri, 30 Sep 2016 16:59:42 GMT",
+                "content-length": "323",
+                "content-type": "text/xml"
+            }
+        },
+
+    "LocationConstraint": null
+}
+
+}

--- a/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_2.json
+++ b/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_2.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+	"IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+                "date": "Fri, 30 Sep 2016 16:59:42 GMT",
+                "content-length": "323",
+                "content-type": "text/xml"
+            }
+        },
+
+    "LocationConstraint": "ap-southeast-2"
+}
+
+}
+

--- a/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_3.json
+++ b/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_3.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data":
+{
+	"IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+                "date": "Fri, 30 Sep 2016 16:59:42 GMT",
+                "content-length": "323",
+                "content-type": "text/xml"
+            }
+        },
+    "LocationConstraint": "ap-southeast-1"
+}
+
+}

--- a/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_4.json
+++ b/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_4.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data":
+{
+	"IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+                "date": "Fri, 30 Sep 2016 16:59:42 GMT",
+                "content-length": "323",
+                "content-type": "text/xml"
+            }
+        },
+
+    "LocationConstraint": "us-west-2"
+}
+
+}

--- a/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_5.json
+++ b/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_5.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data":
+{
+	"IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+                "date": "Fri, 30 Sep 2016 16:59:42 GMT",
+                "content-length": "323",
+                "content-type": "text/xml"
+            }
+        },
+
+    "LocationConstraint": "us-west-1"
+}
+
+}

--- a/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_6.json
+++ b/tests/data/placebo/test_s3_location_restriction/s3.GetBucketLocation_6.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data":
+{
+	"IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+                "date": "Fri, 30 Sep 2016 16:59:42 GMT",
+                "content-length": "323",
+                "content-type": "text/xml"
+            }
+        },
+    "LocationConstraint": "eu-west-2"
+}
+
+}

--- a/tests/data/placebo/test_s3_location_restriction/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_location_restriction/s3.ListBuckets_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200,
+    "data":
+{
+	"IsTruncated": false,
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "482892b8-872f-11e6-acfe-07a6295c8f0a",
+                "date": "Fri, 30 Sep 2016 16:59:42 GMT",
+                "content-length": "323",
+                "content-type": "text/xml"
+            }
+        },
+
+    "Owner": {
+        "DisplayName": "custodian-tests",
+        "ID": "13dc366338eieud820jwfb05cf04ca3009a783d33add02097647ekei28whrm91"
+    },
+    "Buckets": [
+        {
+            "CreationDate": "2015-04-20T04:58:46.000Z",
+            "Name": "bucketne-mau4ch5degbr"
+        },
+        {
+            "CreationDate": "2016-04-24T06:33:40.000Z",
+            "Name": "ajc-ctbucket-1q"
+        },
+        {
+            "CreationDate": "2014-04-20T04:11:03.000Z",
+            "Name": "nzpoctemplates"
+        },
+	{
+            "CreationDate": "2015-04-20T04:11:46.000Z",
+            "Name": "bucket-xxxxxxxxx"
+        },
+        {
+            "CreationDate": "2016-04-24T02:33:40.000Z",
+            "Name": "test-bucket"
+        },
+        {
+            "CreationDate": "2014-04-20T04:11:03.000Z",
+            "Name": "mnbvcxz"
+        }
+    ]
+}
+
+}


### PR DESCRIPTION
Add filter to identify S3 buckets not residing within white-listed region, useful for account wide scanning of dormant or ninja resources