### PR TITLE
Health in regions other than us-east-1

### DIFF
--- a/c7n/filters/health.py
+++ b/c7n/filters/health.py
@@ -42,7 +42,7 @@ class HealthEventFilter(Filter):
 
         client = local_session(self.manager.session_factory).client(
             'health', region_name='us-east-1')
-        f = self.get_filter()
+        f = self.get_filter_parameters()
         resource_map = {r[self.manager.get_model().id]: r for r in resources}
         found = set()
         seen = set()
@@ -51,8 +51,7 @@ class HealthEventFilter(Filter):
             f['entityValues'] = resource_set
             events = client.describe_events(filter=f)['events']
             events = [e for e in events if e['arn'] not in seen]
-            entities = []
-            self.process_event(events, entities)
+            entities = self.process_event(events)
 
             event_map = {e['arn']: e for e in events}
             for e in entities:
@@ -65,7 +64,7 @@ class HealthEventFilter(Filter):
             seen.update(event_map.keys())
         return [resource_map[rid] for rid in found]
 
-    def get_filter(self):
+    def get_filter_parameters(self):
         m = self.manager
         if m.data['resource'] == 'ebs':
             service = 'EBS'
@@ -78,7 +77,8 @@ class HealthEventFilter(Filter):
             f['eventTypeCodes'] = self.data.get('types')
         return f
 
-    def process_event(self, health_events, entities):
+    def process_event(self, health_events):
+        entities = []
         client = local_session(self.manager.session_factory).client(
             'health', region_name='us-east-1')
         for event_set in chunks(health_events, 10):
@@ -91,3 +91,4 @@ class HealthEventFilter(Filter):
             entities.extend(list(itertools.chain(
                             *[p['entities']for p in paginator.paginate(
                                 filter={'eventArns': event_map.keys()})])))
+        return entities

--- a/c7n/filters/health.py
+++ b/c7n/filters/health.py
@@ -40,7 +40,11 @@ class HealthEventFilter(Filter):
         if not resources:
             return resources
 
-        client = local_session(self.manager.session_factory).client('health')
+        if self.manager.config.region == 'us-east-1':
+            session = local_session(self.manager.session_factory)
+        else:
+            session = self.manager.session_factory(region='us-east-1')
+        client = session.client('health')
         f = self.get_filter()
         resource_map = {r[self.manager.get_model().id]: r for r in resources}
         found = set()

--- a/c7n/filters/health.py
+++ b/c7n/filters/health.py
@@ -40,11 +40,8 @@ class HealthEventFilter(Filter):
         if not resources:
             return resources
 
-        if self.manager.config.region == 'us-east-1':
-            session = local_session(self.manager.session_factory)
-        else:
-            session = self.manager.session_factory(region='us-east-1')
-        client = session.client('health')
+        client = local_session(self.manager.session_factory).client(
+            'health', region_name='us-east-1')
         f = self.get_filter()
         resource_map = {r[self.manager.get_model().id]: r for r in resources}
         found = set()
@@ -82,7 +79,8 @@ class HealthEventFilter(Filter):
         return f
 
     def process_event(self, health_events, entities):
-        client = local_session(self.manager.session_factory).client('health')
+        client = local_session(self.manager.session_factory).client(
+            'health', region_name='us-east-1')
         for event_set in chunks(health_events, 10):
             event_map = {e['arn']: e for e in event_set}
             for d in client.describe_event_details(

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -472,7 +472,8 @@ class HealthFilter(HealthEventFilter):
         if not resources:
             return resources
 
-        client = local_session(self.manager.session_factory).client('health')
+        client = local_session(self.manager.session_factory).client(
+            'health', region_name='us-east-1')
         f = self.get_filter()
         resource_map = {}
 

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -474,14 +474,13 @@ class HealthFilter(HealthEventFilter):
 
         client = local_session(self.manager.session_factory).client(
             'health', region_name='us-east-1')
-        f = self.get_filter()
+        f = self.get_filter_parameters()
         resource_map = {}
 
         paginator = client.get_paginator('describe_events')
         events = list(itertools.chain(
             *[p['events']for p in paginator.paginate(filter=f)]))
-        entities = []
-        self.process_event(events, entities)
+        entities = self.process_event(events)
 
         event_map = {e['arn']: e for e in events}
         for e in entities:

--- a/c7n/resources/health.py
+++ b/c7n/resources/health.py
@@ -40,6 +40,9 @@ class HealthEvents(QueryResourceManager):
         'health:DescribeAffectedEntities')
 
     def __init__(self, ctx, data):
