### PR TITLE
Parameter Group filter fix

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1524,7 +1524,6 @@ class ParameterFilter(ValueFilter):
     """
 
     schema = type_schema('db-parameter', rinherit=ValueFilter.schema)
-    schema = type_schema('db-parameter', rinherit=ValueFilter.schema)
     permissions = ('rds:DescribeDBInstances', 'rds:DescribeDBParameters', )
 
     @staticmethod

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1532,20 +1532,23 @@ class ParameterFilter(ValueFilter):
             and treat nulls sensibly.
         """
         ret_val = val
-        try:
-            if datatype == 'string':
-                ret_val = str(val)
-            elif datatype == 'boolean':
-                # AWS returns 1s and 0s for this
+        if datatype == 'string':
+            ret_val = str(val)
+        elif datatype == 'boolean':
+            # AWS returns 1s and 0s for boolean for most of the cases
+            if val.isdigit():
                 ret_val = bool(int(val))
-            elif datatype == 'integer':
-                if val.isdigit():
-                    ret_val = int(val)
-            elif datatype == 'float':
-                ret_val = float(val) if val else 0.0
-        except:
-            log.warning(
-                'recast failed type: %s  value: %s', datatype, val)
+            # AWS returns 'TRUE,FALSE' for Oracle engine
+            elif val == 'TRUE':
+                ret_val = True
+            elif val == 'FALSE':
+                ret_val = False
+        elif datatype == 'integer':
+            if val.isdigit():
+                ret_val = int(val)
+        elif datatype == 'float':
+            ret_val = float(val) if val else 0.0
+
         return ret_val
 
     def process(self, resources, event=None):

--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 import functools
 import json
 import logging
+import itertools
 
 from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
@@ -156,8 +157,9 @@ class Parameter(ValueFilter):
 
         def get_params(group_name):
             c = local_session(self.manager.session_factory).client('redshift')
-            param_group = c.describe_cluster_parameters(
-                ParameterGroupName=group_name)['Parameters']
+            paginator = c.get_paginator('describe_cluster_parameters')
+            param_group = list(itertools.chain(*[p['Parameters']
+                for p in paginator.paginate(ParameterGroupName=group_name)]))
             params = {}
             for p in param_group:
                 v = p['ParameterValue']

--- a/tests/data/placebo/test_rds_param_filter/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_param_filter/rds.DescribeDBInstances_1.json
@@ -34,14 +34,14 @@
                 "Engine": "postgres", 
                 "MultiAZ": false, 
                 "LatestRestorableTime": {
-                    "hour": 20, 
+                    "hour": 22, 
                     "__class__": "datetime", 
-                    "month": 5, 
-                    "second": 49, 
+                    "month": 6, 
+                    "second": 22, 
                     "microsecond": 0, 
                     "year": 2017, 
-                    "day": 16, 
-                    "minute": 51
+                    "day": 15, 
+                    "minute": 26
                 }, 
                 "DBSecurityGroups": [], 
                 "DBParameterGroups": [
@@ -116,13 +116,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "8bd236a5-3a7a-11e7-95c5-677648e242bf", 
+            "RequestId": "b795944d-521a-11e7-aed6-cf2cdb11ec36", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "8bd236a5-3a7a-11e7-95c5-677648e242bf", 
+                "x-amzn-requestid": "b795944d-521a-11e7-aed6-cf2cdb11ec36", 
                 "vary": "Accept-Encoding", 
                 "content-length": "8677", 
                 "content-type": "text/xml", 
-                "date": "Tue, 16 May 2017 20:59:26 GMT"
+                "date": "Thu, 15 Jun 2017 22:33:55 GMT"
             }
         }
     }

