### PR TITLE
[WIP] Improved support for related resources

### DIFF
--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -85,22 +85,21 @@ class RelatedResourceFilter(ValueFilter):
                     self.RelatedResource.rsplit('.', 1)[-1],
                     rid)
                 continue
-            found.append(robj)
-
+            items.append(robj)
 
         filtered = []
         # Now, we filter accordingly...
         if self.data.get('filters'):
-            filtered = self.get_resource_manager().filter_resources(found)
+            filtered = self.get_resource_manager().filter_resources(items)
         else:
-            filtered = filter(self.match, found)
+            filtered = filter(self.match, items)
 
         if self.AnnotationKey is not None:
             resource['c7n.%s' % self.AnnotationKey] = filtered
 
         if op == 'or' and filtered:
             return True
-        elif op == 'and' and len(filtered) == len(found):
+        elif op == 'and' and len(filtered) == len(items):
             return True
         return False
 

--- a/c7n/filters/related.py
+++ b/c7n/filters/related.py
@@ -61,13 +61,17 @@ class RelatedResourceFilter(ValueFilter):
         mod_path, class_name = self.RelatedResource.rsplit('.', 1)
         module = importlib.import_module(mod_path)
         manager_class = getattr(module, class_name)
-        return manager_class(self.manager.ctx, {})
+
+        data = {}
+        if self.data.get('filters'):
+            data['filters'] = self.data['filters']
+        return manager_class(self.manager.ctx, data)
 
     def process_resource(self, resource, related):
         related_ids = self.get_related_ids([resource])
         model = self.manager.get_model()
         op = self.data.get('operator', 'or')
-        found = []
+        items = []
         if self.data.get('match-resource') is True:
             self.data['value'] = self.get_resource_value(
                 self.data['key'], resource)
@@ -81,15 +85,22 @@ class RelatedResourceFilter(ValueFilter):
                     self.RelatedResource.rsplit('.', 1)[-1],
                     rid)
                 continue
-            if self.match(robj):
-                found.append(rid)
+            found.append(robj)
+
+
+        filtered = []
+        # Now, we filter accordingly...
+        if self.data.get('filters'):
+            filtered = self.get_resource_manager().filter_resources(found)
+        else:
+            filtered = filter(self.match, found)
 
         if self.AnnotationKey is not None:
-            resource['c7n.%s' % self.AnnotationKey] = found
+            resource['c7n.%s' % self.AnnotationKey] = filtered
 
-        if op == 'or' and found:
+        if op == 'or' and filtered:
             return True
-        elif op == 'and' and len(found) == len(related_ids):
+        elif op == 'and' and len(filtered) == len(found):
             return True
         return False
 

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -23,7 +23,8 @@ class SecurityGroupFilter(RelatedResourceFilter):
     schema = type_schema(
         'security-group', rinherit=ValueFilter.schema,
         **{'match-resource':{'type': 'boolean'},
-           'operator': {'enum': ['and', 'or']}})
+           'operator': {'enum': ['and', 'or']},
+           'filters': {'type': 'array'}})
 
     RelatedResource = "c7n.resources.vpc.SecurityGroup"
     AnnotationKey = "matched-security-groups"
@@ -34,7 +35,8 @@ class SubnetFilter(RelatedResourceFilter):
     schema = type_schema(
         'subnet', rinherit=ValueFilter.schema,
         **{'match-resource':{'type': 'boolean'},
-           'operator': {'enum': ['and', 'or']}})
+           'operator': {'enum': ['and', 'or']},
+           'filters': {'type': 'array'}})
 
     RelatedResource = "c7n.resources.vpc.Subnet"
     AnnotationKey = "matched-subnets"


### PR DESCRIPTION
Currently, the related resources filter is a simple ValueFilter on the associated object. Useful, but not powerful.

This extends it even more - We instantiate the resource manage and pass in nested filters, allowing us to easily filter by the custom filters of an associated object.

Now, what's the value in this you ask?

Simple use case: Filter to all EC2 Instances that have a security group with Port 22 open.

This is still very much WIP, so I'd love some feedback, especially based on our prior discussions @kapilt.