+        if ctx.options.region != 'us-east-1':
+            raise ValueError(
+                'resource:health-event is only available in us-east-1')
         super(HealthEvents, self).__init__(ctx, data)
         self.queries = QueryFilter.parse(
             self.data.get('query', [

--- a/tests/data/placebo/test_ec2_health_events_filter/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_health_events_filter/ec2.DescribeInstances_1.json
@@ -1,17 +1,406 @@
 {
     "status_code": 200, 
     "data": {
-        "Reservations": [], 
+        "Reservations": [
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-0e5fa0bb3af3dee00", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "", 
+                        "RootDeviceType": "ebs", 
+                        "State": {
+                            "Code": 80, 
+                            "Name": "stopped"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 1, 
+                            "__class__": "datetime", 
+                            "month": 4, 
+                            "second": 39, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 3, 
+                            "minute": 34
+                        }, 
+                        "PrivateIpAddress": "172.31.62.61", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "User initiated (2017-04-04 12:27:48 GMT)", 
+                        "InstanceId": "i-0aace5764d21d3105", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-62-61.ec2.internal", 
+                        "KeyName": "scot", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-15", 
+                                "GroupId": "sg-f7117688"
+                            }
+                        ], 
+                        "ClientToken": "WqUbW1491183279011", 
+                        "SubnetId": "subnet-3a334610", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "12:52:99:dc:96:6e", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "NetworkInterfaceId": "eni-ce54683a", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-62-61.ec2.internal", 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.62.61"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-62-61.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-67e3864b", 
+                                    "AttachTime": {
+                                        "hour": 1, 
+                                        "__class__": "datetime", 
+                                        "month": 4, 
+                                        "second": 39, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 3, 
+                                        "minute": 34
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-15", 
+                                        "GroupId": "sg-f7117688"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-3a334610", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.62.61"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1d"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-0b5bc31549f55bdd2", 
+                                    "AttachTime": {
+                                        "hour": 1, 
+                                        "__class__": "datetime", 
+                                        "month": 4, 
+                                        "second": 40, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 3, 
+                                        "minute": 34
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "StateReason": {
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown", 
+                            "Code": "Client.UserInitiatedShutdown"
+                        }, 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "Tags": [
+                            {
+                                "Value": "2017-04-10", 
+                                "Key": "expiration"
+                            }
+                        ], 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }, 
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-01054e3c8ee6075e6", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "", 
+                        "RootDeviceType": "ebs", 
+                        "State": {
+                            "Code": 80, 
+                            "Name": "stopped"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 14, 
+                            "__class__": "datetime", 
+                            "month": 3, 
+                            "second": 27, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 28, 
+                            "minute": 55
+                        }, 
+                        "PrivateIpAddress": "172.31.28.33", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "User initiated (2017-04-03 01:32:42 GMT)", 
+                        "InstanceId": "i-0a0b51bcf11a8cdfb", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-0b33d91d", 
+                        "PrivateDnsName": "ip-172-31-28-33.ec2.internal", 
+                        "KeyName": "calvin-east-1", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-14", 
+                                "GroupId": "sg-fc46c983"
+                            }
+                        ], 
+                        "ClientToken": "tJMFV1490712926683", 
+                        "SubnetId": "subnet-efbcccb7", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:63:aa:34:b4:02", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "NetworkInterfaceId": "eni-2de6aceb", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-28-33.ec2.internal", 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "172.31.28.33"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-28-33.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-a6156bf6", 
+                                    "AttachTime": {
+                                        "hour": 14, 
+                                        "__class__": "datetime", 
+                                        "month": 3, 
+                                        "second": 27, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 28, 
+                                        "minute": 55
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-14", 
+                                        "GroupId": "sg-fc46c983"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-efbcccb7", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.28.33"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-01adbb6a4f175941d", 
+                                    "AttachTime": {
+                                        "hour": 14, 
+                                        "__class__": "datetime", 
+                                        "month": 3, 
+                                        "second": 28, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 28, 
+                                        "minute": 55
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "StateReason": {
+                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown", 
+                            "Code": "Client.UserInitiatedShutdown"
+                        }, 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "Tags": [
+                            {
+                                "Value": "2017-04-13", 
+                                "Key": "expiration"
+                            }
+                        ], 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }, 
+            {
+                "OwnerId": "644160558196", 
+                "ReservationId": "r-052b81d37c4baa7b0", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 20, 
+                            "__class__": "datetime", 
+                            "month": 4, 
+                            "second": 21, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 10, 
+                            "minute": 41
+                        }, 
+                        "PrivateIpAddress": "10.0.42.59", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-f1516b97", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-0be2fdca058278ea3", 
+                        "ImageId": "ami-f4cc1de2", 
+                        "PrivateDnsName": "ip-10-0-42-59.ec2.internal", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "FancyTestGroupPublic", 
+                                "GroupId": "sg-f8c78787"
+                            }
+                        ], 
+                        "ClientToken": "Gjqgm1491856879879", 
+                        "SubnetId": "subnet-6f273034", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "0e:13:c9:48:3d:58", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-f1516b97", 
+                                "Description": "Primary network interface", 
+                                "NetworkInterfaceId": "eni-67d758be", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "10.0.42.59"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-aab053f9", 
+                                    "AttachTime": {
+                                        "hour": 20, 
+                                        "__class__": "datetime", 
+                                        "month": 4, 
+                                        "second": 21, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 10, 
+                                        "minute": 41
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "FancyTestGroupPublic", 
+                                        "GroupId": "sg-f8c78787"
+                                    }
+                                ], 
+                                "SubnetId": "subnet-6f273034", 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "10.0.42.59"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1b"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/sda1", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-0252f61378ede9d01", 
+                                    "AttachTime": {
+                                        "hour": 20, 
+                                        "__class__": "datetime", 
+                                        "month": 4, 
+                                        "second": 21, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 10, 
+                                        "minute": 41
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/sda1", 
+                        "VirtualizationType": "hvm", 
+                        "Tags": [
+                            {
+                                "Value": "FancyTestInstancePrivate", 
+                                "Key": "Name"
+                            }
+                        ], 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            }
+        ], 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "9102e013-d8c9-419a-85f5-bda018423301", 
+            "RequestId": "9e654cf7-626c-4f37-9d7b-11cf333509c2", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "vary": "Accept-Encoding", 
                 "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Thu, 09 Feb 2017 21:29:31 GMT"