--- a/tests/data/placebo/test_rds_param_filter/rds.DescribeDBParameters_1.json
+++ b/tests/data/placebo/test_rds_param_filter/rds.DescribeDBParameters_1.json
@@ -1,17 +1,17 @@
 {
     "status_code": 200, 
     "data": {
-        "Marker": "bG9nX2Rpc2Nvbm5lY3Rpb25z", 
+        "Marker": "bG9nX2RpcmVjdG9yeQ==", 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "8c7ef19a-3a7a-11e7-96f9-cf1f58744ebc", 
+            "RequestId": "b862a8a1-521a-11e7-ab28-6d89c50f6e01", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "8c7ef19a-3a7a-11e7-96f9-cf1f58744ebc", 
+                "x-amzn-requestid": "b862a8a1-521a-11e7-ab28-6d89c50f6e01", 
                 "vary": "Accept-Encoding", 
-                "content-length": "44883", 
+                "content-length": "44953", 
                 "content-type": "text/xml", 
-                "date": "Tue, 16 May 2017 20:59:27 GMT"
+                "date": "Thu, 15 Jun 2017 22:33:56 GMT"
             }
         }, 
         "Parameters": [
@@ -862,6 +862,18 @@
             }, 
             {
                 "ApplyMethod": "pending-reboot", 
+                "Description": "Use of huge pages on Linux.", 
+                "DataType": "string", 
+                "IsModifiable": true, 
+                "AllowedValues": "on,off", 
+                "Source": "system", 
+                "ParameterValue": "off", 
+                "ParameterName": "huge_pages", 
+                "MinimumEngineVersion": "9.6.2", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
                 "Description": "Sets the servers ident configuration file.", 
                 "DataType": "string", 
                 "IsModifiable": false, 
@@ -1008,16 +1020,6 @@
                 "Source": "system", 
                 "ParameterValue": "/rdsdbdata/log/error", 
                 "ParameterName": "log_directory", 
-                "ApplyType": "dynamic"
-            }, 
-            {
-                "ApplyMethod": "pending-reboot", 
-                "Description": "Logs end of a session, including duration.", 
-                "DataType": "boolean", 
-                "AllowedValues": "0,1", 
-                "Source": "engine-default", 
-                "IsModifiable": true, 
-                "ParameterName": "log_disconnections", 
                 "ApplyType": "dynamic"
             }
         ]

