### PR TITLE
policy explicit validation 

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -176,7 +176,8 @@ def validate(options):
             null_config = Bag(dryrun=True, log_group=None, cache=None, assume_role="na")
             for p in data.get('policies', ()):
                 try:
-                    Policy(p, null_config, Bag())
+                    p = Policy(p, null_config, Bag())
+                    p.validate()
                 except Exception as e:
                     msg = "Policy: %s is invalid: %s" % (
                         p.get('name', 'unknown'), e)

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -126,7 +126,7 @@ class FilterRegistry(PluginRegistry):
                     self.plugin_type, data))
         filter_class = self.get(filter_type)
         if filter_class is not None:
-            return filter_class(data, manager).validate()
+            return filter_class(data, manager)
         else:
             raise FilterValidationError(
                 "%s Invalid filter type %s" % (

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -21,6 +21,7 @@ import time
 
 import boto3
 from botocore.client import ClientError
+import jmespath
 
 from c7n.actions import EventAction
 from c7n.cwe import CloudWatchEvents
@@ -455,6 +456,15 @@ class PeriodicMode(LambdaMode, PullMode):
 
 class CloudTrailMode(LambdaMode):
     """A lambda policy using cloudwatch events rules on cloudtrail api logs."""
+
+    def validate(self):
+        events = self.policy.data['mode'].get('events')
+        assert events, "cloud trail mode requires specifiying events to subscribe"
+        for e in events:
+            if isinstance(e, basestring):
+                assert e in CloudWatchEvents.trail_events, "event shortcut not defined"
+            if isinstance(e, dict):
+                jmespath.compile(e['ids'])
 
 
 class EC2InstanceState(LambdaMode):

--- a/tests/common.py
+++ b/tests/common.py
@@ -104,7 +104,9 @@ class BaseTest(PillTest):
             config['cache'] = os.path.join(temp_dir, 'c7n.cache')
             config['cache_period'] = 300
         conf = Config.empty(**config)
-        return policy.Policy(data, conf, session_factory)
+        p = policy.Policy(data, conf, session_factory)
+        p.validate()
+        return p
 
     def load_policy_set(self, data, config=None):
         filename = self.write_policy_file(data)

--- a/tests/test_elb.py
+++ b/tests/test_elb.py
@@ -226,37 +226,37 @@ class SSLPolicyTest(BaseTest):
             'test-elb-invalid-policy')
 
     def test_filter_validation_no_blacklist(self):
-
-        p = self.load_policy({
-            'name': 'test-ssl-ciphers',
-            'resource': 'elb',
-            'filters': [
-                {'type': 'ssl-policy'}
-            ]},
+        self.assertRaises(
+            FilterValidationError,
+            self.load_policy,
+            {'name': 'test-ssl-ciphers',
+             'resource': 'elb',
+             'filters': [
+                 {'type': 'ssl-policy'}
+             ]},
             session_factory=None, validate=False)
-        self.assertRaises(FilterValidationError, p.validate)        
 
     def test_filter_validation_blacklist_not_iterable(self):
-
-        p = self.load_policy({
-            'name': 'test-ssl-ciphers',
-            'resource': 'elb',
-            'filters': [
-                {'type': 'ssl-policy', 'blacklist': 'single-value'}
-            ]},
+        self.assertRaises(
+            FilterValidationError,
+            self.load_policy,
+            {'name': 'test-ssl-ciphers',
+             'resource': 'elb',
+             'filters': [
+                 {'type': 'ssl-policy', 'blacklist': 'single-value'}
+             ]},
             session_factory=None, validate=False)
-        self.assertRaises(FilterValidationError, p.validate)        
 
 
 class TestDefaultVpc(BaseTest):
 
     def test_elb_default_vpc(self):
         session_factory = self.replay_flight_data('test_elb_default_vpc')
-        p = self.load_policy(
-            {'name': 'elb-default-filters',
-             'resource': 'elb',
-             'filters': [
-                 {'type': 'default-vpc'}]},
+        p = self.load_policy({
+            'name': 'elb-default-filters',
+            'resource': 'elb',
+            'filters': [
+                {'type': 'default-vpc'}]},
             config={'region': 'us-west-2'},
             session_factory=session_factory)
 

--- a/tests/test_elb.py
+++ b/tests/test_elb.py
@@ -226,24 +226,26 @@ class SSLPolicyTest(BaseTest):
             'test-elb-invalid-policy')
 
     def test_filter_validation_no_blacklist(self):
-        self.assertRaises(FilterValidationError,
-            self.load_policy, {
-                'name': 'test-ssl-ciphers',
-                'resource': 'elb',
-                'filters': [
-                    {'type': 'ssl-policy'}
-                ]},
-                session_factory=None, validate=False)
+
+        p = self.load_policy({
+            'name': 'test-ssl-ciphers',
+            'resource': 'elb',
+            'filters': [
+                {'type': 'ssl-policy'}
+            ]},
+            session_factory=None, validate=False)
+        self.assertRaises(FilterValidationError, p.validate)        
 
     def test_filter_validation_blacklist_not_iterable(self):
-        self.assertRaises(FilterValidationError,
-            self.load_policy, {
-                'name': 'test-ssl-ciphers',
-                'resource': 'elb',
-                'filters': [
-                    {'type': 'ssl-policy', 'blacklist': 'single-value'}
-                ]},
-                session_factory=None, validate=False)
+
+        p = self.load_policy({
+            'name': 'test-ssl-ciphers',
+            'resource': 'elb',
+            'filters': [
+                {'type': 'ssl-policy', 'blacklist': 'single-value'}
+            ]},
+            session_factory=None, validate=False)
+        self.assertRaises(FilterValidationError, p.validate)        
 
 
 class TestDefaultVpc(BaseTest):

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -217,11 +217,11 @@ class TestRegexValue(unittest.TestCase):
     def test_regex_validate(self):
         self.assertRaises(
             base_filters.FilterValidationError,
-            filters.factory,
-            {'type': 'value',
-             'key': 'Color',
-             'value': '*green',
-             'op': 'regex'})
+            filters.factory({
+                'type': 'value',
+                'key': 'Color',
+                'value': '*green',
+                'op': 'regex'}).validate)
 
     def test_regex_match(self):
         f = filters.factory(
@@ -363,7 +363,7 @@ class TestValueTypes(BaseFilterTest):
             'value': 1,
         }
         self.assertRaises(
-            base_filters.FilterValidationError, filters.factory, f, {})
+            base_filters.FilterValidationError, filters.factory(f, {}).validate)
 
         # Bad `value`
         f = {
@@ -373,7 +373,7 @@ class TestValueTypes(BaseFilterTest):
             'value': 'foo',
         }
         self.assertRaises(
-            base_filters.FilterValidationError, filters.factory, f, {})
+            base_filters.FilterValidationError, filters.factory(f, {}).validate)
 
         # Missing `op`
         f = {
@@ -382,7 +382,7 @@ class TestValueTypes(BaseFilterTest):
             'value': 1,
         }
         self.assertRaises(
-            base_filters.FilterValidationError, filters.factory, f, {})
+            base_filters.FilterValidationError, filters.factory(f, {}).validate)
 
 
 class TestInstanceAge(BaseFilterTest):