+                "date": "Fri, 28 Apr 2017 18:52:31 GMT"
             }
         }
     }

--- a/tests/data/placebo/test_ec2_health_events_filter/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_health_events_filter/ec2.DescribeInstances_1.json
@@ -1,274 +1,10 @@
 {
     "status_code": 200, 
     "data": {
-        "Reservations": [
+        "Reservations": [ 
             {
                 "OwnerId": "644160558196", 
-                "ReservationId": "r-0e5fa0bb3af3dee00", 
-                "Groups": [], 
-                "Instances": [
-                    {
-                        "Monitoring": {
-                            "State": "disabled"
-                        }, 
-                        "PublicDnsName": "", 
-                        "RootDeviceType": "ebs", 
-                        "State": {
-                            "Code": 80, 
-                            "Name": "stopped"
-                        }, 
-                        "EbsOptimized": false, 
-                        "LaunchTime": {
-                            "hour": 1, 
-                            "__class__": "datetime", 
-                            "month": 4, 
-                            "second": 39, 
-                            "microsecond": 0, 
-                            "year": 2017, 
-                            "day": 3, 
-                            "minute": 34
-                        }, 
-                        "PrivateIpAddress": "172.31.62.61", 
-                        "ProductCodes": [], 
-                        "VpcId": "vpc-d2d616b5", 
-                        "StateTransitionReason": "User initiated (2017-04-04 12:27:48 GMT)", 
-                        "InstanceId": "i-0aace5764d21d3105", 
-                        "EnaSupport": true, 
-                        "ImageId": "ami-0b33d91d", 
-                        "PrivateDnsName": "ip-172-31-62-61.ec2.internal", 
-                        "KeyName": "scot", 
-                        "SecurityGroups": [
-                            {
-                                "GroupName": "launch-wizard-15", 
-                                "GroupId": "sg-f7117688"
-                            }
-                        ], 
-                        "ClientToken": "WqUbW1491183279011", 
-                        "SubnetId": "subnet-3a334610", 
-                        "InstanceType": "t2.micro", 
-                        "NetworkInterfaces": [
-                            {
-                                "Status": "in-use", 
-                                "MacAddress": "12:52:99:dc:96:6e", 
-                                "SourceDestCheck": true, 
-                                "VpcId": "vpc-d2d616b5", 
-                                "Description": "", 
-                                "NetworkInterfaceId": "eni-ce54683a", 
-                                "PrivateIpAddresses": [
-                                    {
-                                        "PrivateDnsName": "ip-172-31-62-61.ec2.internal", 
-                                        "Primary": true, 
-                                        "PrivateIpAddress": "172.31.62.61"
-                                    }
-                                ], 
-                                "PrivateDnsName": "ip-172-31-62-61.ec2.internal", 
-                                "Attachment": {
-                                    "Status": "attached", 
-                                    "DeviceIndex": 0, 
-                                    "DeleteOnTermination": true, 
-                                    "AttachmentId": "eni-attach-67e3864b", 
-                                    "AttachTime": {
-                                        "hour": 1, 
-                                        "__class__": "datetime", 
-                                        "month": 4, 
-                                        "second": 39, 
-                                        "microsecond": 0, 
-                                        "year": 2017, 
-                                        "day": 3, 
-                                        "minute": 34
-                                    }
-                                }, 
-                                "Groups": [
-                                    {
-                                        "GroupName": "launch-wizard-15", 
-                                        "GroupId": "sg-f7117688"
-                                    }
-                                ], 
-                                "Ipv6Addresses": [], 
-                                "SubnetId": "subnet-3a334610", 
-                                "OwnerId": "644160558196", 
-                                "PrivateIpAddress": "172.31.62.61"
-                            }
-                        ], 
-                        "SourceDestCheck": true, 
-                        "Placement": {
-                            "Tenancy": "default", 
-                            "GroupName": "", 
-                            "AvailabilityZone": "us-east-1d"
-                        }, 
-                        "Hypervisor": "xen", 
-                        "BlockDeviceMappings": [
-                            {
-                                "DeviceName": "/dev/xvda", 
-                                "Ebs": {
-                                    "Status": "attached", 
-                                    "DeleteOnTermination": true, 
-                                    "VolumeId": "vol-0b5bc31549f55bdd2", 
-                                    "AttachTime": {
-                                        "hour": 1, 
-                                        "__class__": "datetime", 
-                                        "month": 4, 
-                                        "second": 40, 
-                                        "microsecond": 0, 
-                                        "year": 2017, 
-                                        "day": 3, 
-                                        "minute": 34
-                                    }
-                                }
-                            }
-                        ], 
-                        "Architecture": "x86_64", 
-                        "StateReason": {
-                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown", 
-                            "Code": "Client.UserInitiatedShutdown"
-                        }, 
-                        "RootDeviceName": "/dev/xvda", 
-                        "VirtualizationType": "hvm", 
-                        "Tags": [
-                            {
-                                "Value": "2017-04-10", 
-                                "Key": "expiration"
-                            }
-                        ], 
-                        "AmiLaunchIndex": 0
-                    }
-                ]
-            }, 
-            {
-                "OwnerId": "644160558196", 
-                "ReservationId": "r-01054e3c8ee6075e6", 
-                "Groups": [], 
-                "Instances": [
-                    {
-                        "Monitoring": {
-                            "State": "disabled"
-                        }, 
-                        "PublicDnsName": "", 
-                        "RootDeviceType": "ebs", 
-                        "State": {
-                            "Code": 80, 
-                            "Name": "stopped"
-                        }, 
-                        "EbsOptimized": false, 
-                        "LaunchTime": {
-                            "hour": 14, 
-                            "__class__": "datetime", 
-                            "month": 3, 
-                            "second": 27, 
-                            "microsecond": 0, 
-                            "year": 2017, 
-                            "day": 28, 
-                            "minute": 55
-                        }, 
-                        "PrivateIpAddress": "172.31.28.33", 
-                        "ProductCodes": [], 
-                        "VpcId": "vpc-d2d616b5", 
-                        "StateTransitionReason": "User initiated (2017-04-03 01:32:42 GMT)", 
-                        "InstanceId": "i-0a0b51bcf11a8cdfb", 
-                        "EnaSupport": true, 
-                        "ImageId": "ami-0b33d91d", 
-                        "PrivateDnsName": "ip-172-31-28-33.ec2.internal", 
-                        "KeyName": "calvin-east-1", 
-                        "SecurityGroups": [
-                            {
-                                "GroupName": "launch-wizard-14", 
-                                "GroupId": "sg-fc46c983"
-                            }
-                        ], 
-                        "ClientToken": "tJMFV1490712926683", 
-                        "SubnetId": "subnet-efbcccb7", 
-                        "InstanceType": "t2.micro", 
-                        "NetworkInterfaces": [
-                            {
-                                "Status": "in-use", 
-                                "MacAddress": "0e:63:aa:34:b4:02", 
-                                "SourceDestCheck": true, 
-                                "VpcId": "vpc-d2d616b5", 
-                                "Description": "", 
-                                "NetworkInterfaceId": "eni-2de6aceb", 
-                                "PrivateIpAddresses": [
-                                    {
-                                        "PrivateDnsName": "ip-172-31-28-33.ec2.internal", 
-                                        "Primary": true, 
-                                        "PrivateIpAddress": "172.31.28.33"
-                                    }
-                                ], 
-                                "PrivateDnsName": "ip-172-31-28-33.ec2.internal", 
-                                "Attachment": {
-                                    "Status": "attached", 
-                                    "DeviceIndex": 0, 
-                                    "DeleteOnTermination": true, 
-                                    "AttachmentId": "eni-attach-a6156bf6", 
-                                    "AttachTime": {
-                                        "hour": 14, 
-                                        "__class__": "datetime", 
-                                        "month": 3, 
-                                        "second": 27, 
-                                        "microsecond": 0, 
-                                        "year": 2017, 
-                                        "day": 28, 
-                                        "minute": 55
-                                    }
-                                }, 
-                                "Groups": [
-                                    {
-                                        "GroupName": "launch-wizard-14", 
-                                        "GroupId": "sg-fc46c983"
-                                    }
-                                ], 
-                                "Ipv6Addresses": [], 
-                                "SubnetId": "subnet-efbcccb7", 
-                                "OwnerId": "644160558196", 
-                                "PrivateIpAddress": "172.31.28.33"
-                            }
-                        ], 
-                        "SourceDestCheck": true, 
-                        "Placement": {
-                            "Tenancy": "default", 
-                            "GroupName": "", 
-                            "AvailabilityZone": "us-east-1b"
-                        }, 
-                        "Hypervisor": "xen", 
-                        "BlockDeviceMappings": [
-                            {
-                                "DeviceName": "/dev/xvda", 
-                                "Ebs": {
-                                    "Status": "attached", 
-                                    "DeleteOnTermination": true, 
-                                    "VolumeId": "vol-01adbb6a4f175941d", 
-                                    "AttachTime": {
-                                        "hour": 14, 
-                                        "__class__": "datetime", 
-                                        "month": 3, 
-                                        "second": 28, 
-                                        "microsecond": 0, 
-                                        "year": 2017, 
-                                        "day": 28, 
-                                        "minute": 55
-                                    }
-                                }
-                            }
-                        ], 
-                        "Architecture": "x86_64", 
-                        "StateReason": {
-                            "Message": "Client.UserInitiatedShutdown: User initiated shutdown", 
-                            "Code": "Client.UserInitiatedShutdown"
-                        }, 
-                        "RootDeviceName": "/dev/xvda", 
-                        "VirtualizationType": "hvm", 
-                        "Tags": [
-                            {
-                                "Value": "2017-04-13", 
-                                "Key": "expiration"
-                            }
-                        ], 
-                        "AmiLaunchIndex": 0
-                    }
-                ]
-            }, 
-            {
-                "OwnerId": "644160558196", 
-                "ReservationId": "r-052b81d37c4baa7b0", 
+                "ReservationId": "r-0e4cdcddb8163e6fa", 
                 "Groups": [], 
                 "Instances": [
                     {
@@ -280,110 +16,124 @@
                             "Code": 16, 
                             "Name": "running"
                         }, 
-                        "EbsOptimized": false, 
+                        "EbsOptimized": true, 
                         "LaunchTime": {
-                            "hour": 20, 
+                            "hour": 14, 
                             "__class__": "datetime", 
                             "month": 4, 
-                            "second": 21, 
+                            "second": 39, 
                             "microsecond": 0, 
                             "year": 2017, 
-                            "day": 10, 
-                            "minute": 41
+                            "day": 26, 
+                            "minute": 36
                         }, 
-                        "PrivateIpAddress": "10.0.42.59", 
+                        "PrivateIpAddress": "172.31.5.205", 
                         "ProductCodes": [], 
-                        "VpcId": "vpc-f1516b97", 
+                        "VpcId": "vpc-63105e06", 
                         "StateTransitionReason": "", 
-                        "InstanceId": "i-0be2fdca058278ea3", 
-                        "ImageId": "ami-f4cc1de2", 
-                        "PrivateDnsName": "ip-10-0-42-59.ec2.internal", 
+                        "InstanceId": "i-063b4adb5673590ed", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-f173cc91", 
+                        "PrivateDnsName": "ip-172-31-5-205.us-west-2.compute.internal", 
+                        "KeyName": "tester", 
                         "SecurityGroups": [
                             {
-                                "GroupName": "FancyTestGroupPublic", 
-                                "GroupId": "sg-f8c78787"
+                                "GroupName": "launch-wizard-19", 
+                                "GroupId": "sg-d4ba53af"
                             }
                         ], 
-                        "ClientToken": "Gjqgm1491856879879", 
-                        "SubnetId": "subnet-6f273034", 
+                        "ClientToken": "Exlsd1490722532697", 
+                        "SubnetId": "subnet-5fb47507", 
                         "InstanceType": "t2.micro", 
                         "NetworkInterfaces": [
                             {
                                 "Status": "in-use", 
-                                "MacAddress": "0e:13:c9:48:3d:58", 
+                                "MacAddress": "0a:f1:cf:d9:76:1b", 
                                 "SourceDestCheck": true, 
-                                "VpcId": "vpc-f1516b97", 
-                                "Description": "Primary network interface", 
-                                "NetworkInterfaceId": "eni-67d758be", 
+                                "VpcId": "vpc-4a9ff72e", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "54.69.72.146", 
+                                    "PublicDnsName": "ec2-54-69-72-146.us-west-2.compute.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-1896024a", 
                                 "PrivateIpAddresses": [
                                     {
+                                        "PrivateDnsName": "ip-172-31-5-205.us-west-2.compute.internal", 
+                                        "Association": {
+                                            "PublicIp": "54.69.72.146", 
+                                            "PublicDnsName": "ec2-54-69-72-146.us-west-2.compute.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
                                         "Primary": true, 
-                                        "PrivateIpAddress": "10.0.42.59"
+                                        "PrivateIpAddress": "172.31.5.205"
                                     }
                                 ], 
-                                "Ipv6Addresses": [], 
+                                "PrivateDnsName": "ip-172-31-5-205.us-west-2.compute.internal", 
                                 "Attachment": {
                                     "Status": "attached", 
                                     "DeviceIndex": 0, 
                                     "DeleteOnTermination": true, 
-                                    "AttachmentId": "eni-attach-aab053f9", 
+                                    "AttachmentId": "eni-attach-fc3bbd9c", 
                                     "AttachTime": {
-                                        "hour": 20, 
+                                        "hour": 17, 
                                         "__class__": "datetime", 
-                                        "month": 4, 
-                                        "second": 21, 
+                                        "month": 3, 
+                                        "second": 33, 
                                         "microsecond": 0, 
                                         "year": 2017, 
-                                        "day": 10, 
-                                        "minute": 41
+                                        "day": 28, 
+                                        "minute": 35
                                     }
                                 }, 
                                 "Groups": [
                                     {
-                                        "GroupName": "FancyTestGroupPublic", 
-                                        "GroupId": "sg-f8c78787"
+                                        "GroupName": "launch-wizard-19", 
+                                        "GroupId": "sg-d4ba53af"
                                     }
                                 ], 
-                                "SubnetId": "subnet-6f273034", 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-5fb47507", 
                                 "OwnerId": "644160558196", 
-                                "PrivateIpAddress": "10.0.42.59"
+                                "PrivateIpAddress": "172.31.5.205"
                             }
                         ], 
                         "SourceDestCheck": true, 
                         "Placement": {
                             "Tenancy": "default", 
                             "GroupName": "", 
-                            "AvailabilityZone": "us-east-1b"
+                            "AvailabilityZone": "us-west-2c"
                         }, 
                         "Hypervisor": "xen", 
                         "BlockDeviceMappings": [
                             {
-                                "DeviceName": "/dev/sda1", 
+                                "DeviceName": "/dev/xvda", 
                                 "Ebs": {
                                     "Status": "attached", 
                                     "DeleteOnTermination": true, 
-                                    "VolumeId": "vol-0252f61378ede9d01", 
+                                    "VolumeId": "vol-07b6d5d522e215cf2", 
                                     "AttachTime": {
-                                        "hour": 20, 
+                                        "hour": 17, 
                                         "__class__": "datetime", 
-                                        "month": 4, 
-                                        "second": 21, 
+                                        "month": 3, 
+                                        "second": 34, 
                                         "microsecond": 0, 
                                         "year": 2017, 
-                                        "day": 10, 
-                                        "minute": 41
+                                        "day": 28, 
+                                        "minute": 35
                                     }
                                 }
                             }
                         ], 
                         "Architecture": "x86_64", 
                         "RootDeviceType": "ebs", 
-                        "RootDeviceName": "/dev/sda1", 
+                        "RootDeviceName": "/dev/xvda", 
                         "VirtualizationType": "hvm", 
                         "Tags": [
                             {
-                                "Value": "FancyTestInstancePrivate", 
-                                "Key": "Name"
+                                "Value": "V", 
+                                "Key": "K"
                             }
                         ], 
                         "AmiLaunchIndex": 0
@@ -394,13 +144,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "9e654cf7-626c-4f37-9d7b-11cf333509c2", 
+            "RequestId": "fba22912-459b-41bf-bcff-400921584b2b", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "vary": "Accept-Encoding", 
                 "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Fri, 28 Apr 2017 18:52:31 GMT"
+                "date": "Tue, 02 May 2017 20:20:25 GMT"
             }
         }
     }

--- a/tests/data/placebo/test_ec2_health_events_filter/health.DescribeAffectedEntities_1.json
+++ b/tests/data/placebo/test_ec2_health_events_filter/health.DescribeAffectedEntities_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200, 
+    "data": {
+        "entities": [
+            {
+                "entityValue": "i-063b4adb5673590ed", 
+                "lastUpdatedTime": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 9, 
+                    "microsecond": 964000, 
+                    "year": 2017, 
+                    "day": 27, 
+                    "minute": 59
+                }, 
+                "tags": {}, 
+                "entityArn": "arn:aws:health:us-west-2:644160558196:entity/12345678901234567890", 
+                "eventArn": "arn:aws:health:us-west-2::event/AWS_EC2_PERSISTENT_INSTANCE_RETIREMENT_SCHEDULED12345678-1234-1234-1234-123456789012", 
+                "awsAccountId": "644160558196"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c988d8d8-2f74-11e7-8171-f787f6681129", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c988d8d8-2f74-11e7-8171-f787f6681129", 
+                "date": "Tue, 02 May 2017 20:20:29 GMT", 
+                "content-length": "363", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_health_events_filter/health.DescribeEventDetails_1.json
+++ b/tests/data/placebo/test_ec2_health_events_filter/health.DescribeEventDetails_1.json
@@ -1,0 +1,62 @@
+{
+    "status_code": 200, 
+    "data": {
+        "failedSet": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c92c12cf-2f74-11e7-8171-f787f6681129", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c92c12cf-2f74-11e7-8171-f787f6681129", 
+                "date": "Tue, 02 May 2017 20:20:29 GMT", 
+                "content-length": "2540", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "successfulSet": [
+            {
+                "event": {
+                    "lastUpdatedTime": {
+                        "hour": 0, 
+                        "__class__": "datetime", 
+                        "month": 4, 
+                        "second": 4, 
+                        "microsecond": 143000, 
+                        "year": 2017, 
+                        "day": 27, 
+                        "minute": 59
+                    }, 
+                    "service": "EC2", 
+                    "eventTypeCode": "AWS_EC2_PERSISTENT_INSTANCE_RETIREMENT_SCHEDULED", 
+                    "startTime": {
+                        "hour": 0, 
+                        "__class__": "datetime", 
+                        "month": 5, 
+                        "second": 0, 
+                        "microsecond": 0, 
+                        "year": 2017, 
+                        "day": 11, 
+                        "minute": 0
+                    }, 
+                    "eventTypeCategory": "scheduledChange", 
+                    "endTime": {
+                        "hour": 0, 
+                        "__class__": "datetime", 
+                        "month": 5, 
+                        "second": 0, 
+                        "microsecond": 0, 
+                        "year": 2017, 
+                        "day": 11, 
+                        "minute": 0
+                    }, 
+                    "region": "us-west-2", 
+                    "arn": "arn:aws:health:us-west-2::event/AWS_EC2_PERSISTENT_INSTANCE_RETIREMENT_SCHEDULED12345678-1234-1234-1234-123456789012", 
+                    "statusCode": "upcoming"
+                }, 
+                "eventDescription": {
+                    "latestDescription": "EC2 has detected degradation of the underlying hardware hosting your Amazon EC2 instance associated with this event in the us-west-2 region. Due to this degradation, your instance could already be unreachable. After 2017-05-11 04:00 UTC your instance, which has an EBS volume as the root device, will be stopped.\n\nYou can see more information on your instances that are scheduled for retirement in the AWS Management Console (https://console.aws.amazon.com/ec2/v2/home?region=us-west-2#Events)\n\n* How does this affect you?\nYour instance's root device is an EBS volume and the instance will be stopped after the specified retirement date. You can start it again at any time. Note that if you have EC2 instance store volumes attached to the instance, any data on these volumes will be lost when the instance is stopped or terminated as these volumes are physically attached to the host computer\n\n* What do you need to do?\nYou may still be able to access the instance. We recommend that you replace the instance by creating an AMI of your instance and launch a new instance from the AMI. For more information please see Amazon Machine Images (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/AMIs.html) in the EC2 User Guide. In case of difficulties stopping your EBS-backed instance, please see the Instance FAQ (http://aws.amazon.com/instance-help/#ebs-stuck-stopping).\n\n* Why retirement?\nAWS may schedule instances for retirement in cases where there is an unrecoverable issue with the underlying hardware. For more information about scheduled retirement events please see the EC2 user guide (http://docs.aws.amazon.com/AWSEC2/latest/UserGuide/instance-retirement.html). To avoid single points of failure within critical applications, please refer to our architecture center for more information on implementing fault-tolerant architectures: http://aws.amazon.com/architecture\n\nIf you have any questions or concerns, you can contact the AWS Support Team on the community forums and via AWS Premium Support at: http://aws.amazon.com/support"
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_ec2_health_events_filter/health.DescribeEvents_1.json
+++ b/tests/data/placebo/test_ec2_health_events_filter/health.DescribeEvents_1.json
@@ -1,15 +1,54 @@
 {
     "status_code": 200, 
     "data": {
-        "events": [], 
+        "events": [
+            {
+                "lastUpdatedTime": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 4, 
+                    "microsecond": 143000, 
+                    "year": 2017, 
+                    "day": 27, 
+                    "minute": 59
+                }, 
+                "service": "EC2", 
+                "eventTypeCode": "AWS_EC2_PERSISTENT_INSTANCE_RETIREMENT_SCHEDULED", 
+                "startTime": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 0
+                }, 
+                "eventTypeCategory": "scheduledChange", 
+                "endTime": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 0, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 0
+                }, 
+                "region": "us-west-2", 
+                "arn": "arn:aws:health:us-west-2::event/AWS_EC2_PERSISTENT_INSTANCE_RETIREMENT_SCHEDULED12345678-1234-1234-1234-123456789012", 
+                "statusCode": "upcoming"
+            }
+        ], 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "d60fcd36-2c43-11e7-9229-832e94e8909b", 
+            "RequestId": "c87bfd4b-2f74-11e7-a362-450705400dc1", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "d60fcd36-2c43-11e7-9229-832e94e8909b", 
-                "date": "Fri, 28 Apr 2017 18:52:32 GMT", 
-                "content-length": "13", 
+                "x-amzn-requestid": "c87bfd4b-2f74-11e7-a362-450705400dc1", 
+                "date": "Tue, 02 May 2017 20:20:29 GMT", 
+                "content-length": "403", 
                 "content-type": "application/x-amz-json-1.1"
             }
         }

--- a/tests/data/placebo/test_ec2_health_events_filter/health.DescribeEvents_1.json
+++ b/tests/data/placebo/test_ec2_health_events_filter/health.DescribeEvents_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "events": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d60fcd36-2c43-11e7-9229-832e94e8909b", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "d60fcd36-2c43-11e7-9229-832e94e8909b", 
+                "date": "Fri, 28 Apr 2017 18:52:32 GMT", 
+                "content-length": "13", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -86,7 +86,7 @@ class TestHealthEventsFilter(BaseTest):
             ]},
             session_factory=session_factory)
         resources = policy.run()
-        self.assertEqual(len(resources), 0)
+        self.assertEqual(len(resources), 1)
 
 
 class TestTagTrim(BaseTest):

--- a/tests/test_health.py
+++ b/tests/test_health.py
@@ -48,4 +48,11 @@ class HealthResource(BaseTest):
             self.assertTrue(
                 (r['eventTypeCategory'] == 'accountNotification'
              ) ^ ('AffectedEntities' in r))
-            
+
+    def test_health_region(self):
+        self.change_environment(AWS_DEFAULT_REGION='us-west-2')
+        self.assertRaises(
+            ValueError,
+            self.load_policy,
+            {'name': 'account-health-query',
+             'resource': 'health-event'})


### PR DESCRIPTION
As mentioned in the [AWS API Reference](http://docs.aws.amazon.com/health/latest/APIReference/Welcome.html), the service endpoint is only in us-east-1. Currently, if running Health policy in other regions, an error will occur when getting health events.

Modified the following part:
1. Raise an error when running `resource: health-event` in regions other than us-east-1
2. Create health client only in us-east-1 whenever using `filter:  health-event`
3. Minor fix mentioned in #954 

Thanks.