### PR TITLE
Adding custom detail-type CWER

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,11 +812,26 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
+        sources = self.data.get('sources', [])
+        cwevents = self.data.get('events')
+        if cwevents is None:
+            print('events is None')
+        else:
+            for e in cwevents:
+                if not isinstance(e, dict):
+                    event_info = CloudWatchEvents.get(e)
+                    if event_info is None:
+                        continue
+                else:
+                    event_info = e
+                sources.append(event_info['source'])
         payload = {}
-        if event_type == 'cloudtrail':
+        if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
+            payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
+            self.resolve_cloudtrail_payload(payload)
+        elif event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']
             payload['detail-type'] = [


### PR DESCRIPTION
For Console login events through CloudTrail it needs a special
detail-type of AWS Console Sign In via Cloudtrail.