### PR TITLE
Region-aware session cache - choice 1 - one total session

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -189,12 +189,16 @@ CONN_CACHE = threading.local()
 def local_session(factory):
     """Cache a session thread local for up to 45m"""
     s = getattr(CONN_CACHE, 'session', None)
+    r = getattr(CONN_CACHE, 'region', None)
     t = getattr(CONN_CACHE, 'time', 0)
     n = time.time()
-    if s is not None and t + (60 * 45) > n:
+    if (s is not None and
+        r == factory.region and
+        t + (60 * 45) > n):
         return s
     s = factory()
     CONN_CACHE.session = s
+    CONN_CACHE.region = factory.region
     CONN_CACHE.time = n
     return s
 

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -190,17 +190,18 @@ CONN_CACHE = threading.local()
 
 def local_session(factory):
     """Cache a session thread local for up to 45m"""
+    factory_region = getattr(factory, 'region', None)
     s = getattr(CONN_CACHE, 'session', None)
     r = getattr(CONN_CACHE, 'region', None)
     t = getattr(CONN_CACHE, 'time', 0)
     n = time.time()
     if (s is not None and
-        r == factory.region and
-        t + (60 * 45) > n):
+            r == factory_region and
+            t + (60 * 45) > n):
         return s
     s = factory()
     CONN_CACHE.session = s
-    CONN_CACHE.region = factory.region
+    CONN_CACHE.region = factory_region
     CONN_CACHE.time = n
     return s
 

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -195,7 +195,7 @@ def local_session(factory):
     r = getattr(CONN_CACHE, 'region', None)
     t = getattr(CONN_CACHE, 'time', 0)
     n = time.time()
-    if (s is not None and
+    if (s is not None and r is not None and
             r == factory_region and
             t + (60 * 45) > n):
         return s


### PR DESCRIPTION
This is mutually exclusive with PR #1162

@kapilt - While looking at #1150 I discovered a problem with the session caching.  It ignores the region when caching sessions so when we ran in multi-region mode we would pull the wrong session.

This fixes that, although it is just storing one session total.  In #1162 I store one session per region.