### PR TITLE
Delete transient tags on newly encrypted volume

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,4 +44,4 @@ ghpages:
 	git commit -m "Updated generated Sphinx documentation"
 
 clean:
-	rm -rf .Python bin include lib pip-selfcheck.json 
+	rm -rf .Python bin include lib pip-selfcheck.json

--- a/tests/data/placebo/test_encrypt_volumes/ec2.AttachVolume_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.AttachVolume_1.json
@@ -2,21 +2,29 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "3eedaff7-930b-4616-a77c-423f747db840"
+            "RequestId": "761ad00f-8e4c-474b-9597-ee9eebb7e3f6", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:24:04 GMT"
+            }
         }, 
         "AttachTime": {
-            "hour": 11, 
+            "hour": 18, 
             "__class__": "datetime", 
-            "month": 5, 
-            "second": 47, 
-            "microsecond": 83000, 
-            "year": 2016, 
+            "month": 6, 
+            "second": 5, 
+            "microsecond": 747000, 
+            "year": 2017, 
             "day": 8, 
-            "minute": 13
+            "minute": 24
         }, 
-        "InstanceId": "i-9432cb49", 
-        "VolumeId": "vol-add3fa14", 
+        "InstanceId": "i-0aaaaec4b77188b69", 
+        "VolumeId": "vol-072dfa20eef03dd38", 
         "State": "attaching", 
         "Device": "/dev/xvda"
     }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.CopySnapshot_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.CopySnapshot_1.json
@@ -1,10 +1,18 @@
 {
     "status_code": 200, 
     "data": {
-        "SnapshotId": "snap-ee6f74be", 
+        "SnapshotId": "snap-0bd2772f3c7cafa62", 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "f1cfcfcf-5e3f-4a8a-ae4a-43faad61eda4"
+            "RequestId": "43f078a5-8377-4c45-9b5d-968900f967b5", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:19:58 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.CreateSnapshot_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.CreateSnapshot_1.json
@@ -3,25 +3,33 @@
     "data": {
         "Description": "maid transient snapshot for encryption", 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "a4eb8dc0-5f38-4fe2-9634-87c43e85590f"
+            "RequestId": "b4f4c742-2a09-4057-ab77-e07ce178632a", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:18:55 GMT"
+            }
         }, 
         "Encrypted": false, 
-        "VolumeId": "vol-fdd1f844", 
+        "VolumeId": "vol-0f53c81b92b4ecfce", 
         "State": "pending", 
         "VolumeSize": 8, 
         "Progress": "", 
         "StartTime": {
-            "hour": 11, 
+            "hour": 18, 
             "__class__": "datetime", 
-            "month": 5, 
-            "second": 7, 
+            "month": 6, 
+            "second": 56, 
             "microsecond": 0, 
-            "year": 2016, 
+            "year": 2017, 
             "day": 8, 
-            "minute": 9
+            "minute": 18
         }, 
-        "SnapshotId": "snap-c8965395", 
-        "OwnerId": "619193117841"
+        "SnapshotId": "snap-09ab186abf23129b6", 
+        "OwnerId": "185106417252"
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.CreateTags_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.CreateTags_1.json
@@ -2,8 +2,16 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "2b7f5783-26ee-4526-9a33-1dad52bc6ee9"
+            "RequestId": "717b41af-ddb7-4aca-a284-f722f2893af6", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:18:56 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.CreateTags_2.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.CreateTags_2.json
@@ -2,8 +2,16 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "c49e69ab-36f3-46bf-b01e-4e7dfa88c742"
+            "RequestId": "e9f41987-3f3b-414b-be99-e084cfe5cb74", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:19:58 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.CreateTags_3.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.CreateTags_3.json
@@ -2,8 +2,16 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "c865cd71-c970-4e94-8ae5-91751b32912e"
+            "RequestId": "ed2cfe96-58f6-4ee4-a294-00f910458a3f", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:23:18 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.CreateVolume_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.CreateVolume_1.json
@@ -1,26 +1,34 @@
 {
     "status_code": 200, 
     "data": {
-        "AvailabilityZone": "us-west-2c", 
+        "AvailabilityZone": "us-east-1a", 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "3d0a2da9-13dd-4d41-b833-cda44e920090"
+            "RequestId": "e3e139eb-1804-41af-9cd8-4dbc36e1512d", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:23:18 GMT"
+            }
         }, 
         "Encrypted": true, 
         "VolumeType": "gp2", 
-        "VolumeId": "vol-add3fa14", 
+        "VolumeId": "vol-072dfa20eef03dd38", 
         "State": "creating", 
-        "Iops": 24, 
-        "SnapshotId": "snap-ee6f74be", 
+        "Iops": 100, 
+        "SnapshotId": "snap-0bd2772f3c7cafa62", 
         "CreateTime": {
-            "hour": 11, 
+            "hour": 18, 
             "__class__": "datetime", 
-            "month": 5, 
-            "second": 26, 
-            "microsecond": 851000, 
-            "year": 2016, 
+            "month": 6, 
+            "second": 18, 
+            "microsecond": 581000, 
+            "year": 2017, 
             "day": 8, 
-            "minute": 13
+            "minute": 23
         }, 
         "Size": 8
     }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DeleteSnapshot_2.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DeleteSnapshot_2.json
