### PR TITLE
Use six.StringIO for py2/py3 compatibility without unicode/str errors

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -18,7 +18,6 @@ import datetime
 from datetime import timedelta
 from dateutil.parser import parse
 from dateutil.tz import tzutc
-import io
 import itertools
 import time
 

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -560,7 +560,7 @@ class CredentialReport(Filter):
             return report
         data = self.fetch_credential_report()
         report = {}
-        reader = csv.reader(io.StringIO(data))
+        reader = csv.reader(six.StringIO(data))
         headers = reader.next()
         for line in reader:
             info = dict(zip(headers, line))


### PR DESCRIPTION
```
2017-06-27 13:28:20,620: custodian.commands:ERROR Error while executing policy biz-iam-mfa-check-policy, continuing
Traceback (most recent call last):
File ".../c7n/c7n/commands.py", line 212, in run
  policy()
File ".../c7n/c7n/policy.py", line 677, in __call__
  resources = PullMode(self).run()
File ".../c7n/c7n/policy.py", line 305, in run
  resources = self.policy.resource_manager.resources()
File ".../c7n/c7n/query.py", line 287, in resources
  return self.filter_resources(resources)
File ".../c7n/c7n/manager.py", line 88, in filter_resources
  resources = f.process(resources, event)
File ".../c7n/c7n/resources/iam.py", line 644, in process
  report = self.get_credential_report()
File ".../c7n/c7n/resources/iam.py", line 563, in get_credential_report
  reader = csv.reader(io.StringIO(data))
TypeError: initial_value must be unicode or None, not str
```