### PR TITLE
Fix validation bug

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,7 +11,7 @@ lib64
 .Python
 pip-selfcheck.json
 cover/
-.coverage
+.coverage*
 tmp/
 docs/source/generated/
 docs/build/

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,6 +13,7 @@ install:
   - python setup.py develop
 script:
   - flake8 tools
-  - make sphinx && py.test -v -n auto --cov=c7n tests tools/c7n_*
+  - make sphinx
+  - py.test -v -n auto --cov=c7n tests tools/c7n_*
 after_success:
   coveralls

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -129,7 +129,7 @@ def validate(options):
             if format in ('json',):
                 data = json.load(fh)
 
-        errors = schema.validate(data, schm)
+        errors += schema.validate(data, schm)
         conf_policy_names = {p['name'] for p in data.get('policies', ())}
         dupes = conf_policy_names.intersection(used_policy_names)
         if len(dupes) >= 1:

--- a/tests/data/test_policies/ami-GOODVALIDATION.yml
+++ b/tests/data/test_policies/ami-GOODVALIDATION.yml
@@ -1,0 +1,12 @@
+policies:
+
+- name: ami-delete-on-expiresat-tag
+  resource: ami
+  filters:
+     - type: value
+       value_type: age
+       op: gt
+       key: tag:ExpiresAt
+       value: 0
+  actions:
+    - type: deregister

--- a/tests/data/test_policies/ebs-BADVALIDATION.yml
+++ b/tests/data/test_policies/ebs-BADVALIDATION.yml
@@ -1,0 +1,12 @@
+policies:
+
+- name: ebs-delete-on-expiresat-tag 
+  resource: eb
+  filters:
+     - type: value
+       value_type: age
+       op: gt
+       key: tag:ExpiresAt
+       value: 0
+  actions:
+    - type: delete

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -1,0 +1,41 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import argparse
+
+from common import BaseTest
+from c7n.commands import validate as validate_yaml_policies
+
+
+class CommandsValidateTest(BaseTest):
+
+    def test_failed_validation(self):
+        yaml_validate_options = argparse.Namespace(
+            command = 'c7n.commands.validate',
+            config  = None,
+            configs = [
+                'tests/data/test_policies/ebs-BADVALIDATION.yml',
+                'tests/data/test_policies/ami-GOODVALIDATION.yml'
+            ],
+            debug=False,
+            subparser='validate',
+            verbose=False
+        )
+        with self.assertRaises(SystemExit) as exit:
+            validate_yaml_policies(yaml_validate_options)
+        # if there is a bad policy in the batch being validated, there should be an exit 1
+        self.assertEqual(exit.exception.code, 1)
+        yaml_validate_options.configs.remove('tests/data/test_policies/ebs-BADVALIDATION.yml')
+        # if there are only good policy, it should exit none
+        self.assertIsNone(validate_yaml_policies(yaml_validate_options))


### PR DESCRIPTION
I am relying on the commands.validate function, I give it many policies at once as the input function. It correctly prints output if a function passes or fails. Though because 'errors' is overwritten in this loop, it does not correctly sys.exit(1). If the last policy in the list of ones being validated passes, the function will not exit(1). This causes my wrapper to continue to do a run, even if validation checks fail.

My change makes it so if any policies that the validate function is looping over fail, it will exit(1).