### PR TITLE
fix trunk regression from #1114 on lambda policies

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -90,7 +90,8 @@ def dispatch_event(event, context):
         return False
 
     # TODO. This enshrines an assumption of a single policy per lambda.
-    options_overrides = policy_config['policies'][0]['mode'].get('execution-options', {})
+    options_overrides = policy_config[
+        'policies'][0].get('mode', {}).get('execution-options', {})
     options = Config.empty(**options_overrides)
 
     load_resources()

--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -87,13 +87,14 @@ def dispatch_event(event, context):
         policy_config = json.load(f)
 
     if not policy_config or not policy_config.get('policies'):
-        return True
+        return False
 
+    # TODO. This enshrines an assumption of a single policy per lambda.
     options_overrides = policy_config['policies'][0]['mode'].get('execution-options', {})
     options = Config.empty(**options_overrides)
 
     load_resources()
-    policies = PolicyCollection(policy_config, options)
+    policies = PolicyCollection.from_data(policy_config, options)
     if policies:
         for p in policies:
             p.push(event, context)

--- a/tests/test_handler.py
+++ b/tests/test_handler.py
@@ -18,6 +18,7 @@ import shutil
 import tempfile
 
 from common import BaseTest
+from c7n.policy import Policy
 
 
 class HandleTest(BaseTest):
@@ -39,10 +40,23 @@ class HandleTest(BaseTest):
         self.addCleanup(cleanup)
         self.change_environment(C7N_OUTPUT_DIR=self.run_dir)
 
+
+        policy_execution = []
+
+        def push(self, event, context):
+            policy_execution.append((event, context))
+
+        self.patch(Policy, 'push', push)
+            
         from c7n import handler
 
         with open(os.path.join(self.run_dir, 'config.json'), 'w') as fh:
-            json.dump({'policies': []}, fh)
+            json.dump(
+                {'policies': [
+                    {'resource': 'asg',
+                     'name': 'autoscaling',
+                     'filters': [],
+                     'actions': []}]}, fh)
 
         self.assertEqual(
             handler.dispatch_event(
@@ -50,6 +64,9 @@ class HandleTest(BaseTest):
             None)
         self.assertEqual(
             handler.dispatch_event({'detail': {}}, None), True)
+        self.assertEqual(
+            policy_execution,
+            [({'detail': {}, 'debug': True}, None)])
 
         config = handler.Config.empty()
         self.assertEqual(config.assume_role, None)

--- a/tools/c7n_logexporter/c7n_logexporter/exporter.py
+++ b/tools/c7n_logexporter/c7n_logexporter/exporter.py
@@ -99,6 +99,7 @@ def cli():
 @cli.command()
 @click.option('--config', type=click.Path())
 def validate(config):
+    """validate config file."""
     with open(config) as fh:
         content = fh.read()
 
@@ -124,6 +125,7 @@ def validate(config):
 @click.option('--end')
 @debug
 def run(config, start, end):
+    """run export across accounts and log groups specified in config."""
     config = validate.callback(config)
     destination = config.get('destination')
     start = start and parse(start) or start
@@ -348,6 +350,7 @@ def filter_extant_exports(client, bucket, prefix, days, start, end=None):
 # @click.option('--stream-prefix)
 @lambdafan
 def export(group, bucket, prefix, start, end, role, session=None):
+    """Export a single log group to s3."""
     start = start and isinstance(start, basestring) and parse(start) or start
     end = (end and isinstance(start, basestring) and
            parse(end) or end or datetime.now())


### PR DESCRIPTION
contrib from #1114 was pre change of policy collection construction and was effectively a regression. that was not included 0.8.24.1 so treating as trunk only regression. Also note that #1114 currently has a behavior that assumes a single policy in a lambda.