--- a/tests/data/placebo/test_rds_param_filter/rds.DescribeDBParameters_2.json
+++ b/tests/data/placebo/test_rds_param_filter/rds.DescribeDBParameters_2.json
@@ -1,0 +1,1048 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Marker": "dHJhY2tfZnVuY3Rpb25z", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b890bd87-521a-11e7-ab28-6d89c50f6e01", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b890bd87-521a-11e7-ab28-6d89c50f6e01", 
+                "vary": "Accept-Encoding", 
+                "content-length": "47147", 
+                "content-type": "text/xml", 
+                "date": "Thu, 15 Jun 2017 22:33:57 GMT"
+            }
+        }, 
+        "Parameters": [
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Logs end of a session, including duration.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_disconnections", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Logs the duration of each completed SQL statement.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_duration", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the verbosity of logged messages.", 
+                "DataType": "string", 
+                "AllowedValues": "terse,default,verbose", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_error_verbosity", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Writes executor performance statistics to the server log.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_executor_stats", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the file permissions for log files.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "0644", 
+                "ParameterName": "log_file_mode", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the file name pattern for log files.", 
+                "DataType": "string", 
+                "IsModifiable": true, 
+                "AllowedValues": "postgresql.log.%Y-%m-%d,postgresql.log.%Y-%m-%d-%H", 
+                "Source": "system", 
+                "ParameterValue": "postgresql.log.%Y-%m-%d-%H", 
+                "ParameterName": "log_filename", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Logs the host name in the connection logs.", 
+                "DataType": "boolean", 
+                "IsModifiable": true, 
+                "AllowedValues": "0,1", 
+                "Source": "system", 
+                "ParameterValue": "1", 
+                "ParameterName": "log_hostname", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Controls information prefixed to each log line.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "%t:%r:%u@%d:[%p]:", 
+                "ParameterName": "log_line_prefix", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Logs long lock waits.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_lock_waits", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) Sets the minimum execution time above which statements will be logged.", 
+                "DataType": "integer", 
+                "AllowedValues": "-1-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_min_duration_statement", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Causes all statements generating error at or above this level to be logged.", 
+                "DataType": "string", 
+                "AllowedValues": "debug5,debug4,debug3,debug2,debug1,info,notice,warning,error,log,fatal,panic", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_min_error_statement", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the message levels that are logged.", 
+                "DataType": "string", 
+                "AllowedValues": "debug5,debug4,debug3,debug2,debug1,info,notice,warning,error,log,fatal,panic", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_min_messages", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Writes parser performance statistics to the server log.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_parser_stats", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Writes planner performance statistics to the server log.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_planner_stats", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Logs each replication command.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_replication_commands", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(min) Automatic log file rotation will occur after N minutes.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "1-1440", 
+                "Source": "system", 
+                "ParameterValue": "60", 
+                "ParameterName": "log_rotation_age", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(kB) Automatic log file rotation will occur after N kilobytes.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2097151", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_rotation_size", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the type of statements logged.", 
+                "DataType": "string", 
+                "AllowedValues": "none,ddl,mod,all", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_statement", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Writes cumulative performance statistics to the server log.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_statement_stats", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(kB) Log the use of temporary files larger than this number of kilobytes.", 
+                "DataType": "integer", 
+                "AllowedValues": "-1-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "log_temp_files", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the time zone to use in log messages.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "UTC", 
+                "ParameterName": "log_timezone", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Truncate existing log files of same name during log rotation.", 
+                "DataType": "boolean", 
+                "IsModifiable": false, 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "ParameterValue": "0", 
+                "ParameterName": "log_truncate_on_rotation", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Start a subprocess to capture stderr output and/or csvlogs into log files.", 
+                "DataType": "boolean", 
+                "IsModifiable": false, 
+                "AllowedValues": "0,1", 
+                "Source": "system", 
+                "ParameterValue": "1", 
+                "ParameterName": "logging_collector", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(kB) Sets the maximum memory to be used for maintenance operations.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "1024-2147483647", 
+                "Source": "engine-default", 
+                "ParameterValue": "GREATEST({DBInstanceClassMemory/63963136*1024},65536)", 
+                "ParameterName": "maintenance_work_mem", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of concurrent connections.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "6-8388607", 
+                "Source": "system", 
+                "ParameterValue": "LEAST({DBInstanceClassMemory/9531392},5000)", 
+                "ParameterName": "max_connections", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of simultaneously open files for each server process.", 
+                "DataType": "integer", 
+                "AllowedValues": "25-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "max_files_per_process", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of locks per transaction.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "10-2147483647", 
+                "Source": "engine-default", 
+                "ParameterValue": "64", 
+                "ParameterName": "max_locks_per_transaction", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of parallel processes per executor node.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-1024", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "max_parallel_workers_per_gather", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of predicate locks per transaction.", 
+                "DataType": "integer", 
+                "AllowedValues": "10-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "max_pred_locks_per_transaction", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of simultaneously prepared transactions.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "0-8388607", 
+                "Source": "engine-default", 
+                "ParameterValue": "0", 
+                "ParameterName": "max_prepared_transactions", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of replication slots that the server can support.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "5-8388607", 
+                "Source": "system", 
+                "ParameterValue": "5", 
+                "ParameterName": "max_replication_slots", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(kB) Sets the maximum stack depth, in kilobytes.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "100-2147483647", 
+                "Source": "system", 
+                "ParameterValue": "6144", 
+                "ParameterName": "max_stack_depth", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) Sets the maximum delay before canceling queries when a hot standby server is processing archived WAL data.", 
+                "DataType": "integer", 
+                "AllowedValues": "-1-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "max_standby_archive_delay", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) Sets the maximum delay before canceling queries when a hot standby server is processing streamed WAL data.", 
+                "DataType": "integer", 
+                "AllowedValues": "-1-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "max_standby_streaming_delay", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of simultaneously running WAL sender processes.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "5-8388607", 
+                "Source": "system", 
+                "ParameterValue": "10", 
+                "ParameterName": "max_wal_senders", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(16MB) Sets the WAL size that triggers a checkpoint.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "2-201326592", 
+                "Source": "system", 
+                "ParameterValue": "128", 
+                "ParameterName": "max_wal_size", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the\\\n  maximum number of concurrent worker processes.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-262143", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "max_worker_processes", 
+                "MinimumEngineVersion": "9.6.1", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(8kB) Sets the minimum size of relations to be considered for parallel scan.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-715827882", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "min_parallel_relation_size", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(16MB) Sets the minimum size to shrink the WAL to.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "2-201326592", 
+                "Source": "system", 
+                "ParameterValue": "16", 
+                "ParameterName": "min_wal_size", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(min) Time before a snapshot is too old to read pages changed after the snapshot was taken.", 
+                "DataType": "integer", 
+                "AllowedValues": "-1-86400", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "old_snapshot_threshold", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Emit a warning for constructs that changed meaning since PostgreSQL 9.4.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "operator_precedence_warning", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the planner's estimate of the cost of starting up worker processes for parallel query.", 
+                "DataType": "float", 
+                "AllowedValues": "0-1.79769e+308", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "parallel_setup_cost", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the planner's estimate of the cost of passing each tuple (row) from worker to master backend.", 
+                "DataType": "float", 
+                "AllowedValues": "0-1.79769e+308", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "parallel_tuple_cost", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Encrypt passwords.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": false, 
+                "ParameterName": "password_encryption", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Logs results of hint parsing.", 
+                "DataType": "string", 
+                "AllowedValues": "off,on,detailed,verbose", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_hint_plan.debug_print", 
+                "MinimumEngineVersion": "9.6.2", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Force\n  planner to use plans specified in the hint comment preceding to the\n  query.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_hint_plan.enable_hint", 
+                "MinimumEngineVersion": "9.6.2", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Force\n  planner to not get hint by using table lookups.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_hint_plan.enable_hint_table", 
+                "MinimumEngineVersion": "9.6.2", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Message level of debug messages.", 
+                "DataType": "string", 
+                "AllowedValues": "debug5,debug4,debug3,debug2,debug1,log,info,notice,warning,error", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_hint_plan.message_level", 
+                "MinimumEngineVersion": "9.6.2", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Message level of parse errors.", 
+                "DataType": "string", 
+                "AllowedValues": "debug5,debug4,debug3,debug2,debug1,log,info,notice,warning,error", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_hint_plan.parse_messages", 
+                "MinimumEngineVersion": "9.6.2", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of statements tracked by pg_stat_statements.", 
+                "DataType": "integer", 
+                "AllowedValues": "100-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_stat_statements.max", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Save pg_stat_statements statistics across server shutdowns.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_stat_statements.save", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Selects which statements are tracked by pg_stat_statements.", 
+                "DataType": "string", 
+                "AllowedValues": "NONE,TOP,ALL", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_stat_statements.track", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Selects whether utility commands are tracked by pg_stat_statements.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "pg_stat_statements.track_utility", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the TCP port the server listens on.", 
+                "DataType": "integer", 
+                "IsModifiable": false, 
+                "AllowedValues": "1-65535", 
+                "Source": "system", 
+                "ParameterValue": "{EndPointPort}", 
+                "ParameterName": "port", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Enable or disable GDAL drivers used with PostGIS in Postgres 9.3.5 and above.", 
+                "DataType": "string", 
+                "IsModifiable": true, 
+                "AllowedValues": "ENABLE_ALL,DISABLE_ALL", 
+                "Source": "system", 
+                "ParameterValue": "ENABLE_ALL", 
+                "ParameterName": "postgis.gdal_enabled_drivers", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "When generating SQL fragments, quote all identifiers.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "quote_all_identifiers", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the planners estimate of the cost of a nonsequentially fetched disk page.", 
+                "DataType": "float", 
+                "AllowedValues": "0-1.79769e+308", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "random_page_cost", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "List of extensions provided by RDS", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "address_standardizer,address_standardizer_data_us,bloom,btree_gin,btree_gist,chkpass,citext,cube,dblink,dict_int,dict_xsyn,earthdistance,fuzzystrmatch,hstore,hstore_plperl,intagg,intarray,ip4r,isn,log_fdw,ltree,pgcrypto,pgrowlocks,pgstattuple,pg_buffercache,pg_freespacemap,pg_hint_plan,pg_prewarm,pg_stat_statements,pg_trgm,pg_visibility,plcoffee,plls,plperl,plpgsql,pltcl,plv8,postgis,postgis_tiger_geocoder,postgis_topology,postgres_fdw,sslinfo,tablefunc,test_parser,tsearch2,tsm_system_rows,tsm_system_time,unaccent,uuid-ossp", 
+                "ParameterName": "rds.extensions", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "See log messages for RDS admin user actions in customer databases.", 
+                "DataType": "string", 
+                "AllowedValues": "disabled,debug5,debug4,debug3,debug2,debug1,info,notice,warning,error,log,fatal,panic", 
+                "Source": "system", 
+                "IsModifiable": true, 
+                "ParameterName": "rds.force_admin_logging_level", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "See log messages related to autovacuum operations.", 
+                "DataType": "string", 
+                "AllowedValues": "disabled,debug5,debug4,debug3,debug2,debug1,info,notice,warning,error,log,fatal,panic", 
+                "Source": "system", 
+                "IsModifiable": true, 
+                "ParameterName": "rds.force_autovacuum_logging_level", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Force SSL connections.", 
+                "DataType": "boolean", 
+                "IsModifiable": true, 
+                "AllowedValues": "0,1", 
+                "Source": "system", 
+                "ParameterValue": "0", 
+                "ParameterName": "rds.force_ssl", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Amazon RDS will delete PostgreSQL log that are older than N minutes.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "1440-10080", 
+                "Source": "system", 
+                "ParameterValue": "4320", 
+                "ParameterName": "rds.log_retention_period", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Enables logical decoding.", 
+                "DataType": "boolean", 
+                "IsModifiable": true, 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "ParameterValue": "0", 
+                "ParameterName": "rds.logical_replication", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum size for tcp buffers.", 
+                "DataType": "integer", 
+                "IsModifiable": false, 
+                "AllowedValues": "4096-1000000000", 
+                "Source": "system", 
+                "ParameterValue": "33554432", 
+                "ParameterName": "rds.max_tcp_buffers", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(MB) Size of the stats ramdisk. A nonzero value will setup the ramdisk.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "0-1024", 
+                "Source": "engine-default", 
+                "ParameterValue": "0", 
+                "ParameterName": "rds.pg_stat_ramdisk_size", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the number of connection slots reserved for rds_superusers.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "0-8388607", 
+                "Source": "system", 
+                "ParameterValue": "2", 
+                "ParameterName": "rds.rds_superuser_reserved_connections", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "List of superuser-only variables for which we elevate rds_superuser modification statements.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "session_replication_role", 
+                "ParameterName": "rds.superuser_variables", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the maximum number of tuples to be sorted using replacement selection.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "replacement_sort_tuples", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Reinitialize server after backend crash.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": false, 
+                "ParameterName": "restart_after_crash", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Enable row security.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "row_security", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the schema search order for names that are not schema-qualified.", 
+                "DataType": "string", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "search_path", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the planners estimate of the cost of a sequentially fetched disk page.", 
+                "DataType": "float", 
+                "AllowedValues": "0-1.79769e+308", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "seq_page_cost", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the server (database) character set encoding.", 
+                "DataType": "string", 
+                "Source": "system", 
+                "IsModifiable": false, 
+                "ParameterName": "server_encoding", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the sessions behavior for triggers and rewrite rules.", 
+                "DataType": "string", 
+                "AllowedValues": "origin,replica,local", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "session_replication_role", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(8kB) Sets the number of shared memory buffers used by the server.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "16-1073741823", 
+                "Source": "system", 
+                "ParameterValue": "{DBInstanceClassMemory/32768}", 
+                "ParameterName": "shared_buffers", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Lists shared libraries to preload into server.", 
+                "DataType": "list", 
+                "AllowedValues": "pg_stat_statements,pg_hint_plan", 
+                "Source": "system", 
+                "IsModifiable": true, 
+                "ParameterName": "shared_preload_libraries", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Causes subtables to be included by default in various commands.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "sql_inheritance", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Enables SSL connections.", 
+                "DataType": "boolean", 
+                "IsModifiable": true, 
+                "AllowedValues": "0,1", 
+                "Source": "system", 
+                "ParameterValue": "1", 
+                "ParameterName": "ssl", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Location of the SSL server authority file.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "/rdsdbdata/rds-metadata/ca-cert.pem", 
+                "ParameterName": "ssl_ca_file", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Location of the SSL server certificate file.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "/rdsdbdata/rds-metadata/server-cert.pem", 
+                "ParameterName": "ssl_cert_file", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the list of allowed SSL ciphers.", 
+                "DataType": "string", 
+                "Source": "engine-default", 
+                "IsModifiable": false, 
+                "ParameterName": "ssl_ciphers", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": " Location of the SSL server private key file", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "/rdsdbdata/rds-metadata/server-key.pem", 
+                "ParameterName": "ssl_key_file", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Causes ... strings to treat backslashes literally.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "standard_conforming_strings", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) Sets the maximum allowed duration of any statement.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "statement_timeout", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Writes temporary statistics files to the specified directory.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "/rdsdbdata/db/pg_stat_tmp", 
+                "ParameterName": "stats_temp_directory", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the number of connection slots reserved for superusers.", 
+                "DataType": "integer", 
+                "IsModifiable": false, 
+                "AllowedValues": "0-8388607", 
+                "Source": "system", 
+                "ParameterValue": "3", 
+                "ParameterName": "superuser_reserved_connections", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Enable synchronized sequential scans.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "synchronize_seqscans", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the current transactions synchronization level.", 
+                "DataType": "string", 
+                "IsModifiable": true, 
+                "AllowedValues": "local,on,off", 
+                "Source": "system", 
+                "ParameterValue": "on", 
+                "ParameterName": "synchronous_commit", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the syslog facility to be used when syslog enabled.", 
+                "DataType": "string", 
+                "AllowedValues": "local0,local1,local2,local3,local4,local5,local6,local7", 
+                "Source": "engine-default", 
+                "IsModifiable": false, 
+                "ParameterName": "syslog_facility", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Maximum number of TCP keepalive retransmits.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "tcp_keepalives_count", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(s) Time between issuing TCP keepalives.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "tcp_keepalives_idle", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(s) Time between TCP keepalive retransmits.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "tcp_keepalives_interval", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(8kB) Sets the maximum number of temporary buffers used by each session.", 
+                "DataType": "integer", 
+                "AllowedValues": "100-1073741823", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "temp_buffers", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the tablespace(s) to use for temporary tables and sort files.", 
+                "DataType": "string", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "temp_tablespaces", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the time zone for displaying and interpreting time stamps.", 
+                "DataType": "string", 
+                "IsModifiable": true, 
+                "Source": "system", 
+                "ParameterValue": "UTC", 
+                "ParameterName": "timezone", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Collects information about executing commands.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "track_activities", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the size reserved for pg_stat_activity.current_query, in bytes.", 
+                "DataType": "integer", 
+                "AllowedValues": "100-102400", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "track_activity_query_size", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Collects transaction commit time.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "track_commit_timestamp", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Collects statistics on database activity.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "track_counts", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Collects function-level statistics on database activity.", 
+                "DataType": "string", 
+                "AllowedValues": "none,pl,all", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "track_functions", 
+                "ApplyType": "dynamic"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_param_filter/rds.DescribeDBParameters_3.json
+++ b/tests/data/placebo/test_rds_param_filter/rds.DescribeDBParameters_3.json
@@ -1,0 +1,323 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b8b0537b-521a-11e7-ab28-6d89c50f6e01", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b8b0537b-521a-11e7-ab28-6d89c50f6e01", 
+                "vary": "Accept-Encoding", 
+                "content-length": "13938", 
+                "content-type": "text/xml", 
+                "date": "Thu, 15 Jun 2017 22:33:57 GMT"
+            }
+        }, 
+        "Parameters": [
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Collects timing statistics on database IO activity.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "system", 
+                "IsModifiable": true, 
+                "ParameterName": "track_io_timing", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Whether to defer a read-only serializable transaction until it can be executed with no possible serialization failures.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "transaction_deferrable", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the current transactions read-only status.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "transaction_read_only", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Treats expr=NULL as expr IS NULL.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "transform_null_equals", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the directory where the Unix-domain socket will be created.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "/tmp", 
+                "ParameterName": "unix_socket_directories", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the owning group of the Unix-domain socket.", 
+                "DataType": "string", 
+                "IsModifiable": false, 
+                "Source": "system", 
+                "ParameterValue": "rdsdb", 
+                "ParameterName": "unix_socket_group", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the access permissions of the Unix-domain socket.", 
+                "DataType": "integer", 
+                "IsModifiable": false, 
+                "AllowedValues": "0-511", 
+                "Source": "system", 
+                "ParameterValue": "0700", 
+                "ParameterName": "unix_socket_permissions", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Updates the process title to show the active SQL command.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "update_process_title", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) Vacuum cost delay in milliseconds.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-100", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_cost_delay", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Vacuum cost amount available before napping.", 
+                "DataType": "integer", 
+                "AllowedValues": "1-10000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_cost_limit", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Vacuum cost for a page dirtied by vacuum.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-10000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_cost_page_dirty", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Vacuum cost for a page found in the buffer cache.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-10000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_cost_page_hit", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Vacuum cost for a page not found in the buffer cache.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-10000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_cost_page_miss", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Number of transactions by which VACUUM and HOT cleanup should be deferred, if any.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-1000000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_defer_cleanup_age", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Minimum age at which VACUUM should freeze a table row.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-1000000000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_freeze_min_age", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Age at which VACUUM should scan whole table to freeze tuples.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2000000000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_freeze_table_age", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Minimum age at which VACUUM should freeze a MultiXactId in a table row.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-1000000000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_multixact_freeze_min_age", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Multixact age at which VACUUM should scan whole table to freeze tuples.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2000000000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "vacuum_multixact_freeze_table_age", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(8kB) Sets the number of disk-page buffers in shared memory for WAL.", 
+                "DataType": "integer", 
+                "AllowedValues": "-1-262143", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "wal_buffers", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Compresses full-page writes written in WAL file.", 
+                "DataType": "boolean", 
+                "AllowedValues": "0,1", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "wal_compression", 
+                "ApplyType": "static"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets the number of WAL files held for standby servers.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "0-2147483647", 
+                "Source": "system", 
+                "ParameterValue": "32", 
+                "ParameterName": "wal_keep_segments", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(s) Sets the maximum interval between WAL receiver status reports to the primary.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2147483", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "wal_receiver_status_interval", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) Sets the maximum wait time to receive data from the primary.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "0-3600000", 
+                "Source": "engine-default", 
+                "ParameterValue": "30000", 
+                "ParameterName": "wal_receiver_timeout", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) Sets the maximum time to wait for WAL replication.", 
+                "DataType": "integer", 
+                "IsModifiable": true, 
+                "AllowedValues": "0-3600000", 
+                "Source": "engine-default", 
+                "ParameterValue": "30000", 
+                "ParameterName": "wal_sender_timeout", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Selects the method used for forcing WAL updates to disk.", 
+                "DataType": "string", 
+                "AllowedValues": "fsync,fdatasync,open_sync,open_datasync", 
+                "Source": "system", 
+                "IsModifiable": false, 
+                "ParameterName": "wal_sync_method", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(ms) WAL writer sleep time between WAL flushes.", 
+                "DataType": "integer", 
+                "AllowedValues": "1-10000", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "wal_writer_delay", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(8Kb) Amount of WAL written out by WAL writer triggering a flush.", 
+                "DataType": "integer", 
+                "AllowedValues": "0-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "wal_writer_flush_after", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "(kB) Sets the maximum memory to be used for query workspaces.", 
+                "DataType": "integer", 
+                "AllowedValues": "64-2147483647", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "work_mem", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets how binary values are to be encoded in XML.", 
+                "DataType": "string", 
+                "AllowedValues": "base64,hex", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "xmlbinary", 
+                "ApplyType": "dynamic"
+            }, 
+            {
+                "ApplyMethod": "pending-reboot", 
+                "Description": "Sets whether XML data in implicit parsing and serialization operations is to be considered as documents or content fragments.", 
+                "DataType": "string", 
+                "AllowedValues": "content,document", 
+                "Source": "engine-default", 
+                "IsModifiable": true, 
+                "ParameterName": "xmloption", 
+                "ApplyType": "dynamic"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_param_filter/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_rds_param_filter/rds.ListTagsForResource_1.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "8c15813f-3a7a-11e7-95c5-677648e242bf", 
+            "RequestId": "b7e22d5b-521a-11e7-b6f2-4d870df0e68c", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "8c15813f-3a7a-11e7-95c5-677648e242bf", 
-                "date": "Tue, 16 May 2017 20:59:26 GMT", 
+                "x-amzn-requestid": "b7e22d5b-521a-11e7-b6f2-4d870df0e68c", 
+                "date": "Thu, 15 Jun 2017 22:33:55 GMT", 
                 "content-length": "394", 
                 "content-type": "text/xml"
             }

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -897,15 +897,12 @@ class TestHealthEventsFilter(BaseTest):
 
 
 class TestRDSParameterGroupFilter(BaseTest):
