### PR TITLE
Minor fix for RDS filter db-parameter

### DIFF
--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1568,7 +1568,7 @@ class ParameterFilter(ValueFilter):
 
         for pg in param_groups:
             cache_key = {
-                'region': self.manager.config.regions,
+                'region': self.manager.config.region,
                 'account_id': self.manager.config.account_id,
                 'rds-pg': pg}
             pg_values = self.manager._cache.get(cache_key)


### PR DESCRIPTION
There seems to be a minor typo when constructing the cache key.
Currently it is assigning `config.regions` to `region`.
Changed to `config.region` instead.

Thanks 