### PR TITLE
Issue #1241 (Topic and Queue name used instead of arn) Some default report field added for VPC and Security Groups

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,13 +1,13 @@
 
 install:
 	python -m virtualenv --python python2.7 .
-	source bin/activate && pip install -r requirements.txt
-	source bin/activate && python setup.py develop
+	. bin/activate && pip install -r requirements.txt
+	. bin/activate && python setup.py develop
 
 develop:
 	python -m virtualenv --python python2.7 .
-	source bin/activate && pip install -r requirements-dev.txt
-	source bin/activate && python setup.py develop
+	. bin/activate && pip install -r requirements-dev.txt
+	. bin/activate && python setup.py develop
 
 coverage:
 	rm -Rf .coverage

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -44,6 +44,12 @@ class Vpc(QueryResourceManager):
         dimension = None
         config_type = 'AWS::EC2::VPC'
         id_prefix = "vpc-"
+        default_report_fields = (
+            'VpcId',
+            'tag:Name',
+            'CidrBlock'
+
+        )
 
 
 @Vpc.filter_registry.register('flow-logs')
@@ -189,6 +195,11 @@ class SecurityGroup(QueryResourceManager):
         dimension = None
         config_type = "AWS::EC2::SecurityGroup"
         id_prefix = "sg-"
+        default_report_fields = (
+            'GroupId',
+            'GroupName',
+            'VpcId'
+        )
 
 
 @SecurityGroup.filter_registry.register('diff')


### PR DESCRIPTION
"source" command is replaced with "." in Makefile because this gives and error. (Issue #1236 )
Default report fields "CidrBlock" and "tag:Name" for VPC and "GroupName" and "VpcId" for Security Groups in vpc.py to give more useful information to user.