### PR TITLE
schema: relax policy name constraints

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -150,7 +150,7 @@ def generate(resource_types=()):
             'properties': {
                 'name': {
                     'type': 'string',
-                    'pattern': "^[A-z][A-z0-9]*(-[A-z0-9]*[A-z][A-z0-9]*)*$"},
+                    'pattern': "^[A-z][A-z0-9]*(-[A-z0-9]+)*$"},
                 'region': {'type': 'string'},
                 'resource': {'type': 'string'},
                 'max-resources': {'type': 'integer'},


### PR DESCRIPTION
I'm attempting to name some policies: control-1-2

Some security documents usually label controls like Control 1.2 and I
feel changing it to control-1-2 is a good compromise as I'm sure there
are reasons I'm not understanding for the current requirements.