### PR TITLE
Adding tox to requiremvents-dev.txt

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -14,6 +14,7 @@ fakeredis
 pytest>=2.7.0
 pytest-xdist
 pytest-cov
+tox
 
 # Local package required for Sphinx docs
 -e tools/c7n_sphinxext


### PR DESCRIPTION
tox was missing from the requirements and I had to manually install it