### PR TITLE
set content-type to text/plain instead of text/Text

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/sqs_message_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/sqs_message_processor.py
@@ -180,7 +180,7 @@ class SqsMessageProcessor(object):
 
     def send_c7n_email(self, data, email_to_addr, subject, body):
         email_format = data['action'].get(
-            'template', 'default').endswith('html') and 'Html' or 'Text'
+            'template', 'default').endswith('html') and 'html' or 'plain'
 
         from_addr          = data['action'].get('from', self.config['from_address'])
         message            = MIMEText(body.encode('utf-8'), email_format)


### PR DESCRIPTION
Sets email to text/plain (with text/Text it comes in as an attachment called noname in gmail)