### PR TITLE
cleanup of off hours

### DIFF
--- a/docs/source/usecases/ec2offhours.rst
+++ b/docs/source/usecases/ec2offhours.rst
@@ -1,32 +1,46 @@
 EC2 - Offhours Support
 ======================
 
-- Offhours are based on current time of the instance
+Offhours are based on current time of the machine that is running custodian. Note, in this case you could tag an instance with the following two tags: StopAfterHours: off=(M-F,18);tz=est; and StartAfterHours: on=(M-F,8). This would have the instance turn off every weekday at 6pm NY time, and turn on every day at 8am California time (since if no tz is set, it uses the default which is pt). Note when custodian runs, if it's 6:00pm or 6:59 pm NY time, it will shut down the VM you tagged this way. The key is the hour integer on the NY clock matching 18. If custodian runs at 5:59pm or 7:00pm NY time, it won't shut down the VM. Same idea for starting.
+
+Policy values:
+
+- weekends: default true, whether to leave resources off for the weekend
+- weekend-only: default false, whether to turn the resource off only on the weekend
+- tag: the tag name to use when configuring
+- default_tz: the default timezone to use when interpreting offhours (REQUIRED)
+- offhour: the time to turn instances off, specified in 0-23
+- onhour: the time to turn instances on, specified in 0-23
+- opt-out: default behavior is opt in, as in ``tag`` must be present,
+  with opt-out: true, the tag doesn't need to be present.
+
+The reason we filter for only seeing instances older than 1 hour, if a dev is on a VM that is shut down by the off hours schedule, and they turn it back on, if we run custodian again we don't want to keep shutting down the VM on the dev repeatedly.
 
 .. code-block:: yaml
 
    policies:
-     - name: offhour_stop_19
+     - name: stop-after-hours
        resource: ec2
-       comments: |
-         Daily stoppage at 7pm
        filters:
          - type: offhour
-           tag: c7n_downtime
-           offhour: 19
-           default_tz: est
+           tag: StopAfterHours
+           default_tz: pt
+         - type: instance-age
+           hours: 1
        actions:
          - stop
    
-     - name: onhour_start_10
+     - name: start-after-hours
        resource: ec2
-       comments: |
-         Daily start at 10am
        filters:
          - type: onhour
-           tag: c7n_downtime
-           onhour: 10
-           default_tz: est
+           tag: StartAfterHours
+           default_tz: pt
+           onhour: 12
+         - type: value
+           value: 1
+           key: LaunchTime
+           op: less-than
+           value_type: age
        actions:
          - start
-         

--- a/tests/test_offhours.py
+++ b/tests/test_offhours.py
@@ -164,7 +164,7 @@ class OffHoursFilterTest(BaseTest):
 
         with mock_datetime_now(t, datetime) as dt:
             for n in range(0, 4):
-                dt.target = t.replace(hour=hour+n)
+                dt.target = t.replace(hour=hour + n)
                 results.append(f(i))
         self.assertEqual(results, [True, True, False, False])
 
@@ -191,7 +191,7 @@ class OffHoursFilterTest(BaseTest):
         results = []
         with mock_datetime_now(t, datetime) as dt:
             for n in range(7):
-                dt.target = t.replace(day=start_day+n)
+                dt.target = t.replace(day=start_day + n)
                 results.append(f(i))
         self.assertEqual(results, [True] * 7)
 
@@ -205,7 +205,7 @@ class OffHoursFilterTest(BaseTest):
         results = []
         with mock_datetime_now(t, datetime) as dt:
             for n in range(7):
-                dt.target = t.replace(day=start_day+n)
+                dt.target = t.replace(day=start_day + n)
                 results.append(f(i))
         self.assertEqual(results, [True] * 7)
 
@@ -220,7 +220,7 @@ class OffHoursFilterTest(BaseTest):
         results = []
         with mock_datetime_now(t, datetime) as dt:
             for n in range(7):
-                dt.target = t.replace(day=start_day+n)
+                dt.target = t.replace(day=start_day + n)
                 results.append(f(i))
         self.assertEqual(results, [
             False, True, False, False, False, False, False])
@@ -236,7 +236,7 @@ class OffHoursFilterTest(BaseTest):
         results = []
         with mock_datetime_now(t, datetime) as dt:
             for n in range(7):
