### PR TITLE
changed the resource type from ec2 to asg for asg policy example

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -104,13 +104,13 @@ Here's doing the same with auto scale groups
 
     policies:
       - name: asg-offhours-stop
-        resource: ec2
+        resource: asg
         filters:
            - offhour
         actions:
            - suspend
       - name: asg-onhours-start
-        resource: ec2
+        resource: asg
         filters:
            - onhour
         actions:


### PR DESCRIPTION
In the policy examples for asg in the offhours.py filter it had the resource ec2 instead of the correct resource of asg.

Signed-off-by: Tony Witherspoon <tony.witherspoon@gmail.com>