### PR TITLE
config rule initialize resources var for left scope evals

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -530,6 +530,7 @@ class ConfigRuleMode(LambdaMode):
         self.cfg_event = json.loads(event['invokingEvent'])
         cfg_item = self.cfg_event['configurationItem']
         evaluation = None
+        resources = []
         # TODO config resource type matches policy check
         if event['eventLeftScope'] or cfg_item['configurationItemStatus'] in (
                 "ResourceDeleted",


### PR DESCRIPTION
closes #1304 