-                dt.target = t.replace(day=start_day+n)
+                dt.target = t.replace(day=start_day + n)
                 results.append(f(i))
         self.assertEqual(results, [
             False, True, False, False, False, False, False])
@@ -250,7 +250,7 @@ class OffHoursFilterTest(BaseTest):
         results = []
         with mock_datetime_now(t, datetime) as dt:
             for n in range(7):
-                dt.target = t.replace(day=start_day+n)
+                dt.target = t.replace(day=start_day + n)
                 results.append(f(i))
         self.assertEqual(
             results,
@@ -265,7 +265,7 @@ class OffHoursFilterTest(BaseTest):
         results = []
         with mock_datetime_now(t, datetime) as dt:
             for n in range(0, 4):
-                dt.target = t.replace(day=start_day+n)
+                dt.target = t.replace(day=start_day + n)
                 results.append(f(i))
         self.assertEqual(results, [True, False, False, True])
 
@@ -291,12 +291,12 @@ class OffHoursFilterTest(BaseTest):
         t = t.replace(year=2015, month=12, day=1, hour=19, minute=5)
         with mock_datetime_now(t, datetime):
             results = [OffHour({})(i) for i in [
-                    instance(Tags=[
-                        {'Key': 'maid_offhours', 'Value': ''}]),
-                    instance(Tags=[
-                        {'Key': 'maid_offhours', 'Value': '"Offhours tz=ET"'}]),
-                    instance(Tags=[
-                        {'Key': 'maid_offhours', 'Value': 'Offhours tz=PT'}])]]
+                instance(Tags=[
+                    {'Key': 'maid_offhours', 'Value': ''}]),
+                instance(Tags=[
+                    {'Key': 'maid_offhours', 'Value': '"Offhours tz=ET"'}]),
+                instance(Tags=[
+                    {'Key': 'maid_offhours', 'Value': 'Offhours tz=PT'}])]]
             # unclear what this is really checking
             self.assertEqual(results, [True, True, True])
 
@@ -306,7 +306,7 @@ class OffHoursFilterTest(BaseTest):
             {'Key': 'maid_offhours', 'Value': 'Offhours tz=PT'}])
         self.assertEqual(off.get_tag_value(i), "offhours tz=pt")
         self.assertFalse(off.parser.has_resource_schedule(
-            off.get_tag_value(i)))
+            off.get_tag_value(i), 'off'))
         self.assertTrue(off.parser.keys_are_valid(
             off.get_tag_value(i)))
         self.assertEqual(off.parser.raw_data(
@@ -381,18 +381,18 @@ class OffHoursFilterTest(BaseTest):
             # This isn't considered a bad value, its basically omitted.
             i = instance(Tags=[{'Key': 'maid_offhours',
                                 'Value': 'off=();tz=et'}])
-            self.assertEqual(OffHour({})(i), True)
+            self.assertEqual(OffHour({})(i), False)
 
             i = instance(Tags=[{'Key': 'maid_offhours',
                                 'Value': 'off=(m-f,90);on=(m-f,7);tz=et'}])
-            #malformed value
+            # malformed value
             self.assertEqual(OffHour({})(i), False)
 
         t = t.replace(year=2016, month=5, day=26, hour=13, minute=00)
         with mock_datetime_now(t, datetime):
             i = instance(Tags=[{'Key': 'maid_offhours',
                                 'Value': 'off=();tz=et'}])
-            #will go to default values, but not work due to default time
+            # will go to default values, but not work due to default time
             self.assertEqual(OffHour({})(i), False)
 
             i = instance(Tags=[{'Key': 'maid_offhours',
@@ -455,7 +455,7 @@ class ScheduleParserTest(BaseTest):
           'tz': 'est'}),
 
         ################
-        ## Invalid Cases
+        # Invalid Cases
         ('', None),
         # invalid day
         ('off=(1-2,12);on=(m-f,10);tz=est', None),


### PR DESCRIPTION
Note, this PR is backwards compatible with existing offhours/onhours tag values and policies.

Changes include:
- fix validation bugs (24 is not a valid time in the value tag, must be 0-23)
- Let the tag value be just on or off, and not require both (though both works too, it just ignores one).
- changed the validation to not be 'on' _and_ 'off' in the value, more intelligently use time_type from the onhours or offhours objects to find out what the required value is in the tag 'on' _or_ 'off' depending on the object.
- spruce up docs a bit so folks can read the use case from their browser and get off the ground without needing to dig through code