### PR TITLE
Account has-virtual-mfa filter

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -656,3 +656,42 @@ class EnableTrail(BaseAction):
             if update_args:
                 update_args['Name'] = trail_name
                 client.update_trail(**update_args)
+
+
+@filters.register('has-virtual-mfa')
+class HasVirtualMFA(Filter):
+    """Is the account configured with a virtual MFA device?
+
+    :example:
+
+        .. code-block: yaml
+
+            policies:
+                - name: account-with-virtual-mfa
+                  resource: account
+                  region: us-east-1
+                  filters:
+                    - type: has-virtual-mfa
+                      value: true
+    """
+
+    schema = type_schema('has-virtual-mfa', **{'value': {'type': 'boolean'}})
+
+    permissions = ('iam:ListVirtualMFADevices',)
+
+    def mfa_belongs_to_root_account(self, mfa):
+        return mfa['SerialNumber'].endswith(':mfa/root-account-mfa-device')
+
+    def account_has_virtual_mfa(self, account):
+        if not account.get('c7n:VirtualMFADevices'):
+            client = local_session(self.manager.session_factory).client('iam')
+            paginator = client.get_paginator('list_virtual_mfa_devices')
+            raw_list = paginator.paginate().build_full_result()['VirtualMFADevices']
+            print(raw_list)
+            account['c7n:VirtualMFADevices'] = filter(self.mfa_belongs_to_root_account, raw_list)
+        expect_virtual_mfa = self.data.get('value', True)
+        has_virtual_mfa = any(account['c7n:VirtualMFADevices'])
+        return expect_virtual_mfa == has_virtual_mfa
+
+    def process(self, resources, event=None):
+        return filter(self.account_has_virtual_mfa, resources)

--- a/tests/data/placebo/test_account_virtual_mfa/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_account_virtual_mfa/iam.ListAccountAliases_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "cloud-custodian"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "1c4380c9-35e8-11e7-9a74-23d61355e462", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "1c4380c9-35e8-11e7-9a74-23d61355e462", 
+                "date": "Thu, 11 May 2017 01:21:07 GMT", 
+                "content-length": "391", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_account_virtual_mfa/iam.ListVirtualMFADevices_1.json
+++ b/tests/data/placebo/test_account_virtual_mfa/iam.ListVirtualMFADevices_1.json
@@ -1,0 +1,110 @@
+{
+    "status_code": 200, 
+    "data": {
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "1cecdfec-35e8-11e7-8dba-0776c02973bd", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "1cecdfec-35e8-11e7-8dba-0776c02973bd", 
+                "date": "Thu, 11 May 2017 01:21:09 GMT", 
+                "content-length": "1873", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "VirtualMFADevices": [
+            {
+                "SerialNumber": "arn:aws:iam::123456789123:mfa/root-account-mfa-device", 
+                "EnableDate": {
+                    "hour": 6, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 36, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 13, 
+                    "minute": 56
+                }
+            }, 
+            {
+                "SerialNumber": "arn:aws:iam::123456789123:mfa/fake.person", 
+                "EnableDate": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 8, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 5, 
+                    "minute": 16
+                }, 
+                "User": {
+                    "UserName": "fake.person", 
+                    "PasswordLastUsed": {
+                        "hour": 22, 
+                        "__class__": "datetime", 
+                        "month": 5, 
+                        "second": 34, 
+                        "microsecond": 0, 
+                        "year": 2017, 
+                        "day": 8, 
+                        "minute": 36
+                    }, 
+                    "CreateDate": {
+                        "hour": 5, 
+                        "__class__": "datetime", 
+                        "month": 12, 
+                        "second": 8, 
+                        "microsecond": 0, 
+                        "year": 2015, 
+                        "day": 14, 
+                        "minute": 30
+                    }, 
+                    "UserId": "FAKEUSER2", 
+                    "Path": "/", 
+                    "Arn": "arn:aws:iam::123456789123:user/fake.person"
+                }
+            }, 
+            {
+                "SerialNumber": "arn:aws:iam::123456789123:mfa/other.person", 
+                "EnableDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 35, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 11, 
+                    "minute": 31
+                }, 
+                "User": {
+                    "UserName": "other.person", 
+                    "PasswordLastUsed": {
+                        "hour": 1, 
+                        "__class__": "datetime", 
+                        "month": 4, 
+                        "second": 23, 
+                        "microsecond": 0, 
+                        "year": 2017, 
+                        "day": 11, 
+                        "minute": 28
+                    }, 
+                    "CreateDate": {
+                        "hour": 0, 
+                        "__class__": "datetime", 
+                        "month": 4, 
+                        "second": 39, 
+                        "microsecond": 0, 
+                        "year": 2017, 
+                        "day": 11, 
+                        "minute": 55
+                    }, 
+                    "UserId": "FAKEUSER3", 
+                    "Path": "/", 
+                    "Arn": "arn:aws:iam::123456789123:user/other.person"
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -219,6 +219,38 @@ class AccountTests(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 0)
 
+    def test_account_virtual_mfa(self):
+        # only warns when the default threshold goes to warning or above
+        session_factory = self.replay_flight_data('test_account_virtual_mfa')
+        p1 = self.load_policy({
+            'name': 'account-virtual-mfa',
+            'resource': 'account',
+            'filters': [{
+                'type': 'has-virtual-mfa'}]},
+            session_factory=session_factory)
+        resources = p1.run()
+        self.assertEqual(len(resources), 1)
+
+        p2 = self.load_policy({
+            'name': 'account-virtual-mfa',
+            'resource': 'account',
+            'filters': [{
+                'type': 'has-virtual-mfa',
+                'value': True}]},
+            session_factory=session_factory)
+        resources = p2.run()
+        self.assertEqual(len(resources), 1)
+
+        p3 = self.load_policy({
+            'name': 'account-virtual-mfa',
+            'resource': 'account',
+            'filters': [{
+                'type': 'has-virtual-mfa',
+                'value': False}]},
+            session_factory=session_factory)
+        resources = p3.run()
+        self.assertEqual(len(resources), 0)
+
     def test_missing_password_policy(self):
         session_factory = self.replay_flight_data('test_account_missing_password_policy')
         p = self.load_policy({


### PR DESCRIPTION
Again, part of the CIS Foundation Benchmark for AWS - Checks for accounts where the root account has a virtual MFA. this is first attempt at implementing it.

It's super simple at the moment, but may be useful to make it a ValueFilter instead that operates on the object - or a related filter (especially if we complete #1144) - but there is a little bit of things around the edges to consider here.