### PR TITLE
Chip away at py36 failures

### DIFF
--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -135,8 +135,8 @@ def _get_values(record, field_list, tag_map):
             value = jmespath.search(field, record)
             if value is None:
                 value = ''
-            if not isinstance(value, six.string_types):
-                value = unicode(value)
+            if not isinstance(value, six.text_type):
+                value = six.text_type(value)
         vals.append(value)
     return vals
 

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -516,7 +516,7 @@ class HealthFilter(HealthEventFilter):
                 resource_map[rid] = self.load_resource(rid)
             resource_map[rid].setdefault(
                 'c7n:HealthEvent', []).append(event_map[e['eventArn']])
-        return resource_map.values()
+        return list(resource_map.values())
 
     def load_resource(self, rid):
         config = local_session(self.manager.session_factory).client('config')

--- a/c7n/sqsexec.py
+++ b/c7n/sqsexec.py
@@ -113,12 +113,7 @@ class MessageIterator(object):
     def __iter__(self):
         return self
 
-    def ack(self, m):
-        self.client.delete_message(
-            QueueUrl=self.queue_url,
-            ReceiptHandle=m['ReceiptHandle'])
-
-    def next(self):
+    def __next__(self):
         if self.messages:
             return self.messages.pop(0)
         response = self.client.receive_message(
@@ -132,6 +127,13 @@ class MessageIterator(object):
         if self.messages:
             return self.messages.pop(0)
         raise StopIteration()
+
+    next = __next__  # back-compat
+
+    def ack(self, m):
+        self.client.delete_message(
+            QueueUrl=self.queue_url,
+            ReceiptHandle=m['ReceiptHandle'])
 
 
 class SQSWorker(object):

--- a/ratchet.txt
+++ b/ratchet.txt
@@ -1,5 +1,4 @@
 tests.test_actions.ActionTest.test_run_api
-tests.test_cli.ReportTest.test_report
 tests.test_ebs.HealthEventsFilterTest.test_ebs_health_events_filter
 tests.test_elb.SSLPolicyTest.test_set_ssl_listener_policy
 tests.test_mu.Constructor.test_class_constructor_only_accepts_py_modules_not_pyc

--- a/ratchet.txt
+++ b/ratchet.txt
@@ -26,7 +26,6 @@ tests.test_revisions.SGDiffLibTest.test_sg_patch_pitr
 tests.test_s3.BucketScanLogTests.test_scan_log
 tests.test_schema.SchemaTest.test_semantic_error
 tests.test_schema.SchemaTest.test_semantic_error_on_value_derived
-tests.test_sqsexec.TestSQSExec.test_sqsexec
 tests.test_utils.UtilTest.testCamelCase
 tests.test_utils.UtilTest.test_chunks
 tests.test_utils.UtilTest.test_load_file

--- a/ratchet.txt
+++ b/ratchet.txt
@@ -1,5 +1,4 @@
 tests.test_actions.ActionTest.test_run_api
-tests.test_ebs.HealthEventsFilterTest.test_ebs_health_events_filter
 tests.test_elb.SSLPolicyTest.test_set_ssl_listener_policy
 tests.test_mu.Constructor.test_class_constructor_only_accepts_py_modules_not_pyc
 tests.test_mu.PolicyLambdaProvision.test_config_coverage_for_lambda_creation

--- a/tests/test_sqsexec.py
+++ b/tests/test_sqsexec.py
@@ -41,13 +41,13 @@ class TestSQSExec(BaseTest):
         client = session_factory().client('sqs')
         map_queue = client.create_queue(
             QueueName = "%s-map-%s" % (
-                TEST_SQS_PREFIX, "".join(random.sample(string.letters, 3))))[
-                    'QueueUrl']
+                TEST_SQS_PREFIX, "".join(
+                    random.sample(string.ascii_letters, 3))))['QueueUrl']
         self.addCleanup(client.delete_queue, QueueUrl=map_queue)
         reduce_queue = client.create_queue(
             QueueName = "%s-map-%s" % (
-                TEST_SQS_PREFIX, "".join(random.sample(string.letters, 3))))[
-                    'QueueUrl']
+                TEST_SQS_PREFIX, "".join(
+                    random.sample(string.ascii_letters, 3))))['QueueUrl']
         self.addCleanup(client.delete_queue, QueueUrl=reduce_queue)
 
         with SQSExecutor(


### PR DESCRIPTION
Here's a few one-off fixes under #705. Takes us from 34 failures down to 31.

Includes #1388, rebase when that's in. [Clean compare](https://github.com/capitalone/cloud-custodian/compare/e512645708c90e0271b7670c033564200b0f72cf...5f63f390df791a937e51beaa01c9cf3df97a489b).