### PR TITLE
Fix offhours code to not assume ec2 if manager not initialized

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -197,7 +197,7 @@ from os.path import join
 from dateutil import zoneinfo
 
 from c7n.filters import Filter, FilterValidationError
-from c7n.utils import type_schema, dumps
+from c7n.utils import type_schema, dumps, get_instance_key
 
 log = logging.getLogger('custodian.offhours')
 
@@ -301,7 +301,7 @@ class Time(Filter):
         # but unit testing is calling this direct.
         if self.id_key is None:
             self.id_key = (
-                self.manager is None and 'InstanceId' or self.manager.get_model().id)
+                self.manager is None and get_instance_key(i) or self.manager.get_model().id)
 
         # The resource tag is not present, if we're not running in an opt-out
         # mode, we're done.

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -204,6 +204,22 @@ def get_account_id_from_sts(session):
     return response.get('Account')
 
 
+def get_instance_key(instance):
+    """Given AWS instance metadata, return the key used to identify the
+    associated resource.
+    """
+    if 'InstanceId' in instance:
+        return 'InstanceId'  # ec2
+    elif 'AutoScalingGroupName' in instance:
+        return 'AutoScalingGroupName'  # asg
+    elif 'DBInstanceIdentifier' in instance:
+        return 'DBInstanceIdentifier'  # rds instance
+    elif 'DBClusterIdentifier' in instance:
+        return 'DBClusterIdentifier'  # rds cluster
+    else:
+        raise ValueError
+
+
 def query_instances(session, client=None, **query):
     """Return a list of ec2 instances for the query.
     """


### PR DESCRIPTION
Resolve problem where i.get('InstanceId', ()) is called from non ec2 metadata, resulting in a key error.