### PR TITLE
More ci tinkering

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,4 +13,4 @@ install:
 script:
   - TOXENV=`tools/dev/citoxenv.py` tox
 after_success:
-  - coveralls
+  - if [ "$TRAVIS_PYTHON_VERSION" == "2.7" ]; then coveralls; fi

--- a/tests/common.py
+++ b/tests/common.py
@@ -179,6 +179,12 @@ class BaseTest(PillTest):
 class TextTestIO(io.StringIO):
 
     def write(self, b):
+
+        # print handles both str/bytes and unicode/str, but io.{String,Bytes}IO
+        # requires us to choose. We don't have control over all of the places
+        # we want to print from (think: traceback.print_exc) so we can't
+        # standardize the arg type up at the call sites. Hack it here.
+
         if not isinstance(b, six.types.UnicodeType):
             b = b.decode('utf8')
         return super(TextTestIO, self).write(b)

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -13,32 +13,15 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import codecs
-import io
 import json
 import os
 import sys
 
-import six
 from argparse import ArgumentTypeError
 from c7n import cli, version, commands, utils
 from datetime import datetime, timedelta
 
-from .common import BaseTest
-
-
-class AmbiguousIO(io.BytesIO):
-
-    def write(self, x):
-
-        # print handles both str/bytes and unicode/str, but io.{String,Bytes}IO
-        # requires us to choose. We don't have control over all of the places
-        # we want to print from (think: traceback.print_exc) so we can't
-        # standardize the arg type up at the call sites. Hack it here.
-
-        if type(x) is six.text_type:
-            x = codecs.encode(x, 'utf8')
-        io.BytesIO.write(self, x)
+from .common import BaseTest, TextTestIO
 
 
 class CliTest(BaseTest):
@@ -54,8 +37,8 @@ class CliTest(BaseTest):
         return out
 
     def capture_output(self):
-        out = AmbiguousIO()
-        err = AmbiguousIO()
+        out = TextTestIO()
+        err = TextTestIO()
         self.patch(sys, 'stdout', out)
         self.patch(sys, 'stderr', err)
         return out, err

--- a/tools/dev/citoxenv.py
+++ b/tools/dev/citoxenv.py
@@ -1,9 +1,7 @@
 #!/usr/bin/env python
 import os
-pyenv = "py%s-cov" % (os.environ.get(
-    'TRAVIS_PYTHON_VERSION', '').replace('python', 'py').replace('.', ''))
-toxenv = [pyenv]
-if pyenv == 'py27-cov':
-    toxenv.append('docs')
-    toxenv.append('lint')
-print(",".join(toxenv))
+pyver = os.environ.get('TRAVIS_PYTHON_VERSION', '')
+if pyver == '2.7':
+    print('py27-cov,docs,lint')
+elif pyver == '3.6':
+    print('py36')

--- a/tools/dev/ratchet.py
+++ b/tools/dev/ratchet.py
@@ -30,7 +30,7 @@ class TestResults(object):
 
     def process_testcase(self, case):
         key = self.case_key(case)
-        
+
         fails = case.findall('failure')
         if not len(case):
             self.passed.append(key)
@@ -40,7 +40,7 @@ class TestResults(object):
             if tags == set(['system-err']):
                 self.stderr_output.append(key)
                 return
-            raise AssertionError("unknown result" % key)
+            raise AssertionError("unknown result for %s" % key)
         else:
             self.failed.append(key)
             self.failed_aggregates.setdefault(

--- a/tox.ini
+++ b/tox.ini
@@ -29,10 +29,7 @@ commands =
     py.test --cov=c7n -n auto --durations 20 tests tools/c7n_logexporter tools/c7n_mailer {posargs}
 
 [testenv:py36]
-commands = - py.test -n auto --tb=line tests {posargs}
-
-[testenv:py36-cov]
-commands = - py.test -n auto --tb=line --cov=c7n --junitxml=results.xml tests
+commands = - py.test -n auto --tb=line --junitxml=results.xml tests {posargs}
     python3 ./tools/dev/ratchet.py results.xml ratchet.txt
 
 [testenv:pypy]


### PR DESCRIPTION
Follow-up from https://github.com/capitalone/cloud-custodian/pull/1326:

- simplifies coverage story, no need to run under py36 (may also help with [erratic Coveralls behavior](https://github.com/whit537/cloud-custodian/issues/28))
- brings ratchet back to `py36` tox env, as promised in docs as of #1303
- drops `AmbiguousIO` in favor of `TextTestIO` (cf. #1314)