### PR TITLE
Reenable the s3 get_bucket_lifecycle augment.

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -118,8 +118,8 @@ S3_AUGMENT_TABLE = (
     ('get_bucket_versioning', 'Versioning', None, None),
     ('get_bucket_website', 'Website', None, None),
     ('get_bucket_logging', 'Logging', None, 'LoggingEnabled'),
-    ('get_bucket_notification_configuration', 'Notification', None, None)
-    #        ('get_bucket_lifecycle', 'Lifecycle', None, None),
+    ('get_bucket_notification_configuration', 'Notification', None, None),
+    ('get_bucket_lifecycle', 'Lifecycle', None, None),
     #        ('get_bucket_cors', 'Cors'),
 )
 


### PR DESCRIPTION
It's useful to be able to do filters based on lifecycle policies - e.g. ensuring that you have data retention enabled on EC2 Buckets.

This appeared to be removed in a bulk commit a while ago, and so renables the augment.

Note that I have a related PR to this, which may deal with why this was disabled - that should let these augments fail more gracefully when an account doesn't have IAM permissions for a specific item.