### PR TITLE
c7n-mailer Fixed LDAP lookup in Assumed Roles

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -813,14 +813,24 @@ class CloudWatchEventSource(object):
     def render_event_pattern(self):
         event_type = self.data.get('type')
         sources = self.data.get('sources', [])
-        for e in  self.data.get('events'):
-            sources.append(e['source'])
+        cwevents = self.data.get('events')
+        if cwevents is None:
+            print('events is None')
+        else:
+            for e in cwevents:
+                if not isinstance(e, dict):
+                    event_info = CloudWatchEvents.get(e)
+                    if event_info is None:
+                        continue
+                else:
+                    event_info = e
+                sources.append(event_info['source'])
         payload = {}
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         elif event_type == 'cloudtrail':
-            payload['detail-type'] = ['AWS API Call via CloudTrail']   
+            payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,10 +812,11 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
-        event_source =  self.data.get('events')
-        event_source = event_source[0].get('source')
+        sources = self.data.get('sources', [])
+        for e in  self.data.get('events'):
+            sources.append(e['source'])
         payload = {}
-        if event_type == 'cloudtrail' and event_source == 'signin.amazonaws.com':
+        if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         elif event_type == 'cloudtrail':

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,11 +812,15 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
+        event_source =  self.data.get('events')
+        event_source = event_source[0].get('source')
         payload = {}
-        if event_type == 'cloudtrail':
-            payload['detail-type'] = ['AWS API Call via CloudTrail']
+        if event_type == 'cloudtrail' and event_source == 'signin.amazonaws.com':
+            payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-
+        elif event_type == 'cloudtrail':
+            payload['detail-type'] = ['AWS API Call via CloudTrail']   
+            self.resolve_cloudtrail_payload(payload)
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']
             payload['detail-type'] = [

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -223,9 +223,10 @@ class EmailDelivery(object):
                 format_struct(event)))
             return None
         if identity['type'] == 'AssumedRole':
-            assume_role_msg = 'No ldap uid is associated with AssumedRole: %s' % identity['arn']
+            assume_role_msg = 'AssumedRole Found: %s' % identity['arn']
             self.logger.debug(assume_role_msg)
-            return None
+            user_id = identity['principalId'].split(':', 1)[-1]
+            return user_id
         if identity['type'] == 'IAMUser' or identity['type'] == 'WebIdentityUser':
             return identity['userName']
         if identity['type'] == 'Root':


### PR DESCRIPTION
In order to get AssumedRoles/Federated users to be looked up in LDAP I
had to modify the code to parse the ID from the end of the AssumedRole
arn and perform a lookup on it.  This works for SSO Federated AWS Users.