### PR TITLE
Add external_id field to options to remediate script failure.

### DIFF
--- a/tools/ops/mugc.py
+++ b/tools/ops/mugc.py
@@ -126,6 +126,7 @@ def main():
     options = parser.parse_args()
     options.policy_filter = None
     options.log_group = None
+    options.external_id = None
     options.cache_period = 0
     options.cache = None
     log_level = logging.INFO


### PR DESCRIPTION
This change is to resolve a script failure resulting from a missing external_id field from options.