### PR TITLE
fix for regions bug

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -86,7 +86,7 @@ class PolicyCollection(object):
 
         for p in self.data.get('policies', []):
             available_regions = service_region_map.get(
-                resource_service_map[p['resource']], ())
+                resource_service_map.get(p['resource']), ())
 
             if 'all' in options.regions:
                 if not available_regions:
@@ -94,7 +94,7 @@ class PolicyCollection(object):
                 else:
                     options.regions = available_regions
             for region in options.regions:
-                if region not in available_regions:
+                if available_regions and region not in available_regions:
                     self.log.debug("policy:%s resources:%s not available in region:%s",
                                    p['name'], p['resource'], region)
                     continue

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -397,9 +397,10 @@ class PullModeTest(BaseTest):
             lines)
 
 
-class AllRegionsTest(BaseTest):
+class AllResourcesTest(BaseTest):
+    """ Make sure we can load a policy for all the resources we support """
     
-    def test_all_regions(self):
+    def test_all_resources(self):
         failures = []
         for resource in sorted(resources.keys()):
             data = {'policies': [{'name': 'test', 'resource': resource}]}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -17,6 +17,7 @@ import shutil
 import tempfile
 
 from c7n import policy, manager
+from c7n.manager import resources
 from c7n.resources.ec2 import EC2
 from c7n.utils import dumps
 
@@ -394,3 +395,15 @@ class PullModeTest(BaseTest):
         self.assertIn(
             "Skipping policy {} target-region: us-east-1 current-region: us-west-2".format(policy_name),
             lines)
+
+
+class AllRegionsTest(BaseTest):
+    
+    def test_all_regions(self):
+        failures = []
+        for resource in sorted(resources.keys()):
+            data = {'policies': [{'name': 'test', 'resource': resource}]}
+            if len(policy.PolicyCollection(data, Config.empty())) == 0:
+                failures.append(resource)
+        
+        self.assertFalse(failures)


### PR DESCRIPTION
@kapilt - your fix handles 90% of the problem services, but for some reason boto still reports no regions for a few services.  the list resources that this includes are:

['account', 'distribution', 'healthcheck', 'hostedzone', 'iam-certificate', 'iam-group', 'iam-policy', 'iam-profile', 'iam-role', 'iam-user', 'rrset', 'streaming-distribution', 'waf']

You can see the problem like so:

```
session.get_available_regions('iam')
[]
```

So I re-added in the code that skips the region validity test if the region list is empty.  And I added in the test that checks that ensures we can load a policy for each of the resources we support.