@@ -2,8 +2,16 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "14e64592-ae75-42e2-ae6c-b836fb916bbc"
+            "RequestId": "dea21f6a-0aaf-4341-a03a-31e35c8c5a33", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:23:33 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DeleteTags_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DeleteTags_1.json
@@ -4,13 +4,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "8ab1192c-adcd-43f4-8120-1de150bb6ad3", 
+            "RequestId": "4a1959d6-03dc-4770-a626-a667079f13f4", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "vary": "Accept-Encoding", 
                 "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Thu, 08 Jun 2017 18:23:33 GMT"
+                "date": "Thu, 08 Jun 2017 18:24:05 GMT"
             }
         }
     }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DeleteVolume_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DeleteVolume_1.json
@@ -2,8 +2,16 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "aa07fd4b-de52-4e0a-a0c5-b8e11702fc1c"
+            "RequestId": "44f066d7-ce25-494a-af48-6d2447a51a06", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:24:05 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DescribeInstances_1.json
@@ -3,103 +3,107 @@
     "data": {
         "Reservations": [
             {
-                "OwnerId": "619193117841", 
-                "ReservationId": "r-518aecff", 
+                "OwnerId": "185106417252", 
+                "ReservationId": "r-0cebd39f31d71ee75", 
                 "Groups": [], 
                 "Instances": [
                     {
                         "Monitoring": {
                             "State": "disabled"
                         }, 
-                        "PublicDnsName": "", 
+                        "PublicDnsName": "ec2-54-166-213-240.compute-1.amazonaws.com", 
                         "State": {
                             "Code": 16, 
                             "Name": "running"
                         }, 
                         "EbsOptimized": false, 
                         "LaunchTime": {
-                            "hour": 11, 
+                            "hour": 17, 
                             "__class__": "datetime", 
-                            "month": 5, 
-                            "second": 33, 
+                            "month": 6, 
+                            "second": 20, 
                             "microsecond": 0, 
-                            "year": 2016, 
+                            "year": 2017, 
                             "day": 8, 
-                            "minute": 6
+                            "minute": 58
                         }, 
-                        "PrivateIpAddress": "172.31.6.75", 
+                        "PublicIpAddress": "54.166.213.240", 
+                        "PrivateIpAddress": "172.31.50.19", 
                         "ProductCodes": [], 
-                        "VpcId": "vpc-399e3d52", 
+                        "VpcId": "vpc-842fd9e2", 
                         "StateTransitionReason": "", 
-                        "InstanceId": "i-9432cb49", 
-                        "ImageId": "ami-c229c0a2", 
-                        "PrivateDnsName": "ip-172-31-6-75.us-west-2.compute.internal", 
-                        "KeyName": "HazmatGreenField", 
+                        "InstanceId": "i-0aaaaec4b77188b69", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-c58c1dd3", 
+                        "PrivateDnsName": "ip-172-31-50-19.ec2.internal", 
                         "SecurityGroups": [
                             {
-                                "GroupName": "jlxc", 
-                                "GroupId": "sg-47b76f22"
-                            }, 
-                            {
                                 "GroupName": "default", 
-                                "GroupId": "sg-0a08e365"
+                                "GroupId": "sg-9bd253e6"
                             }
                         ], 
-                        "ClientToken": "RMwtS1462705593120", 
-                        "SubnetId": "subnet-389e3d53", 
-                        "InstanceType": "m3.medium", 
+                        "ClientToken": "oZhSF1496944699380", 
+                        "SubnetId": "subnet-719b295c", 
+                        "InstanceType": "t2.micro", 
                         "NetworkInterfaces": [
                             {
                                 "Status": "in-use", 
-                                "MacAddress": "0a:b3:a8:83:54:ff", 
+                                "MacAddress": "12:d9:d1:45:41:56", 
                                 "SourceDestCheck": true, 
-                                "VpcId": "vpc-399e3d52", 
-                                "Description": "Primary network interface", 
-                                "NetworkInterfaceId": "eni-d23dd48e", 
+                                "VpcId": "vpc-842fd9e2", 
+                                "Description": "", 
+                                "Association": {
+                                    "PublicIp": "54.166.213.240", 
+                                    "PublicDnsName": "ec2-54-166-213-240.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }, 
+                                "NetworkInterfaceId": "eni-ca3b7702", 
                                 "PrivateIpAddresses": [
                                     {
-                                        "PrivateDnsName": "ip-172-31-6-75.us-west-2.compute.internal", 
+                                        "PrivateDnsName": "ip-172-31-50-19.ec2.internal", 
+                                        "Association": {
+                                            "PublicIp": "54.166.213.240", 
+                                            "PublicDnsName": "ec2-54-166-213-240.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }, 
                                         "Primary": true, 
-                                        "PrivateIpAddress": "172.31.6.75"
+                                        "PrivateIpAddress": "172.31.50.19"
                                     }
                                 ], 
-                                "PrivateDnsName": "ip-172-31-6-75.us-west-2.compute.internal", 
+                                "PrivateDnsName": "ip-172-31-50-19.ec2.internal", 
                                 "Attachment": {
                                     "Status": "attached", 
                                     "DeviceIndex": 0, 
                                     "DeleteOnTermination": true, 
-                                    "AttachmentId": "eni-attach-a741656e", 
+                                    "AttachmentId": "eni-attach-0dbaf023", 
                                     "AttachTime": {
-                                        "hour": 11, 
+                                        "hour": 17, 
                                         "__class__": "datetime", 
-                                        "month": 5, 
-                                        "second": 33, 
+                                        "month": 6, 
+                                        "second": 20, 
                                         "microsecond": 0, 
-                                        "year": 2016, 
+                                        "year": 2017, 
                                         "day": 8, 
-                                        "minute": 6
+                                        "minute": 58
                                     }
                                 }, 
                                 "Groups": [
                                     {
-                                        "GroupName": "jlxc", 
-                                        "GroupId": "sg-47b76f22"
-                                    }, 
-                                    {
                                         "GroupName": "default", 
-                                        "GroupId": "sg-0a08e365"
+                                        "GroupId": "sg-9bd253e6"
                                     }
                                 ], 
-                                "SubnetId": "subnet-389e3d53", 
-                                "OwnerId": "619193117841", 
-                                "PrivateIpAddress": "172.31.6.75"
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-719b295c", 
+                                "OwnerId": "185106417252", 
+                                "PrivateIpAddress": "172.31.50.19"
                             }
                         ], 
                         "SourceDestCheck": true, 
                         "Placement": {
                             "Tenancy": "default", 
                             "GroupName": "", 
-                            "AvailabilityZone": "us-west-2c"
+                            "AvailabilityZone": "us-east-1a"
                         }, 
                         "Hypervisor": "xen", 
                         "BlockDeviceMappings": [
@@ -108,16 +112,16 @@
                                 "Ebs": {
                                     "Status": "attached", 
                                     "DeleteOnTermination": true, 
-                                    "VolumeId": "vol-fdd1f844", 
+                                    "VolumeId": "vol-0f53c81b92b4ecfce", 
                                     "AttachTime": {
-                                        "hour": 11, 
+                                        "hour": 17, 
                                         "__class__": "datetime", 
-                                        "month": 5, 
-                                        "second": 34, 
+                                        "month": 6, 
+                                        "second": 20, 
                                         "microsecond": 0, 
-                                        "year": 2016, 
+                                        "year": 2017, 
                                         "day": 8, 
-                                        "minute": 6
+                                        "minute": 58
                                     }
                                 }
                             }
@@ -128,12 +132,8 @@
                         "VirtualizationType": "hvm", 
                         "Tags": [
                             {
-                                "Value": "CompiledLambda", 
-                                "Key": "Name"
-                            }, 
-                            {
-                                "Value": "Testing123", 
-                                "Key": "Testing"
+                                "Value": "autorecover-alarm", 
+                                "Key": "c7n-test"
                             }
                         ], 
                         "AmiLaunchIndex": 0
@@ -142,8 +142,16 @@
             }
         ], 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "52c75e54-d5a7-42d0-aa8f-f508de78fcff"
+            "RequestId": "cd4376b3-7546-4542-b1b7-70aee28a6123", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:17:36 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DescribeInstances_2.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DescribeInstances_2.json
@@ -3,8 +3,8 @@
     "data": {
         "Reservations": [
             {
-                "OwnerId": "619193117841", 
-                "ReservationId": "r-518aecff", 
+                "OwnerId": "185106417252", 
+                "ReservationId": "r-0cebd39f31d71ee75", 
                 "Groups": [], 
                 "Instances": [
                     {
@@ -19,88 +19,81 @@
                         }, 
                         "EbsOptimized": false, 
                         "LaunchTime": {
-                            "hour": 11, 
+                            "hour": 17, 
                             "__class__": "datetime", 
-                            "month": 5, 
-                            "second": 33, 
+                            "month": 6, 
+                            "second": 20, 
                             "microsecond": 0, 
-                            "year": 2016, 
+                            "year": 2017, 
                             "day": 8, 
-                            "minute": 6
+                            "minute": 58
                         }, 
-                        "PrivateIpAddress": "172.31.6.75", 
+                        "PrivateIpAddress": "172.31.50.19", 
                         "ProductCodes": [], 
-                        "VpcId": "vpc-399e3d52", 
-                        "StateTransitionReason": "User initiated (2016-05-08 11:08:36 GMT)", 
-                        "InstanceId": "i-9432cb49", 
-                        "ImageId": "ami-c229c0a2", 
-                        "PrivateDnsName": "ip-172-31-6-75.us-west-2.compute.internal", 
-                        "KeyName": "HazmatGreenField", 
+                        "VpcId": "vpc-842fd9e2", 
+                        "StateTransitionReason": "User initiated (2017-06-08 18:17:38 GMT)", 
+                        "InstanceId": "i-0aaaaec4b77188b69", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-c58c1dd3", 
+                        "PrivateDnsName": "ip-172-31-50-19.ec2.internal", 
                         "SecurityGroups": [
                             {
-                                "GroupName": "jlxc", 
-                                "GroupId": "sg-47b76f22"
-                            }, 
-                            {
                                 "GroupName": "default", 
-                                "GroupId": "sg-0a08e365"
+                                "GroupId": "sg-9bd253e6"
                             }
                         ], 
-                        "ClientToken": "RMwtS1462705593120", 
-                        "SubnetId": "subnet-389e3d53", 
-                        "InstanceType": "m3.medium", 
+                        "ClientToken": "oZhSF1496944699380", 
+                        "SubnetId": "subnet-719b295c", 
+                        "InstanceType": "t2.micro", 
                         "NetworkInterfaces": [
                             {
                                 "Status": "in-use", 
-                                "MacAddress": "0a:b3:a8:83:54:ff", 
+                                "MacAddress": "12:d9:d1:45:41:56", 
                                 "SourceDestCheck": true, 
-                                "VpcId": "vpc-399e3d52", 
-                                "Description": "Primary network interface", 
-                                "NetworkInterfaceId": "eni-d23dd48e", 
+                                "VpcId": "vpc-842fd9e2", 
+                                "Description": "", 
+                                "NetworkInterfaceId": "eni-ca3b7702", 
                                 "PrivateIpAddresses": [
                                     {
-                                        "PrivateDnsName": "ip-172-31-6-75.us-west-2.compute.internal", 
+                                        "PrivateDnsName": "ip-172-31-50-19.ec2.internal", 
                                         "Primary": true, 
-                                        "PrivateIpAddress": "172.31.6.75"
+                                        "PrivateIpAddress": "172.31.50.19"
                                     }
                                 ], 
-                                "PrivateDnsName": "ip-172-31-6-75.us-west-2.compute.internal", 
+                                "PrivateDnsName": "ip-172-31-50-19.ec2.internal", 
                                 "Attachment": {
                                     "Status": "attached", 
                                     "DeviceIndex": 0, 
                                     "DeleteOnTermination": true, 
-                                    "AttachmentId": "eni-attach-a741656e", 
+                                    "AttachmentId": "eni-attach-0dbaf023", 
                                     "AttachTime": {
-                                        "hour": 11, 
+                                        "hour": 17, 
                                         "__class__": "datetime", 
-                                        "month": 5, 
-                                        "second": 33, 
+                                        "month": 6, 
+                                        "second": 20, 
                                         "microsecond": 0, 
-                                        "year": 2016, 
+                                        "year": 2017, 
                                         "day": 8, 
-                                        "minute": 6
+                                        "minute": 58
                                     }
                                 }, 
                                 "Groups": [
                                     {
-                                        "GroupName": "jlxc", 
-                                        "GroupId": "sg-47b76f22"
-                                    }, 
-                                    {
                                         "GroupName": "default", 
-                                        "GroupId": "sg-0a08e365"
+                                        "GroupId": "sg-9bd253e6"
                                     }
                                 ], 
-                                "SubnetId": "subnet-389e3d53", 
-                                "OwnerId": "619193117841", 
-                                "PrivateIpAddress": "172.31.6.75"
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-719b295c", 
+                                "OwnerId": "185106417252", 
+                                "PrivateIpAddress": "172.31.50.19"
                             }
                         ], 
                         "SourceDestCheck": true, 
                         "Placement": {
                             "Tenancy": "default", 
                             "GroupName": "", 
-                            "AvailabilityZone": "us-west-2c"
+                            "AvailabilityZone": "us-east-1a"
                         }, 
                         "Hypervisor": "xen", 
                         "BlockDeviceMappings": [
@@ -109,16 +102,16 @@
                                 "Ebs": {
                                     "Status": "attached", 
                                     "DeleteOnTermination": true, 
-                                    "VolumeId": "vol-fdd1f844", 
+                                    "VolumeId": "vol-0f53c81b92b4ecfce", 
                                     "AttachTime": {
-                                        "hour": 11, 
+                                        "hour": 17, 
                                         "__class__": "datetime", 
-                                        "month": 5, 
-                                        "second": 34, 
+                                        "month": 6, 
+                                        "second": 20, 
                                         "microsecond": 0, 
-                                        "year": 2016, 
+                                        "year": 2017, 
                                         "day": 8, 
-                                        "minute": 6
+                                        "minute": 58
                                     }
                                 }
                             }
@@ -132,12 +125,8 @@
                         "VirtualizationType": "hvm", 
                         "Tags": [
                             {
-                                "Value": "CompiledLambda", 
-                                "Key": "Name"
-                            }, 
-                            {
-                                "Value": "Testing123", 
-                                "Key": "Testing"
+                                "Value": "autorecover-alarm", 
+                                "Key": "c7n-test"
                             }
                         ], 
                         "AmiLaunchIndex": 0
@@ -146,8 +135,16 @@
             }
         ], 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "656994cf-437d-4601-9ce0-cbf6cbb0e2ee"
+            "RequestId": "4dd91870-29e5-4210-9e4e-e4f2e569789c", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:18:54 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DescribeSnapshots_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DescribeSnapshots_1.json
@@ -1,36 +1,44 @@
 {
-    "status_code": 200, 
+    "status_code": 200,
     "data": {
         "ResponseMetadata": {
-            "HTTPStatusCode": 200, 
-            "RequestId": "b700bf35-dbd2-4c41-af4c-c9d8bfc6e438"
-        }, 
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "4675df0b-ff29-438a-b37f-d45c84a7f53c",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Thu, 08 Jun 2017 18:19:57 GMT"
+            }
+        },
         "Snapshots": [
             {
-                "Description": "maid transient snapshot for encryption", 
+                "Description": "maid transient snapshot for encryption",
                 "Tags": [
                     {
-                        "Value": "true", 
+                        "Value": "true",
                         "Key": "maid-crypto-remediation"
                     }
-                ], 
-                "Encrypted": false, 
-                "VolumeId": "vol-fdd1f844", 
-                "State": "completed", 
-                "VolumeSize": 8, 
-                "Progress": "100%", 
+                ],
+                "Encrypted": false,
+                "VolumeId": "vol-0f53c81b92b4ecfce",
+                "State": "completed",
+                "VolumeSize": 8,
+                "Progress": "100%",
                 "StartTime": {
-                    "hour": 11, 
-                    "__class__": "datetime", 
-                    "month": 5, 
-                    "second": 7, 
-                    "microsecond": 0, 
-                    "year": 2016, 
-                    "day": 8, 
-                    "minute": 9
-                }, 
-                "SnapshotId": "snap-c8965395", 
-                "OwnerId": "619193117841"
+                    "hour": 18,
+                    "__class__": "datetime",
+                    "month": 6,
+                    "second": 56,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 8,
+                    "minute": 18
+                },
+                "SnapshotId": "snap-09ab186abf23129b6",
+                "OwnerId": "185106417252"
             }
         ]
     }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DescribeSnapshots_2.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DescribeSnapshots_2.json
@@ -2,8 +2,16 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "429f1dd2-aad5-47ef-b11a-315af3bd0789"
+            "RequestId": "d6f346e5-13c6-4dd2-9154-644ae98442c2", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:23:17 GMT"
+            }
         }, 
         "Snapshots": [
             {
@@ -15,23 +23,23 @@
                     }
                 ], 
                 "Encrypted": true, 
-                "VolumeId": "vol-f4976c8e", 
-                "KmsKeyId": "arn:aws:kms:us-west-2:619193117841:key/00d9c89e-13ee-4758-9167-41de13b5bb68", 
+                "VolumeId": "vol-ffffffff", 
+                "KmsKeyId": "arn:aws:kms:us-east-1:185106417252:key/3cc8863f-09dd-45cd-90cf-d6149710582e", 
                 "State": "completed", 
                 "VolumeSize": 8, 
                 "Progress": "100%", 
                 "StartTime": {
-                    "hour": 11, 
+                    "hour": 18, 
                     "__class__": "datetime", 
-                    "month": 5, 
-                    "second": 24, 
+                    "month": 6, 
+                    "second": 58, 
                     "microsecond": 0, 
-                    "year": 2016, 
+                    "year": 2017, 
                     "day": 8, 
-                    "minute": 10
+                    "minute": 19
                 }, 
-                "SnapshotId": "snap-ee6f74be", 
-                "OwnerId": "619193117841"
+                "SnapshotId": "snap-0bd2772f3c7cafa62", 
+                "OwnerId": "185106417252"
             }
         ]
     }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DescribeVolumes_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DescribeVolumes_1.json
