### PR TITLE
fix pluralization in MetricsFilter example

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -38,7 +38,7 @@ class MetricsFilter(Filter):
       - name: ec2-underutilized
         resource: ec2
         filters:
-          - type: metric
+          - type: metrics
             name: CPUUtilization
             days: 4
             period: 86400


### PR DESCRIPTION
I copied the example from the [docs](http://www.capitalone.io/cloud-custodian/docs/generated/c7n.filters.html#c7n.filters.metrics.MetricsFilter) and couldn't figure out why schema validation was failing, until I realized the example in the docs is missing the ``s`` on ``metrics`` in the filter type.