### PR TITLE
Update mu.py to allow root console login detection

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,11 +812,16 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
+        sources = self.data.get('sources', [])
+        for e in  self.data.get('events'):
+            sources.append(e['source'])
         payload = {}
-        if event_type == 'cloudtrail':
-            payload['detail-type'] = ['AWS API Call via CloudTrail']
+        if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
+            payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-
+        elif event_type == 'cloudtrail':
+            payload['detail-type'] = ['AWS API Call via CloudTrail']   
+            self.resolve_cloudtrail_payload(payload)
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']
             payload['detail-type'] = [


### PR DESCRIPTION
In order to get a policy working that triggers on a CloudTrail console
signin event I edited the mu.py code to provide the correct detail-type
payload for the CWERule as its different for console signins vs other
API actions.  I have tested this and it works