### PR TITLE
Fix message assembling for notify action

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -461,9 +461,9 @@ class Notify(EventAction):
             'event': event,
             'account_id': self.manager.config.account_id,
             'account': account_name,
-            'action': self.data,
-            'region': self.manager.config.region}
-        message['policy'] = self.expand_variables(message)
+            'region': self.manager.config.region,
+            'policy': self.manager.data}
+        message['action'] = self.expand_variables(message)
 
         for batch in utils.chunks(resources, self.batch_size):
             message['resources'] = batch


### PR DESCRIPTION
1. Met an error when using `notify` action. The c7n_mailer is not able to find [`data['policy']['resource']`](https://github.com/capitalone/cloud-custodian/blob/master/tools/c7n_mailer/c7n_mailer/sqs_message_processor.py#L101)
2. c7n_mailer gets to/cc list  from `data['action']`

Assign the `expand_variables(message)` to `data['action']` instead of `data['policy']`.
This should also fix issue #1280 