### PR TITLE
Limit set-instance-profile to operate on instances with valid states

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1058,14 +1058,14 @@ class AutorecoverAlarm(BaseAction, StateTransitionFilter):
 
 @actions.register('set-instance-profile')
 class SetInstanceProfile(BaseAction, StateTransitionFilter):
-    """Sets (or removes) the instance profile for an existing EC2 instance.
+    """Sets (or removes) the instance profile for a running EC2 instance.
 
     :Example:
 
     .. code-block: yaml
 
         policies:
-          - name:
+          - name: set-default-instance-profile
             resource: ec2
             query:
               - IamInstanceProfile: absent

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1057,7 +1057,7 @@ class AutorecoverAlarm(BaseAction, StateTransitionFilter):
 
 
 @actions.register('set-instance-profile')
-class SetInstanceProfile(BaseAction):
+class SetInstanceProfile(BaseAction, StateTransitionFilter):
     """Sets (or removes) the instance profile for an existing EC2 instance.
 
     :Example:
@@ -1086,7 +1086,12 @@ class SetInstanceProfile(BaseAction):
         'ec2:DisassociateIamInstanceProfile',
         'iam:PassRole')
 
+    valid_origin_states = ('running', 'pending')
+
     def process(self, instances):
+        instances = self.filter_instance_state(instances)
+        if not len(instances):
+            return
         client = utils.local_session(
             self.manager.session_factory).client('ec2')
         profile_name = self.data.get('name', '')


### PR DESCRIPTION
SetInstanceProfile raises an exception when operating on terminated instances. Filtering the instances for running and pending seemed like a reasonable solution.