@@ -486,8 +486,9 @@ class EventFilterTest(BaseFilterTest):
         f = {'type': 'event',
              'key': 'detail.state',
              'value': 'pending'}
+        f = filters.factory(f, b)
         self.assertRaises(
-            base_filters.FilterValidationError, filters.factory, f, b)
+            base_filters.FilterValidationError,  f.validate)
 
 
 class TestInstanceValue(BaseFilterTest):
@@ -542,21 +543,20 @@ class TestInstanceValue(BaseFilterTest):
     def test_complex_validator(self):
         self.assertRaises(
             base_filters.FilterValidationError,
-            filters.factory,
-            {"key": "xyz",
-             "type": "value"})
+            filters.factory({
+                "key": "xyz", "type": "value"}).validate)
         self.assertRaises(
             base_filters.FilterValidationError,
-            filters.factory,
-            {"value": "xyz",
-             "type": "value"})
+            filters.factory({
+                "value": "xyz", "type": "value"}).validate)
+
         self.assertRaises(
             base_filters.FilterValidationError,
-            filters.factory,
-            {"key": "xyz",
-             "value": "xyz",
-             "op": "oo",
-             "type": "value"})
+            filters.factory({
+                "key": "xyz",
+                "value": "xyz",
+                "op": "oo",
+                "type": "value"}).validate)
 
     def test_complex_value_filter(self):
         self.assertFilter(

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1043,14 +1043,12 @@ class SecurityGroupTest(BaseTest):
               u'UserIdGroupPairs': []}])
 
     def test_egress_validation_error(self):
-        p = self.load_policy({
-            'name': 'sg-find2',
-            'resource': 'security-group',
-            'filters': [
-                {'type': 'egress',
-                 'InvalidKey': True},
-                {'GroupName': 'sg2'}]})
-            
         self.assertRaises(
             FilterValidationError,
-            p.validate)
+            self.load_policy,
+            {'name': 'sg-find2',
+             'resource': 'security-group',
+             'filters': [
+                 {'type': 'egress',
+                  'InvalidKey': True},
+                 {'GroupName': 'sg2'}]})

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1043,12 +1043,14 @@ class SecurityGroupTest(BaseTest):
               u'UserIdGroupPairs': []}])
 
     def test_egress_validation_error(self):
-        self.assertRaises(
-            FilterValidationError,
-            self.load_policy,
-            {'name': 'sg-find2',
-             'resource': 'security-group',
-             'filters': [
+        p = self.load_policy({
+            'name': 'sg-find2',
+            'resource': 'security-group',
+            'filters': [
                 {'type': 'egress',
                  'InvalidKey': True},
                 {'GroupName': 'sg2'}]})
+            
+        self.assertRaises(
+            FilterValidationError,
+            p.validate)


### PR DESCRIPTION
switches implicit validation of filters/actions on construction to explicit when calling policy.validate, also adds execution mode to validate.

closes #1240 
closes #1011 