### PR TITLE
WIP - #1401 - Run a policy file stored in S3

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -112,7 +112,7 @@ def _load_vars(options):
     vars = None
     if options.vars:
         try:
-            vars = load_file(options.vars)
+            vars = load_file(options.vars, options)
         except IOError as e:
             log.error('Problem loading vars file "{}": {}'.format(options.vars, e.strerror))
             sys.exit(1)

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -47,12 +47,8 @@ log = logging.getLogger('c7n.policy')
 
 
 def load(options, path, format='yaml', validate=True, vars=None):
-    # should we do os.path.expanduser here?
-    if not os.path.exists(path):
-        raise IOError("Invalid path for config %r" % path)
-
     load_resources()
-    data = utils.load_file(path, format=format, vars=vars)
+    data = utils.load_file(path, options, format=format, vars=vars)
 
     if format == 'json':
         validate = False

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -18,9 +18,8 @@ import io
 import json
 import os.path
 from six.moves.urllib.request import urlopen
-from six.moves.urllib.parse import parse_qsl, urlparse
 
-import c7n.utils
+from c7n import utils
 
 import jmespath
 

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from botocore.exceptions import ClientError
 
+from c7n.resolver import URIResolver
+
 import boto3
 import copy
 from datetime import datetime
@@ -59,30 +61,34 @@ class Bag(dict):
             raise AttributeError(k)
 
 
-def load_file(path, format=None, vars=None):
+def load_file(path, options, format=None, vars=None):
     if format is None:
         format = 'yaml'
         _, ext = os.path.splitext(path)
         if ext[1:] == 'json':
             format = 'json'
 
-    with open(path) as fh:
-        contents = fh.read()
+    if path.startswith('s3://'):
+        session = get_profile_session(options)
+        contents = URIResolver(session, None).resolve(path)
+    else:
+        with open(path) as fh:
+            contents = fh.read()
 
-        if vars:
-            try:
-                contents = contents.format(**vars)
-            except IndexError as e:
-                msg = 'Failed to substitute variable by positional argument.'
-                raise VarsSubstitutionError(msg)
-            except KeyError as e:
-                msg = 'Failed to substitute variables.  KeyError on "{}"'.format(e.message)
-                raise VarsSubstitutionError(msg)
+    if vars:
+        try:
+            contents = contents.format(**vars)
+        except IndexError as e:
+            msg = 'Failed to substitute variable by positional argument.'
+            raise VarsSubstitutionError(msg)
+        except KeyError as e:
+            msg = 'Failed to substitute variables.  KeyError on "{}"'.format(e.message)
+            raise VarsSubstitutionError(msg)
 
-        if format == 'yaml':
-            return yaml_load(contents)
-        elif format == 'json':
-            return loads(contents)
+    if format == 'yaml':
+        return yaml_load(contents)
+    elif format == 'json':
+        return loads(contents)
 
 
 def yaml_load(value):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -25,7 +25,7 @@ import six
 
 from c7n import utils
 
-from .common import BaseTest
+from .common import BaseTest, Config
 
 
 class Backoff(BaseTest):
@@ -270,20 +270,22 @@ class UtilTest(unittest.TestCase):
         self.assertIsInstance(ret, six.text_type)
 
     def test_load_file(self):
+        config = Config.empty()
+
         # Basic load
         yml_file = os.path.join(os.path.dirname(__file__), 'data', 'vars-test.yml')
-        data = utils.load_file(yml_file)
+        data = utils.load_file(yml_file, config)
         self.assertTrue(len(data['policies']) == 1)
 
         # Load with vars
         resource = 'ec2'
-        data = utils.load_file(yml_file, vars={'resource': resource})
+        data = utils.load_file(yml_file, config, vars={'resource': resource})
         self.assertTrue(data['policies'][0]['resource'] == resource)
 
         # Fail to substitute
-        self.assertRaises(utils.VarsSubstitutionError, utils.load_file, yml_file, vars={'foo': 'bar'})
+        self.assertRaises(utils.VarsSubstitutionError, utils.load_file, yml_file, config, vars={'foo': 'bar'})
 
         # JSON load
         json_file = os.path.join(os.path.dirname(__file__), 'data', 'ec2-instance.json')
-        data = utils.load_file(json_file)
+        data = utils.load_file(json_file, config)
         self.assertTrue(data['InstanceId'] == 'i-1aebf7c0')


### PR DESCRIPTION
Issue #1401 

This allows you to run a policy file stored in S3, e.g.:

```
$ custodian run -s out s3://scot-test/ec2.yml
2017-07-16 09:52:34,069: custodian.policy:INFO policy: ec2-running-instances resource:ec2 region:us-east-1 count:2 time:1.44
```

@kapilt 

One thing I'm not sure about is how to construct a session when fetching the policy file from S3.  I'm currently using the `get_profile_session` function which takes the profile into account but not the region if someone passes `--region`.  It seems like we should consider the region, but then again, what happens if someone passes multiple regions?  How would we know which one to use to fetch the policy?  So I opted for just using the profile for now, but wanted to call this decision out if you have other thoughts.