### PR TITLE
Unfrobulate tests at Travis

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -121,8 +121,7 @@ class EmailDelivery(object):
             # we allow multiple emails from various places, we'll unique with set to not have any
             # duplicates, and we'll also sort it so we always have the same key for other resources
             # and finally we'll make it a tuple, since that is hashable and can be a key in a dict
-            resource_emails.sort()
-            resource_emails = tuple(set(resource_emails))
+            resource_emails = tuple(sorted(set(resource_emails)))
             # only if there are valid emails available, add it to the map
             if resource_emails:
                 email_to_addrs_to_resources_map.setdefault(resource_emails, []).append(resource)

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -104,7 +104,7 @@ class EmailTest(unittest.TestCase):
         )
         # make sure only 1 email is queued to go out
         self.assertEqual(len(emails_to_resources_map.items()), 1)
-        to_emails = ('peter@initech.com', 'milton@initech.com', 'bill_lumberg@initech.com')
+        to_emails = ('bill_lumberg@initech.com', 'milton@initech.com', 'peter@initech.com')
         self.assertEqual(emails_to_resources_map, {to_emails: [RESOURCE_1]})
 
     def test_email_to_email_message_map_without_ldap_manager(self):
@@ -113,7 +113,7 @@ class EmailTest(unittest.TestCase):
         email_addrs_to_email_message_map = self.email_delivery.get_to_addrs_email_messages_map(
             SQS_MESSAGE
         )
-        to_emails = ('peter@initech.com', 'milton@initech.com', 'bill_lumberg@initech.com')
+        to_emails = ('bill_lumberg@initech.com', 'milton@initech.com', 'peter@initech.com')
         self.assertEqual(email_addrs_to_email_message_map.items()[0][0], to_emails)
         self.assertEqual(email_addrs_to_email_message_map.items()[0][1]['to'], ', '.join(to_emails))
 
@@ -134,7 +134,7 @@ class EmailTest(unittest.TestCase):
             self.assertEqual(smtp_instance.sendmail.call_count, 1)
             # Check the mock' calls are equal to a specific list of calls in a
             # specific order
-            to_addrs = ['peter@initech.com', 'milton@initech.com', 'bill_lumberg@initech.com']
+            to_addrs = ['bill_lumberg@initech.com', 'milton@initech.com', 'peter@initech.com']
             self.assertEqual(
                 smtp_instance.sendmail.mock_calls,
                 [call(MAILER_CONFIG['from_address'], to_addrs, mimetext_msg.as_string())]
@@ -188,7 +188,7 @@ class EmailTest(unittest.TestCase):
         emails_to_resources_map = self.email_delivery.get_email_to_addrs_to_resources_map(
             SQS_MESSAGE
         )
-        email_1_to_addrs = ('peter@initech.com', 'milton@initech.com', 'bill_lumberg@initech.com')
+        email_1_to_addrs = ('bill_lumberg@initech.com', 'milton@initech.com', 'peter@initech.com')
         email_2_to_addrs = ('samir@initech.com',)
         self.assertEqual(emails_to_resources_map[email_1_to_addrs], [RESOURCE_1])
         self.assertEqual(emails_to_resources_map[email_2_to_addrs], [RESOURCE_2])

--- a/tox.ini
+++ b/tox.ini
@@ -14,9 +14,6 @@ envlist = py27,py36
 
 [testenv]
 deps = -rrequirements-dev.txt
-    pytest
-    pytest-xdist
-    pytest-cov
 
 [testenv:py27]
 whitelist_externals = make

--- a/tox.ini
+++ b/tox.ini
@@ -18,7 +18,7 @@ deps = -rrequirements-dev.txt
 [testenv:py27]
 whitelist_externals = make
 commands = flake8
-    py.test -v -n auto --cov=c7n tests tools
+    py.test -v -n auto --cov=c7n --cov=tools tests tools
     make sphinx
 
 [testenv:py36]

--- a/tox.ini
+++ b/tox.ini
@@ -1,5 +1,5 @@
 [flake8]
-exclude = .git,venv,python2.7,bin,test_*,tests,docs,__init__.py
+exclude = .git,venv,python2.7,bin,test_*,tests,docs,__init__.py,.tox
 ; E401 is 'multiple imports on one line' -- no big deal
 ; E128 is under identation
 ; E203 is whitespace before ':'


### PR DESCRIPTION
Travis got frobulated in #1234 after resolving conflicts from #1201, because, now that these deps are also spec'd in `requirements-dev.txt`, pytest complains to see them here.