### PR TITLE
Fix s3 has-statement filter empty policy behavior

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -403,7 +403,7 @@ class HasStatementFilter(Filter):
     def process_bucket(self, b):
         p = b.get('Policy')
         if p is None:
-            return b
+            return None
         p = json.loads(p)
         required = list(self.data.get('statement_ids', []))
         statements = p.get('Statement', [])


### PR DESCRIPTION
Buckets with no bucket policy should not be returned in 'has-statement', it currently returns all buckets with no  bucket-policy for any 'has-statement' query