@@ -2,26 +2,34 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "31fbd943-df5b-40d7-9320-f21078d97a5d"
+            "RequestId": "5c2be22c-95a1-4813-a6ce-b2156da10d38", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:17:37 GMT"
+            }
         }, 
         "Volumes": [
             {
-                "AvailabilityZone": "us-west-2c", 
+                "AvailabilityZone": "us-east-1a", 
                 "Attachments": [
                     {
                         "AttachTime": {
-                            "hour": 11, 
+                            "hour": 17, 
                             "__class__": "datetime", 
-                            "month": 5, 
-                            "second": 34, 
+                            "month": 6, 
+                            "second": 20, 
                             "microsecond": 0, 
-                            "year": 2016, 
+                            "year": 2017, 
                             "day": 8, 
-                            "minute": 6
+                            "minute": 58
                         }, 
-                        "InstanceId": "i-9432cb49", 
-                        "VolumeId": "vol-fdd1f844", 
+                        "InstanceId": "i-0aaaaec4b77188b69", 
+                        "VolumeId": "vol-0f53c81b92b4ecfce", 
                         "State": "attached", 
                         "DeleteOnTermination": true, 
                         "Device": "/dev/xvda"
@@ -29,19 +37,58 @@
                 ], 
                 "Encrypted": false, 
                 "VolumeType": "gp2", 
-                "VolumeId": "vol-fdd1f844", 
+                "VolumeId": "vol-0f53c81b92b4ecfce", 
                 "State": "in-use", 
-                "Iops": 24, 
-                "SnapshotId": "snap-eef4cdae", 
+                "Iops": 100, 
+                "SnapshotId": "snap-0120309fef406aa90", 
                 "CreateTime": {
-                    "hour": 11, 
+                    "hour": 17, 
                     "__class__": "datetime", 
-                    "month": 5, 
-                    "second": 33, 
-                    "microsecond": 984000, 
-                    "year": 2016, 
+                    "month": 6, 
+                    "second": 20, 
+                    "microsecond": 943000, 
+                    "year": 2017, 
                     "day": 8, 
-                    "minute": 6
+                    "minute": 58
+                }, 
+                "Size": 8
+            }, 
+            {
+                "AvailabilityZone": "us-east-1d", 
+                "Attachments": [
+                    {
+                        "AttachTime": {
+                            "hour": 17, 
+                            "__class__": "datetime", 
+                            "month": 6, 
+                            "second": 13, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 8, 
+                            "minute": 56
+                        }, 
+                        "InstanceId": "i-0923d7347b2922405", 
+                        "VolumeId": "vol-06fb3a30a68993a66", 
+                        "State": "attached", 
+                        "DeleteOnTermination": true, 
+                        "Device": "/dev/xvda"
+                    }
+                ], 
+                "Encrypted": false, 
+                "VolumeType": "gp2", 
+                "VolumeId": "vol-06fb3a30a68993a66", 
+                "State": "in-use", 
+                "Iops": 100, 
+                "SnapshotId": "snap-0120309fef406aa90", 
+                "CreateTime": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 13, 
+                    "microsecond": 625000, 
+                    "year": 2017, 
+                    "day": 8, 
+                    "minute": 56
                 }, 
                 "Size": 8
             }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DescribeVolumes_3.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DescribeVolumes_3.json
@@ -4,37 +4,41 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "57d42816-b194-4a14-be24-f799fd11a85e", 
+            "RequestId": "18ec197d-bbe3-4480-a1cd-eedb2946f090", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "vary": "Accept-Encoding", 
                 "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Thu, 08 Jun 2017 18:23:33 GMT"
+                "date": "Thu, 08 Jun 2017 18:24:06 GMT"
             }
         }, 
         "Volumes": [
             {
                 "AvailabilityZone": "us-east-1a", 
-                "Attachments": [], 
-                "Tags": [
+                "Attachments": [
                     {
-                        "Value": "/dev/xvda", 
-                        "Key": "maid-instance-device"
-                    }, 
-                    {
-                        "Value": "i-0aaaaec4b77188b69", 
-                        "Key": "maid-crypt-remediation"
-                    }, 
-                    {
-                        "Value": "vol-0f53c81b92b4ecfce", 
-                        "Key": "maid-origin-volume"
+                        "AttachTime": {
+                            "hour": 18, 
+                            "__class__": "datetime", 
+                            "month": 6, 
+                            "second": 5, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 8, 
+                            "minute": 24
+                        }, 
+                        "InstanceId": "i-0aaaaec4b77188b69", 
+                        "VolumeId": "vol-072dfa20eef03dd38", 
+                        "State": "attaching", 
+                        "DeleteOnTermination": true, 
+                        "Device": "/dev/xvda"
                     }
                 ], 
                 "Encrypted": true, 
                 "VolumeType": "gp2", 
                 "VolumeId": "vol-072dfa20eef03dd38", 
-                "State": "available", 
+                "State": "in-use", 
                 "Iops": 100, 
                 "KmsKeyId": "arn:aws:kms:us-east-1:185106417252:key/3cc8863f-09dd-45cd-90cf-d6149710582e", 
                 "SnapshotId": "snap-0bd2772f3c7cafa62", 

--- a/tests/data/placebo/test_encrypt_volumes/ec2.DetachVolume_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.DetachVolume_1.json
@@ -2,21 +2,29 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "2cb1fcce-f954-45b9-a070-24bec2a7713a"
+            "RequestId": "15ca21fd-7964-4260-b617-2982d9371dc3", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:23:34 GMT"
+            }
         }, 
         "AttachTime": {
-            "hour": 11, 
+            "hour": 17, 
             "__class__": "datetime", 
-            "month": 5, 
-            "second": 34, 
+            "month": 6, 
+            "second": 20, 
             "microsecond": 0, 
-            "year": 2016, 
+            "year": 2017, 
             "day": 8, 
-            "minute": 6
+            "minute": 58
         }, 
-        "InstanceId": "i-9432cb49", 
-        "VolumeId": "vol-fdd1f844", 
+        "InstanceId": "i-0aaaaec4b77188b69", 
+        "VolumeId": "vol-0f53c81b92b4ecfce", 
         "State": "detaching", 
         "Device": "/dev/xvda"
     }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.ModifyInstanceAttribute_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.ModifyInstanceAttribute_1.json
