### PR TITLE
WIP - fix 'all' regions regression when botocore reports no regions (#901)

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -77,10 +77,10 @@ class PolicyCollection(object):
         session = utils.get_profile_session(options)
         for p in self.data.get('policies', []):
             all_regions = session.get_available_regions(p['resource'])
-            if 'all' in options.regions:
+            if 'all' in options.regions and all_regions:
                 options.regions = all_regions
             for region in options.regions:
-                if region not in all_regions:
+                if all_regions and region not in all_regions:
                     # TODO - do we want a message
                     continue
                 options_copy = copy.copy(options)

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -39,6 +39,8 @@ from c7n.version import version
 
 from c7n.resources import load_resources
 
+log = logging.getLogger('custodian.policy')
+
 
 def load(options, path, format='yaml', validate=True):
     # should we do os.path.expanduser here?
@@ -81,7 +83,7 @@ class PolicyCollection(object):
                 options.regions = all_regions
             for region in options.regions:
                 if all_regions and region not in all_regions:
-                    # TODO - do we want a message
+                    log.info('Skipping invalid region {} for resource {}.'.format(region, p['resource']))
                     continue
                 options_copy = copy.copy(options)
                 # TODO - why doesn't aws like unicode regions?

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -83,7 +83,8 @@ class PolicyCollection(object):
                 options.regions = all_regions
             for region in options.regions:
                 if all_regions and region not in all_regions:
-                    log.info('Skipping invalid region {} for resource {}.'.format(region, p['resource']))
+                    log.info('Skipping invalid region {} for resource {}.'.format(
+                            region, p['resource']))
                     continue
                 options_copy = copy.copy(options)
                 # TODO - why doesn't aws like unicode regions?

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,6 +19,7 @@ from argparse import ArgumentTypeError
 from common import BaseTest
 from cStringIO import StringIO
 from c7n import cli, version, commands
+from c7n.PolicyCollection
 from datetime import datetime, timedelta
 
 
@@ -546,9 +547,3 @@ class MiscTest(CliTest):
         self.run_and_expect_failure(
             ['custodian', 'run', '-s', temp_dir, yaml_file, yaml_file],
             1)
-
-
-class AllRegionsTest(CliTest):
-    
-    def test_all_regions(self):
-        pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -546,3 +546,9 @@ class MiscTest(CliTest):
         self.run_and_expect_failure(
             ['custodian', 'run', '-s', temp_dir, yaml_file, yaml_file],
             1)
+
+
+class AllRegionsTest(CliTest):
+    
+    def test_all_regions(self):
+        pass

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -19,7 +19,6 @@ from argparse import ArgumentTypeError
 from common import BaseTest
 from cStringIO import StringIO
 from c7n import cli, version, commands
-from c7n.PolicyCollection
 from datetime import datetime, timedelta
 
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -17,6 +17,7 @@ import shutil
 import tempfile
 
 from c7n import policy, manager
+from c7n.manager import resources
 from c7n.resources.ec2 import EC2
 from c7n.utils import dumps
 
@@ -394,3 +395,16 @@ class PullModeTest(BaseTest):
         self.assertIn(
             "Skipping policy {} target-region: us-east-1 current-region: us-west-2".format(policy_name),
             lines)
+
+
+
+class AllRegionsTest(BaseTest):
+    
+    def test_all_regions(self):
+        failures = []
+        for resource in sorted(resources.keys()):
+            data = {'policies': [{'name': 'test', 'resource': resource}]}
+            if len(policy.PolicyCollection(data, Config.empty())) == 0:
+                failures.append(resource)
+        
+        self.assertFalse(failures)


### PR DESCRIPTION
@JohnTheodore reported a problem - EBS does not give any regions from the `get_available_regions` call.  This, combined with the check that removes any non-available regions, means that EBS policies cannot currently run.

After testing I found that a large number of c7n resources have a similar problem:

```
['account', 'acm-certificate', 'alarm', 'ami', 'app-elb', 'app-elb-target-group', 'asg', 'batch-compute', 'batch-definition', 'cache-cluster', 'cache-snapshot', 'cache-subnet-group', 'cfn', 'customer-gateway', 'directory', 'distribution', 'dynamodb-stream', 'dynamodb-table', 'ebs', 'ebs-snapshot', 'elasticsearch', 'eni', 'event-rule', 'gamelift-build', 'gamelift-fleet', 'health-event', 'healthcheck', 'hostedzone', 'hsm', 'hsm-client', 'hsm-hapg', 'iam-certificate', 'iam-group', 'iam-policy', 'iam-profile', 'iam-role', 'iam-user', 'identity-pool', 'internet-gateway', 'key-pair', 'kinesis-analytics', 'kms-key', 'launch-config', 'log-group', 'ml-model', 'network-acl', 'network-addr', 'opswork-cm', 'opswork-stack', 'peering-connection', 'rds-cluster', 'rds-cluster-snapshot', 'rds-snapshot', 'rds-subnet-group', 'rds-subscription', 'redshift-snapshot', 'redshift-subnet-group', 'rest-api', 'route-table', 'rrset', 'security-group', 'shield-attack', 'shield-protection', 'simpledb', 'snowball-cluster', 'step-machine', 'storage-gateway', 'streaming-distribution', 'subnet', 'support-case', 'user-pool', 'vpc', 'vpn-connection', 'vpn-gateway', 'waf']
```

It is possible we could create a mapping for some of them similar to `ebs` -> `ec2`, but I suspect not for all of them.  So my solution is that whenever `get_available_regions` returns nothing, we ignore it.  This means that:

1. We won't do region validity checks for these resources, removing the bug in question.
2. The `--region all` flag is ignored those this set of resources