### PR TITLE
Remove hard-failure on S3 Augment

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -162,7 +162,10 @@ def assemble_bucket(item):
                 log.warning(
                     "Bucket:%s unable to invoke method:%s error:%s ",
                     b['Name'], m, e.response['Error']['Message'])
-                return None
+                # We don't bail out, continue processing if we can.
+                # Note this can lead to missing data, but in general is cleaner than
+                # failing hard.
+                continue
         # As soon as we learn location (which generally works)
         if k == 'Location' and v is not None:
             b_location = v.get('LocationConstraint')


### PR DESCRIPTION
This is a bit of a risky one - but I think it's worth adding.

We use cloudcustodian with external accounts via STS assumed roles and a custom policy. Now, for some permissions, we don't have adequate the specified IAM permission  (nor, for some of them, do we want it - the data is quite revealing!).

Now, in the current S3 augment, if we fail the call for data for a specific augment, it'll bail out on that bucket - raising an error.

This subtly changes the handling - to ignore failures, with the failure case being the absent of an augment full stop. We still log it as a warning as before, but we augment what we can. This to me makes sense - you can still check for absence of the field etc, and doesn't rely on an error-driven edge case to remove resources.

Thoughts / feedback? I'd love to know if you think this will break anything in specific.