@@ -4,13 +4,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "8ab1192c-adcd-43f4-8120-1de150bb6ad3", 
+            "RequestId": "67f14fdb-df9b-47cd-86ca-f5f488812825", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "vary": "Accept-Encoding", 
                 "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Thu, 08 Jun 2017 18:23:33 GMT"
+                "date": "Thu, 08 Jun 2017 18:24:05 GMT"
             }
         }
     }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.StartInstances_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.StartInstances_1.json
@@ -3,7 +3,7 @@
     "data": {
         "StartingInstances": [
             {
-                "InstanceId": "i-9432cb49", 
+                "InstanceId": "i-0aaaaec4b77188b69", 
                 "CurrentState": {
                     "Code": 0, 
                     "Name": "pending"
@@ -15,8 +15,16 @@
             }
         ], 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "a8e3a7b8-682a-4ee1-830d-ffc93d021f61"
+            "RequestId": "158998e4-2f81-4412-b390-9e5c634b6762", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:24:05 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/ec2.StopInstances_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/ec2.StopInstances_1.json
@@ -3,7 +3,7 @@
     "data": {
         "StoppingInstances": [
             {
-                "InstanceId": "i-9432cb49", 
+                "InstanceId": "i-0aaaaec4b77188b69", 
                 "CurrentState": {
                     "Code": 64, 
                     "Name": "stopping"
@@ -15,8 +15,16 @@
             }
         ], 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "ee37ee1a-46f8-4e15-9083-3a0ff58c68f9"
+            "RequestId": "292f2c94-e084-4f37-a7ef-540e36314ead", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 08 Jun 2017 18:17:38 GMT"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_encrypt_volumes/kms.DescribeKey_1.json
+++ b/tests/data/placebo/test_encrypt_volumes/kms.DescribeKey_1.json
@@ -2,27 +2,37 @@
     "status_code": 200, 
     "data": {
         "KeyMetadata": {
-            "KeyId": "00d9c89e-13ee-4758-9167-41de13b5bb68", 
+            "Origin": "AWS_KMS", 
+            "KeyId": "3cc8863f-09dd-45cd-90cf-d6149710582e", 
             "Description": "", 
             "Enabled": true, 
             "KeyUsage": "ENCRYPT_DECRYPT", 
             "KeyState": "Enabled", 
             "CreationDate": {
-                "hour": 21, 
+                "hour": 12, 
                 "__class__": "datetime", 
-                "month": 5, 
-                "second": 40, 
-                "microsecond": 675000, 
-                "year": 2016, 
-                "day": 7, 
-                "minute": 3
+                "month": 6, 
+                "second": 26, 
+                "microsecond": 305000, 
+                "year": 2017, 
+                "day": 8, 
+                "minute": 59
             }, 
-            "Arn": "arn:aws:kms:us-west-2:619193117841:key/00d9c89e-13ee-4758-9167-41de13b5bb68", 
-            "AWSAccountId": "619193117841"
+            "Arn": "arn:aws:kms:us-east-1:185106417252:key/3cc8863f-09dd-45cd-90cf-d6149710582e", 
+            "AWSAccountId": "185106417252"
         }, 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "3582c758-150d-11e6-9d0b-a147b354389f"
+            "RequestId": "c0b10d3c-4c76-11e7-a803-c35d5aff7716", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c0b10d3c-4c76-11e7-a803-c35d5aff7716", 
+                "content-length": "311", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Thu, 08 Jun 2017 18:17:38 GMT", 
+                "content-type": "application/x-amz-json-1.1"
+            }
         }
     }
 }


### PR DESCRIPTION
Existing process was not cleaning up transient tags. Added code to delete transient maid tags left behind on newly encrypted volume.