### PR TITLE
support console login events

### DIFF
--- a/c7n/cwe.py
+++ b/c7n/cwe.py
@@ -31,6 +31,10 @@ class CloudWatchEvents(object):
     trail_events = {
         # event source, resource type as keys, mapping to api call and
         # jmespath expression
+        'ConsoleLogin': {
+            'ids': 'userIdentity.arn',
+            'source': 'signin.amazonaws.com'},
+
         'CreateAutoScalingGroup': {
             'ids': 'requestParameters.autoScalingGroupName',
             'source': 'autoscaling.amazonaws.com'},

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -817,6 +817,9 @@ class CloudWatchEventSource(object):
             payload['detail-type'] = ['AWS API Call via CloudTrail']
             self.resolve_cloudtrail_payload(payload)
 
+        if event_type == 'cloudtrail':
+            if 'signin.amazonaws.com' in payload['detail']['eventSource']:
+                payload['detail-type'] = ['AWS Console Sign In via CloudTrail']
         elif event_type == "ec2-instance-state":
             payload['source'] = ['aws.ec2']
             payload['detail-type'] = [


### PR DESCRIPTION
support for policies around console login events, supersedes #1371 

example policy 
```
policies:
 - name: root-login-detected
   resource: account
   description: |
     Notifies on root user logins
   mode:
      type: cloudtrail
      role: arn:aws:iam::619193117841:role/CustodianDemoRole
      events:
       - ConsoleLogin
   filters:
     - type: event
       key: "detail.userIdentity.type"
       value: Root
```

note for the root user the `account` resource is recommended as the root user doesn't have an iam resource representation. For normal iam users the recommend would be to use an `iam-user` resource for federated users, its probably best as a `iam-role` but requires long form definition to extract the role instead of the shortcut given here.