### PR TITLE
Add delete and set-encryption action to SQS

### DIFF
--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -20,6 +20,7 @@ from c7n.query import QueryResourceManager
 from c7n.actions import BaseAction
 from c7n.utils import type_schema
 
+
 @resources.register('sqs')
 class SQS(QueryResourceManager):
 
@@ -72,6 +73,7 @@ class SQS(QueryResourceManager):
 class SQSCrossAccount(CrossAccountAccessFilter):
     permissions = ('sqs:GetQueueAttributes',)
 
+
 @SQS.action_registry.register('delete')
 class DeleteSqsQueue(BaseAction):
     """Action to delete a SQS queue
@@ -107,6 +109,7 @@ class DeleteSqsQueue(BaseAction):
             self.log.exception(
                 "Exception deleting queue:\n %s" % e)
 
+
 @SQS.action_registry.register('set-encryption')
 class SetEncryption(BaseAction):
     """Action to set encryption key on SQS queue
@@ -126,8 +129,7 @@ class SetEncryption(BaseAction):
     """
     schema = type_schema(
         'set-encryption',
-         key={'type': 'string'},
-         required=('key',))
+        key={'type': 'string'},required=('key',))
 
     permissions = ('sqs:SetQueueAttributes','kms:DescribeKey',)
 

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -17,7 +17,8 @@ from c7n.filters import CrossAccountAccessFilter
 from c7n.manager import resources
 from c7n.utils import local_session
 from c7n.query import QueryResourceManager
-
+from c7n.actions import BaseAction
+from c7n.utils import type_schema
 
 @resources.register('sqs')
 class SQS(QueryResourceManager):
@@ -70,3 +71,83 @@ class SQS(QueryResourceManager):
 @SQS.filter_registry.register('cross-account')
 class SQSCrossAccount(CrossAccountAccessFilter):
     permissions = ('sqs:GetQueueAttributes',)
+
+@SQS.action_registry.register('delete')
+class DeleteSqsQueue(BaseAction):
+    """Action to delete a SQS queue
+
+    To prevent unwanted deletion of SQS queues, it is recommended
+    to include a filter
+
+    :example:
+
+        .. code-block: yaml
+
+            policies:
+              - name: sqs-delete
+                resource: sqs
+                filters:
+                  - KmsMasterKeyId: absent
+                actions:
+                  - type: delete
+    """
+
+    schema = type_schema('delete')
+    permissions = ('sqs:DeleteQueue',)
+
+    def process(self, queues):
+        with self.executor_factory(max_workers=2) as w:
+            list(w.map(self.process_queue, queues))
+
+    def process_queue(self, queue):
+        client = local_session(self.manager.session_factory).client('sqs')
+        try:
+            client.delete_queue(QueueUrl=queue['QueueUrl'])
+        except ClientError as e:
+            self.log.exception(
+                "Exception deleting queue:\n %s" % e)
+
+@SQS.action_registry.register('set-encryption')
+class SetEncryption(BaseAction):
+    """Action to set encryption key on SQS queue
+
+    :example:
+
+        .. code-block: yaml
+
+            policies:
+              - name: sqs-set-encrypt
+                resource: sqs
+                filters:
+                  - KmsMasterKeyId: absent
+                actions:
+                  - type: set_encryption
+                    key: "<alias of kms key>"
+    """
+    schema = type_schema(
+        'set-encryption',
+         key={'type': 'string'},
+         required=('key',))
+
+    permissions = ('sqs:SetQueueAttributes','kms:DescribeKey',)
+
+    def process(self, queues):
+        with self.executor_factory(max_workers=2) as w:
+            list(w.map(self.process_queue, queues))
+
+    def process_queue(self, queue):
+        # get KeyId
+        key = "alias/" + self.data.get('key')
+        key_id = local_session(self.manager.session_factory).client(
+            'kms').describe_key(KeyId=key)['KeyMetadata']['KeyId']
+        client = local_session(self.manager.session_factory).client('sqs')
+        try:
+            client.set_queue_attributes(
+                QueueUrl=queue['QueueUrl'],
+                Attributes={
+                    'KmsMasterKeyId': key_id
+                }
+            )
+        except ClientError as e:
+            self.log.exception(
+                "Exception modifying queue:\n %s" % e)

--- a/tests/data/placebo/test_sqs_delete/sqs.CreateQueue_1.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.CreateQueue_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "QueueUrl": "https://us-west-2.queue.amazonaws.com/644160558196/test-sqs", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "32974770-ce28-5524-9616-16e76b6f2cb9", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "32974770-ce28-5524-9616-16e76b6f2cb9", 
+                "content-length": "330", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 18 May 2017 13:35:04 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_delete/sqs.DeleteQueue_1.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.DeleteQueue_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "76f63a89-65af-5643-b138-6b0713d8ce3d", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "76f63a89-65af-5643-b138-6b0713d8ce3d", 
+                "content-length": "211", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 11 May 2017 14:24:55 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Attributes": {
+            "ApproximateNumberOfMessagesNotVisible": "0", 
+            "KmsDataKeyReusePeriodSeconds": "300", 
+            "KmsMasterKeyId": "alias/aws/sqs", 
+            "MessageRetentionPeriod": "345600", 
+            "ApproximateNumberOfMessagesDelayed": "0", 
+            "MaximumMessageSize": "262144", 
+            "CreatedTimestamp": "1494512627", 
+            "ApproximateNumberOfMessages": "0", 
+            "ReceiveMessageWaitTimeSeconds": "0", 
+            "DelaySeconds": "0", 
+            "VisibilityTimeout": "30", 
+            "LastModifiedTimestamp": "1494512627", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:test-sqs"
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "5b7d1d80-7410-5397-8d05-4c0e02662bcb", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "5b7d1d80-7410-5397-8d05-4c0e02662bcb", 
+                "content-length": "1322", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 11 May 2017 14:24:54 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_2.json
@@ -1,0 +1,32 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Attributes": {
+            "ApproximateNumberOfMessagesNotVisible": "0", 
+            "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer/SQSDefaultPolicy\",\"Statement\":[{\"Sid\":\"Sid1483703606926\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"SQS:*\",\"Resource\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer\"}]}", 
+            "MessageRetentionPeriod": "345600", 
+            "ApproximateNumberOfMessagesDelayed": "0", 
+            "MaximumMessageSize": "262144", 
+            "CreatedTimestamp": "1483525735", 
+            "ApproximateNumberOfMessages": "0", 
+            "ReceiveMessageWaitTimeSeconds": "0", 
+            "DelaySeconds": "0", 
+            "VisibilityTimeout": "30", 
+            "LastModifiedTimestamp": "1483703607", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer"
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4d3d7731-8cf4-5a5a-8880-26bffa8294ad", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "4d3d7731-8cf4-5a5a-8880-26bffa8294ad", 
+                "content-length": "1651", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 11 May 2017 14:24:54 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_2.json
@@ -3,28 +3,27 @@
     "data": {
         "Attributes": {
             "ApproximateNumberOfMessagesNotVisible": "0", 
-            "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer/SQSDefaultPolicy\",\"Statement\":[{\"Sid\":\"Sid1483703606926\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"SQS:*\",\"Resource\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer\"}]}", 
             "MessageRetentionPeriod": "345600", 
             "ApproximateNumberOfMessagesDelayed": "0", 
             "MaximumMessageSize": "262144", 
-            "CreatedTimestamp": "1483525735", 
+            "CreatedTimestamp": "1495114503", 
             "ApproximateNumberOfMessages": "0", 
             "ReceiveMessageWaitTimeSeconds": "0", 
             "DelaySeconds": "0", 
             "VisibilityTimeout": "30", 
-            "LastModifiedTimestamp": "1483703607", 
-            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer"
+            "LastModifiedTimestamp": "1495114503", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:test-sqs"
         }, 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "4d3d7731-8cf4-5a5a-8880-26bffa8294ad", 
+            "RequestId": "87b3544d-b3c8-562b-8cd6-05da16814a6b", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "4d3d7731-8cf4-5a5a-8880-26bffa8294ad", 
-                "content-length": "1651", 
+                "x-amzn-requestid": "87b3544d-b3c8-562b-8cd6-05da16814a6b", 
+                "content-length": "1162", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Thu, 11 May 2017 14:24:54 GMT", 
+                "date": "Thu, 18 May 2017 13:35:05 GMT", 
                 "content-type": "text/xml"
             }
         }

--- a/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_3.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.GetQueueAttributes_3.json
@@ -3,25 +3,26 @@
     "data": {
         "Attributes": {
             "ApproximateNumberOfMessagesNotVisible": "0", 
-            "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer/SQSDefaultPolicy\",\"Statement\":[{\"Sid\":\"Sid1483703606926\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"SQS:*\",\"Resource\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer\"}]}", 
+            "KmsDataKeyReusePeriodSeconds": "300", 
+            "KmsMasterKeyId": "alias/aws/sqs", 
             "MessageRetentionPeriod": "345600", 
             "ApproximateNumberOfMessagesDelayed": "0", 
             "MaximumMessageSize": "262144", 
-            "CreatedTimestamp": "1483525735", 
+            "CreatedTimestamp": "1495109287", 
             "ApproximateNumberOfMessages": "0", 
             "ReceiveMessageWaitTimeSeconds": "0", 
             "DelaySeconds": "0", 
             "VisibilityTimeout": "30", 
-            "LastModifiedTimestamp": "1483703607", 
-            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer"
+            "LastModifiedTimestamp": "1495109287", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:test-2-wyp927"
         }, 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "354bd4e2-c4a2-5545-abc9-857561eb25b9", 
+            "RequestId": "a9d45290-02d3-5483-b157-0307a79afe98", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "354bd4e2-c4a2-5545-abc9-857561eb25b9", 
-                "content-length": "1651", 
+                "x-amzn-requestid": "a9d45290-02d3-5483-b157-0307a79afe98", 
+                "content-length": "1327", 
                 "server": "Server", 
                 "connection": "keep-alive", 
                 "date": "Thu, 18 May 2017 13:35:05 GMT", 

--- a/tests/data/placebo/test_sqs_delete/sqs.GetQueueUrl_1.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.GetQueueUrl_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "QueueUrl": "https://us-west-2.queue.amazonaws.com/644160558196/test-sqs", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b9ddaccb-62f5-568a-a838-fd5cc7bdbf17", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b9ddaccb-62f5-568a-a838-fd5cc7bdbf17", 
+                "content-length": "330", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 18 May 2017 13:35:04 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_delete/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.ListQueues_1.json
@@ -2,19 +2,20 @@
     "status_code": 200, 
     "data": {
         "QueueUrls": [
+            "https://us-west-2.queue.amazonaws.com/644160558196/test-2-wyp927", 
             "https://us-west-2.queue.amazonaws.com/644160558196/test-sqs", 
             "https://us-west-2.queue.amazonaws.com/644160558196/whit537-testing-mailer"
         ], 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "936dbef5-b14c-5057-9892-ef7bc73a04eb", 
+            "RequestId": "457c3861-6a52-543a-99e6-69f6cf1a88ec", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "936dbef5-b14c-5057-9892-ef7bc73a04eb", 
-                "content-length": "420", 
+                "x-amzn-requestid": "457c3861-6a52-543a-99e6-69f6cf1a88ec", 
+                "content-length": "505", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Thu, 11 May 2017 14:24:54 GMT", 
+                "date": "Thu, 18 May 2017 13:35:04 GMT", 
                 "content-type": "text/xml"
             }
         }

--- a/tests/data/placebo/test_sqs_delete/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.ListQueues_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "QueueUrls": [
+            "https://us-west-2.queue.amazonaws.com/644160558196/test-sqs", 
+            "https://us-west-2.queue.amazonaws.com/644160558196/whit537-testing-mailer"
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "936dbef5-b14c-5057-9892-ef7bc73a04eb", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "936dbef5-b14c-5057-9892-ef7bc73a04eb", 
+                "content-length": "420", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 11 May 2017 14:24:54 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_delete/sqs.PurgeQueue_1.json
+++ b/tests/data/placebo/test_sqs_delete/sqs.PurgeQueue_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 400, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 400, 
+            "RequestId": "f1656e37-e88d-54e3-838f-3fa04dc7675d", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f1656e37-e88d-54e3-838f-3fa04dc7675d", 
+                "content-length": "333", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 18 May 2017 13:35:06 GMT", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "Error": {
+            "Message": "The specified queue does not exist for this wsdl version.", 
+            "Code": "AWS.SimpleQueueService.NonExistentQueue", 
+            "Type": "Sender", 
+            "Detail": null
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/kms.CreateAlias_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/kms.CreateAlias_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "a638a8ac-3be5-11e7-bbe2-9d269cf3e736", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "a638a8ac-3be5-11e7-bbe2-9d269cf3e736", 
+                "content-length": "0", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 18 May 2017 16:18:38 GMT", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/kms.CreateKey_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/kms.CreateKey_1.json
@@ -24,13 +24,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "a7562734-3be5-11e7-808e-33010b744dbb", 
+            "RequestId": "a60d5389-3be5-11e7-bbe2-9d269cf3e736", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "a7562734-3be5-11e7-808e-33010b744dbb", 
+                "x-amzn-requestid": "a60d5389-3be5-11e7-bbe2-9d269cf3e736", 
                 "content-length": "334", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Thu, 18 May 2017 16:18:39 GMT", 
+                "date": "Thu, 18 May 2017 16:18:37 GMT", 
                 "content-type": "application/x-amz-json-1.1"
             }
         }

--- a/tests/data/placebo/test_sqs_set_encryption/kms.DescribeKey_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/kms.DescribeKey_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "KeyMetadata": {
+            "Origin": "AWS_KMS", 
+            "KeyId": "44d25a5c-7efa-44ed-8436-b9511ea921b3", 
+            "Description": "Custodian Test", 
+            "Enabled": true, 
+            "KeyUsage": "ENCRYPT_DECRYPT", 
+            "KeyState": "Enabled", 
+            "CreationDate": {
+                "hour": 6, 
+                "__class__": "datetime", 
+                "month": 5, 
+                "second": 38, 
+                "microsecond": 394000, 
+                "year": 2017, 
+                "day": 5, 
+                "minute": 56
+            }, 
+            "Arn": "arn:aws:kms:us-west-2:644160558196:key/44d25a5c-7efa-44ed-8436-b9511ea921b3", 
+            "AWSAccountId": "644160558196"
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "eb4366e1-3725-11e7-80c2-1763fb6d0630", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "eb4366e1-3725-11e7-80c2-1763fb6d0630", 
+                "content-length": "325", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Fri, 12 May 2017 15:16:06 GMT", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/kms.DisableKey_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/kms.DisableKey_1.json
@@ -4,14 +4,14 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "a4721c4d-bdc5-552c-b40a-4dda7665d4b1", 
+            "RequestId": "a7dff00d-3be5-11e7-bbe2-9d269cf3e736", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "a4721c4d-bdc5-552c-b40a-4dda7665d4b1", 
-                "content-length": "225", 
+                "x-amzn-requestid": "a7dff00d-3be5-11e7-bbe2-9d269cf3e736", 
+                "content-length": "0", 
                 "server": "Server", 
                 "connection": "keep-alive", 
                 "date": "Thu, 18 May 2017 16:18:40 GMT", 
-                "content-type": "text/xml"
+                "content-type": "application/x-amz-json-1.1"
             }
         }
     }

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.CreateQueue_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.CreateQueue_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "QueueUrl": "https://us-west-2.queue.amazonaws.com/644160558196/sqs-test", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e7b78d33-ef17-54ec-ae2f-dca4248b0d99", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "e7b78d33-ef17-54ec-ae2f-dca4248b0d99", 
+                "content-length": "330", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 18 May 2017 16:18:37 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.DeleteQueue_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.DeleteQueue_1.json
@@ -4,13 +4,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "744e5716-59da-5708-8c5e-0681fc9060cc", 
+            "RequestId": "ca544404-837a-523b-849d-159348da6b4e", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "744e5716-59da-5708-8c5e-0681fc9060cc", 
+                "x-amzn-requestid": "ca544404-837a-523b-849d-159348da6b4e", 
                 "content-length": "211", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Thu, 18 May 2017 13:35:06 GMT", 
+                "date": "Thu, 18 May 2017 16:18:40 GMT", 
                 "content-type": "text/xml"
             }
         }

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,31 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Attributes": {
+            "ApproximateNumberOfMessagesNotVisible": "0", 
+            "MessageRetentionPeriod": "345600", 
+            "ApproximateNumberOfMessagesDelayed": "0", 
+            "MaximumMessageSize": "262144", 
+            "CreatedTimestamp": "1494600997", 
+            "ApproximateNumberOfMessages": "0", 
+            "ReceiveMessageWaitTimeSeconds": "0", 
+            "DelaySeconds": "0", 
+            "VisibilityTimeout": "30", 
+            "LastModifiedTimestamp": "1494600997", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:test-sqs"
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b7351969-3a5a-575f-9726-48e6e9afb94e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b7351969-3a5a-575f-9726-48e6e9afb94e", 
+                "content-length": "1162", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Fri, 12 May 2017 15:16:05 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_1.json
@@ -6,24 +6,24 @@
             "MessageRetentionPeriod": "345600", 
             "ApproximateNumberOfMessagesDelayed": "0", 
             "MaximumMessageSize": "262144", 
-            "CreatedTimestamp": "1494600997", 
+            "CreatedTimestamp": "1495124316", 
             "ApproximateNumberOfMessages": "0", 
             "ReceiveMessageWaitTimeSeconds": "0", 
             "DelaySeconds": "0", 
             "VisibilityTimeout": "30", 
-            "LastModifiedTimestamp": "1494600997", 
-            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:test-sqs"
+            "LastModifiedTimestamp": "1495124316", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:sqs-test"
         }, 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "b7351969-3a5a-575f-9726-48e6e9afb94e", 
+            "RequestId": "f7a012e9-b73a-5282-8920-437e7ca59e61", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "b7351969-3a5a-575f-9726-48e6e9afb94e", 
+                "x-amzn-requestid": "f7a012e9-b73a-5282-8920-437e7ca59e61", 
                 "content-length": "1162", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Fri, 12 May 2017 15:16:05 GMT", 
+                "date": "Thu, 18 May 2017 16:18:39 GMT", 
                 "content-type": "text/xml"
             }
         }

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_2.json
@@ -1,0 +1,32 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Attributes": {
+            "ApproximateNumberOfMessagesNotVisible": "0", 
+            "Policy": "{\"Version\":\"2012-10-17\",\"Id\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer/SQSDefaultPolicy\",\"Statement\":[{\"Sid\":\"Sid1483703606926\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"SQS:*\",\"Resource\":\"arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer\"}]}", 
+            "MessageRetentionPeriod": "345600", 
+            "ApproximateNumberOfMessagesDelayed": "0", 
+            "MaximumMessageSize": "262144", 
+            "CreatedTimestamp": "1483525735", 
+            "ApproximateNumberOfMessages": "0", 
+            "ReceiveMessageWaitTimeSeconds": "0", 
+            "DelaySeconds": "0", 
+            "VisibilityTimeout": "30", 
+            "LastModifiedTimestamp": "1483703607", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:whit537-testing-mailer"
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "a86e5daf-baf2-5664-8ed6-0c2069077a7e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "a86e5daf-baf2-5664-8ed6-0c2069077a7e", 
+                "content-length": "1651", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Fri, 12 May 2017 15:16:05 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_2.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_2.json
@@ -18,13 +18,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "a86e5daf-baf2-5664-8ed6-0c2069077a7e", 
+            "RequestId": "ba2359da-ff72-585c-8330-084d34edb64d", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "a86e5daf-baf2-5664-8ed6-0c2069077a7e", 
+                "x-amzn-requestid": "ba2359da-ff72-585c-8330-084d34edb64d", 
                 "content-length": "1651", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Fri, 12 May 2017 15:16:05 GMT", 
+                "date": "Thu, 18 May 2017 16:18:39 GMT", 
                 "content-type": "text/xml"
             }
         }

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_3.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_3.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Attributes": {
+            "ApproximateNumberOfMessagesNotVisible": "0", 
+            "KmsDataKeyReusePeriodSeconds": "300", 
+            "KmsMasterKeyId": "44d25a5c-7efa-44ed-8436-c9821qe872m3",
+            "MessageRetentionPeriod": "345600", 
+            "ApproximateNumberOfMessagesDelayed": "0", 
+            "MaximumMessageSize": "262144", 
+            "CreatedTimestamp": "1494600997", 
+            "ApproximateNumberOfMessages": "0", 
+            "ReceiveMessageWaitTimeSeconds": "0", 
+            "DelaySeconds": "0", 
+            "VisibilityTimeout": "30", 
+            "LastModifiedTimestamp": "1494602166", 
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:test-sqs"
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ac8e8def-5cf1-5d86-9f93-dc60bb89cf07", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ac8e8def-5cf1-5d86-9f93-dc60bb89cf07", 
+                "content-length": "1345", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Fri, 12 May 2017 16:39:20 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_3.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueAttributes_3.json
@@ -3,29 +3,29 @@
     "data": {
         "Attributes": {
             "ApproximateNumberOfMessagesNotVisible": "0", 
-            "KmsDataKeyReusePeriodSeconds": "300", 
-            "KmsMasterKeyId": "44d25a5c-7efa-44ed-8436-c9821qe872m3",
-            "MessageRetentionPeriod": "345600", 
-            "ApproximateNumberOfMessagesDelayed": "0", 
-            "MaximumMessageSize": "262144", 
-            "CreatedTimestamp": "1494600997", 
-            "ApproximateNumberOfMessages": "0", 
-            "ReceiveMessageWaitTimeSeconds": "0", 
-            "DelaySeconds": "0", 
-            "VisibilityTimeout": "30", 
-            "LastModifiedTimestamp": "1494602166", 
-            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:test-sqs"
-        }, 
+            "KmsDataKeyReusePeriodSeconds": "300",
+            "KmsMasterKeyId": "c4816d44-73c3-4eed-a7cc-d52a74fa3294",
+            "MessageRetentionPeriod": "345600",
+            "ApproximateNumberOfMessagesDelayed": "0",
+            "MaximumMessageSize": "262144",
+            "CreatedTimestamp": "1495123666",
+            "ApproximateNumberOfMessages": "0",
+            "ReceiveMessageWaitTimeSeconds": "0",
+            "DelaySeconds": "0",
+            "VisibilityTimeout": "30",
+            "LastModifiedTimestamp": "1495123670",
+            "QueueArn": "arn:aws:sqs:us-west-2:644160558196:sqs-test"
+        },
         "ResponseMetadata": {
-            "RetryAttempts": 0, 
-            "HTTPStatusCode": 200, 
-            "RequestId": "ac8e8def-5cf1-5d86-9f93-dc60bb89cf07", 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "fa74f3cb-cc78-581e-bb85-a25c05a32bda",
             "HTTPHeaders": {
-                "x-amzn-requestid": "ac8e8def-5cf1-5d86-9f93-dc60bb89cf07", 
-                "content-length": "1345", 
-                "server": "Server", 
-                "connection": "keep-alive", 
-                "date": "Fri, 12 May 2017 16:39:20 GMT", 
+                "x-amzn-requestid": "fa74f3cb-cc78-581e-bb85-a25c05a32bda",
+                "content-length": "1345",
+                "server": "Server",
+                "connection": "keep-alive",
+                "date": "Thu, 18 May 2017 16:11:07 GMT",
                 "content-type": "text/xml"
             }
         }

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueUrl_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.GetQueueUrl_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "QueueUrl": "https://us-west-2.queue.amazonaws.com/644160558196/sqs-test", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "058182e5-f18b-5220-b7c2-d3723a165b55", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "058182e5-f18b-5220-b7c2-d3723a165b55", 
+                "content-length": "330", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 18 May 2017 16:18:37 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.ListQueues_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "QueueUrls": [
+            "https://us-west-2.queue.amazonaws.com/644160558196/test-sqs", 
+            "https://us-west-2.queue.amazonaws.com/644160558196/whit537-testing-mailer"
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "62c25883-ee52-5604-8e12-090c3da61451", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "62c25883-ee52-5604-8e12-090c3da61451", 
+                "content-length": "420", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Fri, 12 May 2017 15:16:04 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.ListQueues_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.ListQueues_1.json
@@ -2,19 +2,19 @@
     "status_code": 200, 
     "data": {
         "QueueUrls": [
-            "https://us-west-2.queue.amazonaws.com/644160558196/test-sqs", 
+            "https://us-west-2.queue.amazonaws.com/644160558196/sqs-test", 
             "https://us-west-2.queue.amazonaws.com/644160558196/whit537-testing-mailer"
         ], 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "62c25883-ee52-5604-8e12-090c3da61451", 
+            "RequestId": "043ae68c-4aa9-5efa-b5ce-b71b8137178f", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "62c25883-ee52-5604-8e12-090c3da61451", 
+                "x-amzn-requestid": "043ae68c-4aa9-5efa-b5ce-b71b8137178f", 
                 "content-length": "420", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Fri, 12 May 2017 15:16:04 GMT", 
+                "date": "Thu, 18 May 2017 16:18:38 GMT", 
                 "content-type": "text/xml"
             }
         }

--- a/tests/data/placebo/test_sqs_set_encryption/sqs.SetQueueAttributes_1.json
+++ b/tests/data/placebo/test_sqs_set_encryption/sqs.SetQueueAttributes_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6199ffeb-c5d5-5399-88a1-ae641623f6a4", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6199ffeb-c5d5-5399-88a1-ae641623f6a4", 
+                "content-length": "225", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Fri, 12 May 2017 15:16:06 GMT", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -1,0 +1,52 @@
+# Copyright 2016 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+from common import BaseTest
+
+
+class TestSqsAction(BaseTest):
+
+    def test_sqs_delete(self):
+        session_factory = self.replay_flight_data(
+            'test_sqs_delete')
+        client = session_factory().client('sqs')
+        p = self.load_policy({
+            'name': 'sqs-delete',
+            'resource': 'sqs',
+            'filters': [{'QueueArn': 'arn:aws:sqs:us-west-2:644160558196:test-sqs'},
+                        {'KmsMasterKeyId': 'alias/aws/sqs'}],
+            'actions': [
+                {'type': 'delete'}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_sqs_set_encryption(self):
+        session_factory = self.replay_flight_data(
+            'test_sqs_set_encryption')
+        client = session_factory().client('sqs')
+        p = self.load_policy({
+            'name': 'sqs-delete',
+            'resource': 'sqs',
+            'filters': [{'QueueArn': 'arn:aws:sqs:us-west-2:644160558196:test-sqs'}],
+            'actions': [
+                {'type': 'set-encryption',
+                 'key': 'c7n-test'}]},
+            session_factory=session_factory)
+        resources = p.run()
+        check_master_key = client.get_queue_attributes(
+            QueueUrl=
+            'https://sqs.us-west-2.amazonaws.com/644160558196/test-sqs',
+            AttributeNames=['All'])['Attributes']['KmsMasterKeyId']
+        self.assertEqual(check_master_key, '44d25a5c-7efa-44ed-8436-c9821qe872m3')

--- a/tests/test_sqs.py
+++ b/tests/test_sqs.py
@@ -12,41 +12,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-from common import BaseTest
+from common import BaseTest, functional
+from botocore.exceptions import ClientError
+import time
+
 
 
 class TestSqsAction(BaseTest):
 
+    @functional
     def test_sqs_delete(self):
         session_factory = self.replay_flight_data(
             'test_sqs_delete')
         client = session_factory().client('sqs')
+        client.create_queue(QueueName='test-sqs')
+        queue_url = client.get_queue_url(QueueName='test-sqs')['QueueUrl']
+
         p = self.load_policy({
             'name': 'sqs-delete',
             'resource': 'sqs',
-            'filters': [{'QueueArn': 'arn:aws:sqs:us-west-2:644160558196:test-sqs'},
-                        {'KmsMasterKeyId': 'alias/aws/sqs'}],
+            'filters': [{'QueueUrl': queue_url}],
             'actions': [
                 {'type': 'delete'}]},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        self.assertRaises(
+            ClientError,
+            client.purge_queue, QueueUrl=queue_url)
 
+
+    @functional
     def test_sqs_set_encryption(self):
         session_factory = self.replay_flight_data(
             'test_sqs_set_encryption')
-        client = session_factory().client('sqs')
+
+        client_sqs = session_factory().client('sqs')
+        client_sqs.create_queue(QueueName='sqs-test')
+        queue_url = client_sqs.get_queue_url(QueueName='sqs-test')['QueueUrl']
+        self.addCleanup(client_sqs.delete_queue, QueueUrl=queue_url)
+
+        client_kms = session_factory().client('kms')
+        key_id = client_kms.create_key(Description='West SQS encryption key')['KeyMetadata']['KeyId']
+        client_kms.create_alias(
+            AliasName='alias/new-key-test-sqs',
+            TargetKeyId=key_id)
+        self.addCleanup(client_kms.disable_key, KeyId=key_id)
+
         p = self.load_policy({
             'name': 'sqs-delete',
             'resource': 'sqs',
-            'filters': [{'QueueArn': 'arn:aws:sqs:us-west-2:644160558196:test-sqs'}],
+            'filters': [{'QueueUrl': queue_url}],
             'actions': [
                 {'type': 'set-encryption',
-                 'key': 'c7n-test'}]},
+                 'key': 'new-key-test-sqs'}]},
             session_factory=session_factory)
         resources = p.run()
-        check_master_key = client.get_queue_attributes(
-            QueueUrl=
-            'https://sqs.us-west-2.amazonaws.com/644160558196/test-sqs',
+
+        check_master_key = client_sqs.get_queue_attributes(
+            QueueUrl=queue_url,
             AttributeNames=['All'])['Attributes']['KmsMasterKeyId']
-        self.assertEqual(check_master_key, '44d25a5c-7efa-44ed-8436-c9821qe872m3')
+        self.assertEqual(check_master_key, 'c4816d44-73c3-4eed-a7cc-d52a74fa3294')


### PR DESCRIPTION
This PR contains 2 actions for SQS:
- delete (deletes queue)
- set-encryption (reconfigures queue to include encryption key)

@kapilt Ready for review.
Thanks.