### PR TITLE
Add singleton filter to find instances that are not resilient.

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -516,6 +516,71 @@ class DefaultVpc(DefaultVpcBase):
         return ec2.get('VpcId') and self.match(ec2.get('VpcId')) or False
 
 
+@filters.register('singleton')
+class SingletonFilter(Filter):
+    """EC2 instances without autoscaling or a recover alarm
+
+    Filters EC2 instances that are not members of an autoscaling group
+    and do not have Cloudwatch recover alarms.
+
+    :Example:
+
+    .. code-block: yaml
+
+        policies:
+          - name: ec2-recover-instances
+            resource: ec2
+            filters:
+              - singleton
+            actions:
+              - type: tag
+                key: problem
+                value: instance is not resilient
+
+    https://docs.aws.amazon.com/AWSEC2/latest/UserGuide/ec2-instance-recover.html
+    """
+
+    schema = type_schema('singleton')
+
+    permissions = ('cloudwatch:DescribeAlarmsForMetric',)
+
+    def __call__(self, i):
+        if self.in_asg(i):
+            return False
+        else:
+            return not self.has_recover_alarm(i)
+
+    @staticmethod
+    def in_asg(i):
+        if 'Tags' not in i:
+            return False
+        else:
+            return 'aws:autoscaling:groupName' in i['Tags']
+
+    def has_recover_alarm(self, i):
+        client = utils.local_session(self.manager.session_factory).client('cloudwatch')
+        alarms = client.describe_alarms_for_metric(
+            MetricName='StatusCheckFailed_System',
+            Namespace='AWS/EC2',
+            Dimensions=[
+                {
+                    'Name': 'InstanceId',
+                    'Value': i['InstanceId']
+                }
+            ]
+        )
+
+        for i in alarms['MetricAlarms']:
+            for a in i['AlarmActions']:
+                if (
+                    a.startswith('arn:aws:automate:') and
+                    a.endswith(':ec2:recover')
+                ):
+                    return True
+
+        return False
+
+
 @actions.register('start')
 class Start(BaseAction, StateTransitionFilter):
     """Starts a previously stopped EC2 instance.

--- a/tests/data/placebo/test_ec2_singleton/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_singleton/ec2.DescribeInstances_1.json
@@ -1,0 +1,145 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Reservations": [
+            {
+                "OwnerId": "0", 
+                "ReservationId": "r-04df2e5d9eea3e407", 
+                "Groups": [], 
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 18, 
+                            "__class__": "datetime", 
+                            "month": 5, 
+                            "second": 18, 
+                            "microsecond": 0, 
+                            "year": 2017, 
+                            "day": 23, 
+                            "minute": 6
+                        }, 
+                        "PrivateIpAddress": "10.0.0.38", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-01234567", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-00fe7967fb7167c62", 
+                        "ImageId": "ami-01234567", 
+                        "PrivateDnsName": "ip-10-0-0-38.us-west-1.compute.internal", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "default", 
+                                "GroupId": "sg-01234567"
+                            }
+                        ], 
+                        "ClientToken": "CZSyv1495562777688", 
+                        "SubnetId": "subnet-01234567", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "06:78:d8:5a:71:5a", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-01234567", 
+                                "Description": "Primary network interface", 
+                                "NetworkInterfaceId": "eni-ee61adee", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-10-0-0-38.us-west-1.compute.internal", 
+                                        "Primary": true, 
+                                        "PrivateIpAddress": "10.0.0.38"
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-10-0-0-38.us-west-1.compute.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-05848ded", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 5, 
+                                        "second": 18, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 23, 
+                                        "minute": 6
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "default", 
+                                        "GroupId": "sg-01234567"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "SubnetId": "subnet-01234567", 
+                                "OwnerId": "0", 
+                                "PrivateIpAddress": "10.0.0.38"
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-west-1c"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-0b6158b4b95bfde5f", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 5, 
+                                        "second": 19, 
+                                        "microsecond": 0, 
+                                        "year": 2017, 
+                                        "day": 23, 
+                                        "minute": 6
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "Tags": [
+                            {
+                                "Value": "Singleton", 
+                                "Key": "Name"
+                            } 
+                        ], 
+                        "AmiLaunchIndex": 0
+                    }
+                ]
+            } 
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "0230153e-09d0-4516-b38f-7aeb829aa287", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Thu, 01 Jun 2017 18:28:07 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_singleton/monitoring.DescribeAlarmsForMetric_1.json
+++ b/tests/data/placebo/test_ec2_singleton/monitoring.DescribeAlarmsForMetric_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "102197c0-46f8-11e7-91b7-f536dcb62247", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "102197c0-46f8-11e7-91b7-f536dcb62247", 
+                "date": "Thu, 01 Jun 2017 18:28:08 GMT", 
+                "content-length": "321", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "MetricAlarms": []
+    }
+}

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -615,6 +615,23 @@ class TestDefaultVpc(BaseTest):
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['InstanceId'], 'i-0bfe468063b02d018')
 
+class TestSingletonFilter(BaseTest):
+
+    def test_ec2_singleton_filter(self):
+        session_factory = self.replay_flight_data('test_ec2_singleton')
+        p = self.load_policy(
+            {'name': 'ec2-singleton-filters',
+             'resource': 'ec2',
+             'filters': [
+                 {'tag:Name': 'Singleton'},
+                 {'type': 'singleton'}]},
+            config={'region': 'us-west-1'},
+            session_factory=session_factory)
+
+        resources = p.run()
+
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['InstanceId'], 'i-00fe7967fb7167c62')
 
 class TestActions(unittest.TestCase):
 


### PR DESCRIPTION
Meaning they are not part of an ASG, and do not have a cloudwatch
recover alarm set.

Planning to add an action for an autorecover alarm next.