### PR TITLE
Updated mu.py to support CloudTrail console login events

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -825,8 +825,7 @@ class CloudWatchEventSource(object):
                         continue
                 else:
                     event_info = e
-                sources.append(event_info['source'])
-        
+                sources.append(event_info['source'])  
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -814,6 +814,7 @@ class CloudWatchEventSource(object):
         event_type = self.data.get('type')
         sources = self.data.get('sources', [])
         cwevents = self.data.get('events')
+        payload = {}
         if cwevents is None:
             print('events is None')
         else:
@@ -828,7 +829,6 @@ class CloudWatchEventSource(object):
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-        payload = {}
         elif event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,7 +812,8 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
-        sources = self.data.get('sources', [])
+        '''
+		sources = self.data.get('sources', [])
         cwevents = self.data.get('events')
         if cwevents is None:
             print('events is None')
@@ -829,7 +830,9 @@ class CloudWatchEventSource(object):
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-        elif event_type == 'cloudtrail':
+        el
+		'''
+		if event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         elif event_type == "ec2-instance-state":

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -826,12 +826,13 @@ class CloudWatchEventSource(object):
                 else:
                     event_info = e
                 sources.append(event_info['source'])
-        payload = {}
+        
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         el
         '''
+        payload = {}
         if event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -816,7 +816,7 @@ class CloudWatchEventSource(object):
         cwevents = self.data.get('events')
         payload = {}
         if cwevents is None:
-            continue
+            test = 'failed'
         else:
             for e in cwevents:
                 if not isinstance(e, dict):

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -825,7 +825,7 @@ class CloudWatchEventSource(object):
                         continue
                 else:
                     event_info = e
-                sources.append(event_info['source'])  
+                sources.append(event_info['source'])
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -816,7 +816,7 @@ class CloudWatchEventSource(object):
         cwevents = self.data.get('events')
         payload = {}
         if cwevents is None:
-            print('events is None')
+            #'events is None'
         else:
             for e in cwevents:
                 if not isinstance(e, dict):
@@ -834,8 +834,7 @@ class CloudWatchEventSource(object):
             self.resolve_cloudtrail_payload(payload)
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']
-            payload['detail-type'] = [
-                "EC2 Instance State-change Notification"]
+            payload['detail-type'] = ["EC2 Instance State-change Notification"]
             # Technically could let empty be all events, but likely misconfig
             payload['detail'] = {"state": self.data.get('events', [])}
         elif event_type == "asg-instance-state":

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -816,7 +816,7 @@ class CloudWatchEventSource(object):
         cwevents = self.data.get('events')
         payload = {}
         if cwevents is None:
-            #'events is None'
+            continue
         else:
             for e in cwevents:
                 if not isinstance(e, dict):

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,11 +812,26 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
+        sources = self.data.get('sources', [])
+        cwevents = self.data.get('events')
+        if cwevents is None:
+            print('events is None')
+        else:
+            for e in cwevents:
+                if not isinstance(e, dict):
+                    event_info = CloudWatchEvents.get(e)
+                    if event_info is None:
+                        continue
+                else:
+                    event_info = e
+                sources.append(event_info['source'])
         payload = {}
-        if event_type == 'cloudtrail':
+        if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
+            payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
+            self.resolve_cloudtrail_payload(payload)
+        elif event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']
             payload['detail-type'] = [

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -815,9 +815,7 @@ class CloudWatchEventSource(object):
         sources = self.data.get('sources', [])
         cwevents = self.data.get('events')
         payload = {}
-        if cwevents is None:
-            test = 'failed'
-        else:
+        if cwevents is not None:
             for e in cwevents:
                 if not isinstance(e, dict):
                     event_info = CloudWatchEvents.get(e)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -813,7 +813,7 @@ class CloudWatchEventSource(object):
     def render_event_pattern(self):
         event_type = self.data.get('type')
         '''
-		sources = self.data.get('sources', [])
+        sources = self.data.get('sources', [])
         cwevents = self.data.get('events')
         if cwevents is None:
             print('events is None')
@@ -831,8 +831,8 @@ class CloudWatchEventSource(object):
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         el
-		'''
-		if event_type == 'cloudtrail':
+        '''
+        if event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         elif event_type == "ec2-instance-state":

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -812,7 +812,6 @@ class CloudWatchEventSource(object):
 
     def render_event_pattern(self):
         event_type = self.data.get('type')
-        '''
         sources = self.data.get('sources', [])
         cwevents = self.data.get('events')
         if cwevents is None:
@@ -829,10 +828,8 @@ class CloudWatchEventSource(object):
         if event_type == 'cloudtrail' and 'signin.amazonaws.com' in sources:
             payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
-        el
-        '''
         payload = {}
-        if event_type == 'cloudtrail':
+        elif event_type == 'cloudtrail':
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
         elif event_type == "ec2-instance-state":


### PR DESCRIPTION
This code will check the source of the event and if the source is signin.amazonaws.com then it will set the proper detail-type of the CloudTrail event for detecting console logins.  This will be used in a policy to detect Root logins and notify as well as logins from external IPs.

```
- name: root-login-detected
  resource: account
  description: |
    Notifies on root user logins
  mode:
     type: cloudtrail
     events:
        - source: signin.amazonaws.com
          event: ConsoleLogin
          ids: "userIdentity.arn"
  filters:
    - type: event
      key: "detail.userIdentity.type"
      value_type: swap
      op: in
      value: Root
  actions:
    - type: notify
      template: default.html
      priority_header: 2
      subject: "Acccount - Root Login Detected - [custodian {{ account }} - {{ region }}]"
      violation_desc: "The Root User has logged in:"
      action_desc: "Actions Taken:  Notify Only"
      to:
        - CloudCustodian@Company.com
      transport:
        type: sqs
        queue: https://sqs.us-east-1.amazonaws.com/12345678890/cloud-custodian-mailer
        region: us-east-1


- name:  invalid-external-login-detected
  resource: account
  description: |
    Notifies on invalid external IP console logins.  The regex triggers if the source IP
    is not from the companys internal CIDRs.  In this example it flags if source IP is not
    190.134.0.0/24 or 165.180.0.0/24 or 197.32.0.0/24
  mode:
     type: cloudtrail
     events:
        - source: signin.amazonaws.com
          event: ConsoleLogin
          ids: "userIdentity.arn"
  filters:
    - not:
          ### Generate the Regex for IPs Here http://www.analyticsmarket.com/freetools/ipregex
        - type: event
          key: 'detail.sourceIPAddress'
          value: '^((190\.134\.|165\.180\.|197\.32\.)([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))|(10\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))|(192\.8\.155\.2([1-9]|[1-9][0-9]|[1-9][0-9][0-9]))$'
          op: regex
  actions:
    - type: notify
      template: default.html
      priority_header: 1
      subject: "Acccount - External Login Detected - [custodian {{ account }} - {{ region }}]"
      violation_desc: "A User Has Logged In Externally From Invalid IP:"
      action_desc: "Actions Taken:  Notify Only"
      to:
        - CloudCustodian@Company.com
      transport:
        type: sqs
        queue: https://sqs.us-east-1.amazonaws.com/123456578900/cloud-custodian-mailer
        region: us-east-1
```