### PR TITLE
Update mu.py to allow for root console login event

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -815,7 +815,7 @@ class CloudWatchEventSource(object):
         payload = {}
         sources = self.data.get('sources', [])
         for e in  self.data.get('events'):
-            e = json.dumps(e)
+            e = json.loads(e)
             sources.append(e['source'])
         payload = {}
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,19 +812,22 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
-        payload = {}
         sources = self.data.get('sources', [])
-        for e in  self.data.get('events'):
-            e = json.loads(e)
-            sources.append(e['source'])
+        for e in self.data.get('events'):
+            if not isinstance(e, dict):
+                event_info = CloudWatchEvents.get(e)
+                if event_info is None:
+                    continue
+            else:
+                event_info = e
+            sources.append(event_info['source'])
         payload = {}
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         elif event_type == 'cloudtrail':
-            payload['detail-type'] = ['AWS API Call via CloudTrail']   
+            payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']
             payload['detail-type'] = [

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -813,14 +813,18 @@ class CloudWatchEventSource(object):
     def render_event_pattern(self):
         event_type = self.data.get('type')
         sources = self.data.get('sources', [])
-        for e in self.data.get('events'):
-            if not isinstance(e, dict):
-                event_info = CloudWatchEvents.get(e)
-                if event_info is None:
-                    continue
-            else:
-                event_info = e
-            sources.append(event_info['source'])
+        cwevents = self.data.get('events')
+        if cwevents is None:
+            print('events is None')
+        else:
+            for e in cwevents:
+                if not isinstance(e, dict):
+                    event_info = CloudWatchEvents.get(e)
+                    if event_info is None:
+                        continue
+                else:
+                    event_info = e
+                sources.append(event_info['source'])
         payload = {}
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -813,8 +813,16 @@ class CloudWatchEventSource(object):
     def render_event_pattern(self):
         event_type = self.data.get('type')
         payload = {}
-        if event_type == 'cloudtrail':
-            payload['detail-type'] = ['AWS API Call via CloudTrail']
+        sources = self.data.get('sources', [])
+        for e in  self.data.get('events'):
+            e = json.dumps(e)
+            sources.append(e['source'])
+        payload = {}
+        if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
+            payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
+            self.resolve_cloudtrail_payload(payload)
+        elif event_type == 'cloudtrail':
+            payload['detail-type'] = ['AWS API Call via CloudTrail']   
             self.resolve_cloudtrail_payload(payload)
 
         elif event_type == "ec2-instance-state":


### PR DESCRIPTION
In order to get a policy working that triggers on a CloudTrail console
signin event I edited the mu.py code to provide the correct detail-type
payload for the CWERule as its different for console signins vs other
API actions.  I have tested this and it works