### PR TITLE
filters: allow ValueFilter to accept null value

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -264,7 +264,8 @@ class ValueFilter(Filter):
                 {'type': 'array'},
                 {'type': 'string'},
                 {'type': 'boolean'},
-                {'type': 'number'}]},
+                {'type': 'number'},
+                {'type': 'null'}]},
             'op': {'enum': OPERATORS.keys()}}}
 
     annotate = True


### PR DESCRIPTION
The ability to filter for null values can be useful.