-    """ This test assumes two parameter groups have been created and
-        assigned to two different RDS instances.
-    """
 
     PARAMGROUP_PARAMETER_FILTER_TEST_CASES = [
         # filter_struct, test_func, err_message
         ({'key': 'log_destination', 'op': 'eq', 'value': 'stderr'},
          lambda r: len(r) == 1,
-         "instances with log_destination == stderr should be 2"),
+         "instances with log_destination == stderr should be 1"),
         ({'key': 'log_destination', 'op': 'eq', 'value': 's3'},
          lambda r: len(r) == 0,
          "instances with log_destination == s3 should be 0"),
@@ -914,7 +911,7 @@ class TestRDSParameterGroupFilter(BaseTest):
          "instances with log_destination != stderr should be 0"),
         ({'key': 'log_destination', 'op': 'ne', 'value': 's3'},
          lambda r: len(r) == 1,
-         "instances with log_destination != s3 should be 2"),
+         "instances with log_destination != s3 should be 1"),
         ({'key': 'full_page_writes', 'op': 'eq', 'value': True},
          lambda r: len(r) == 1,
          "full_page_writes ( a boolean ) should be on"),

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -915,9 +915,6 @@ class TestRDSParameterGroupFilter(BaseTest):
         ({'key': 'full_page_writes', 'op': 'eq', 'value': True},
          lambda r: len(r) == 1,
          "full_page_writes ( a boolean ) should be on"),
-        ({'key': 'port', 'op': 'eq', 'value': 80},
-         lambda r: len(r) == 0,
-         "instance with port == 80 should be 0"),
     ]
 
     def test_param_value_cases(self):

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -915,6 +915,9 @@ class TestRDSParameterGroupFilter(BaseTest):
         ({'key': 'full_page_writes', 'op': 'eq', 'value': True},
          lambda r: len(r) == 1,
          "full_page_writes ( a boolean ) should be on"),
+        ({'key': 'port', 'op': 'eq', 'value': 80},
+         lambda r: len(r) == 0,
+         "instance with port == 80 should be 0"),
     ]
 
     def test_param_value_cases(self):


### PR DESCRIPTION
1. The response of `describe_db_parameters` has a maximum of 100 parameters per call while many parameter groups have hundreds of parameter. Paginate it to get the full list of parameters. 
The maximum also applies to `describe_cluster_parameters` for redshift (although currently there are only few parameters per group for redshift).

2. When recast the value, some errors occur because of unexpected value. 
For example:
![image](https://user-images.githubusercontent.com/10120438/27212838-ce952db2-5230-11e7-94c9-df64bc86e67b.png)
Add more statement to determine the return value

3. Update placebo data and test case. Remove some outdated part.

Thanks!