### PR TITLE
Implement an in memory cache.

### DIFF
--- a/c7n/cache.py
+++ b/c7n/cache.py
@@ -66,10 +66,10 @@ class InMemoryCache(object):
         return True
 
     def get(self, key):
-        return self.data.get(cPickle.dumps(key))
+        return self.data.get(pickle.dumps(key))
 
     def save(self, key, data):
-        self.data[cPickle.dumps(key)] = data
+        self.data[pickle.dumps(key)] = data
 
 
 class FileCacheManager(object):

--- a/c7n/cache.py
+++ b/c7n/cache.py
@@ -32,6 +32,9 @@ def factory(config):
     if not config.cache or not config.cache_period:
         log.debug("Disabling cache")
         return NullCache(config)
+    elif config.cache == 'memory':
+        log.debug("Using in-memory cache")
+        return InMemoryCache()
 
     return FileCacheManager(config)
 
@@ -49,6 +52,24 @@ class NullCache(object):
 
     def save(self, key, data):
         pass
+
+
+class InMemoryCache(object):
+    # Running in a temporary environment, so keep as a cache.
+
+    __shared_state = {}
+
+    def __init__(self):
+        self.data = self.__shared_state
+
+    def load(self):
+        return True
+
+    def get(self, key):
+        return self.data.get(cPickle.dumps(key))
+
+    def save(self, key, data):
+        self.data[cPickle.dumps(key)] = data
 
 
 class FileCacheManager(object):


### PR DESCRIPTION
This is a WIP PR, but it's worth nothing this implements a simple, shared in memory cache.

The default file cache has a pretty serious memory leak in pull mode - Since it instantiates and loads the cache for each policy, memory grows a copy of the cache for each policy.

This uses a single shared dict, and a simpler structure, to avoid that when want a cache for the lifetime of the run but not to be persisted.