### PR TITLE
iam: allow null as value

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -520,7 +520,8 @@ class CredentialReport(Filter):
             {'type': 'array'},
             {'type': 'string'},
             {'type': 'boolean'},
-            {'type': 'number'}]},
+            {'type': 'number'},
+            {'type': 'null'}]},
         op={'enum': OPERATORS.keys()},
         report_generate={
             'title': 'Generate a report if none is present.',


### PR DESCRIPTION
Sometimes its useful to use a value of null.  For instance:

    resource: iam-user
    filters:
    - type: credential
      key: access_keys.last_used_date
      value: null

In order to find all users that have never used their access_keys.