### PR TITLE
Issues/1345 - EB/EFS on/offhours tagging workaround

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -77,9 +77,10 @@ per-resource basis. Note that the name of the tag is configurable via the
 
 The value of the tag must be one of the following:
 
-- **(empty)** - An empty tag value implies night and weekend offhours using
-  the default time zone configured in the policy (tz=est if unspecified) and the
-  default onhour and offhour values configured in the policy.
+- **(empty)** or **on** - An empty tag value or a value of "on" implies night
+  and weekend offhours using the default time zone configured in the policy
+  (tz=est if unspecified) and the default onhour and offhour values configured
+  in the policy.
 - **off** - If offhours is configured to run in opt-out mode, this tag can be
   specified to disable offhours on a given instance. If offhours is configured
   to run in opt-in mode, this tag will have no effect (the resource will still
@@ -185,6 +186,20 @@ done at all.
 As a result of this, if custodian stops an instance or suspends an ASG and you
 need to start/resume it, you can safely do so manually and custodian won't touch
 it again until the next day.
+
+ElasticBeanstalk, EFS and Other Services with Tag Value Restrictions
+====================================================================
+
+A number of AWS services have restrictions on the characters that can be used
+in tag values, such as `ElasticBeanstalk <http://docs.aws.amazon.com/elasticbean
+stalk/latest/dg/using-features.tagging.html>`_ and `EFS <http://docs.aws.amazon.
+com/efs/latest/ug/API_Tag.html>`_. In particular, these services do not allow
+parenthesis, square brackets, commas, or semicolons, or empty tag values. This
+proves to be problematic with the tag-based schedule configuration describe
+above. The best current workaround is to define a separate policy with a unique
+``tag`` name for each unique schedule that you want to use, and then tag
+resources with that tag name and a value of ``on``. Note that this can only be
+used in opt-in mode, not opt-out.
 
 """
 from __future__ import absolute_import, division, print_function, unicode_literals
@@ -346,20 +361,17 @@ class Time(Filter):
                 schedule = self.default_schedule
         else:
             schedule = None
-
         if schedule is None:
             log.warning(
                 "Invalid schedule on resource:%s value:%s", rid, value)
             self.parse_errors.append((rid, value))
             return False
-
         tz = self.get_tz(schedule['tz'])
         if not tz:
             log.warning(
                 "Could not resolve tz on resource:%s value:%s", rid, value)
             self.parse_errors.append((rid, value))
             return False
-
         now = datetime.datetime.now(tz).replace(
             minute=0, second=0, microsecond=0)
         return self.match(now, schedule)

--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -195,7 +195,7 @@ in tag values, such as `ElasticBeanstalk <http://docs.aws.amazon.com/elasticbean
 stalk/latest/dg/using-features.tagging.html>`_ and `EFS <http://docs.aws.amazon.
 com/efs/latest/ug/API_Tag.html>`_. In particular, these services do not allow
 parenthesis, square brackets, commas, or semicolons, or empty tag values. This
-proves to be problematic with the tag-based schedule configuration describe
+proves to be problematic with the tag-based schedule configuration described
 above. The best current workaround is to define a separate policy with a unique
 ``tag`` name for each unique schedule that you want to use, and then tag
 resources with that tag name and a value of ``on``. Note that this can only be

--- a/tests/test_offhours.py
+++ b/tests/test_offhours.py
@@ -141,18 +141,22 @@ class OffHoursFilterTest(BaseTest):
         # Given the addition of opt out behavior, verify if its
         # not configured that we don't touch an instance that
         # has no downtime tag
+        i = instance(Tags=[])
+
         t = datetime.datetime(
             year=2015, month=12, day=1, hour=19, minute=5,
             tzinfo=zoneinfo.gettz('America/New_York'))
-        i = instance(Tags=[])
         f = OffHour({})
 
         with mock_datetime_now(t, datetime):
             self.assertEqual(f(i), False)
-            t = datetime.datetime(
-                year=2015, month=12, day=1, hour=7, minute=5,
-                tzinfo=zoneinfo.gettz('America/New_York'))
-            f = OnHour({})
+
+        t = datetime.datetime(
+            year=2015, month=12, day=1, hour=7, minute=5,
+            tzinfo=zoneinfo.gettz('America/New_York'))
+        f = OnHour({})
+
+        with mock_datetime_now(t, datetime):
             self.assertEqual(f(i), False)
 
     def xtest_time_match_stops_after_skew(self):

--- a/tests/test_offhours.py
+++ b/tests/test_offhours.py
@@ -110,6 +110,8 @@ class OffHoursFilterTest(BaseTest):
         instances = [
             instance(Tags=[]),
             instance(
+                Tags=[{'Key': 'maid_offhours', 'Value': ''}]),
+            instance(
                 Tags=[{'Key': 'maid_offhours', 'Value': 'off'}]),
             instance(
                 Tags=[
@@ -119,7 +121,9 @@ class OffHoursFilterTest(BaseTest):
             year=2015, month=12, day=1, hour=19, minute=5,
             tzinfo=zoneinfo.gettz('America/New_York'))
         with mock_datetime_now(t, datetime):
-            self.assertEqual(f.process(instances), [instances[0]])
+            self.assertEqual(
+                f.process(instances), [instances[0], instances[1]]
+            )
 
     def test_opt_out_behavior(self):
         # Some users want to match based on policy filters to
@@ -133,6 +137,10 @@ class OffHoursFilterTest(BaseTest):
             i = instance(Tags=[])
             self.assertEqual(f(i), True)
             i = instance(
+                Tags=[{'Key': 'maid_offhours', 'Value': ''}]
+            )
+            self.assertEqual(f(i), True)
+            i = instance(
                 Tags=[{'Key': 'maid_offhours', 'Value': 'off'}])
             self.assertEqual(f(i), False)
             self.assertEqual(f.opted_out, [i])
@@ -142,6 +150,7 @@ class OffHoursFilterTest(BaseTest):
         # not configured that we don't touch an instance that
         # has no downtime tag
         i = instance(Tags=[])
+        i2 = instance(Tags=[{'Key': 'maid_offhours', 'Value': ''}])
 
         t = datetime.datetime(
             year=2015, month=12, day=1, hour=19, minute=5,
@@ -150,6 +159,7 @@ class OffHoursFilterTest(BaseTest):
 
         with mock_datetime_now(t, datetime):
             self.assertEqual(f(i), False)
+            self.assertEqual(f(i2), True)
 
         t = datetime.datetime(
             year=2015, month=12, day=1, hour=7, minute=5,
@@ -158,6 +168,7 @@ class OffHoursFilterTest(BaseTest):
 
         with mock_datetime_now(t, datetime):
             self.assertEqual(f(i), False)
+            self.assertEqual(f(i2), True)
 
     def xtest_time_match_stops_after_skew(self):
         hour = 7


### PR DESCRIPTION
This is a workaround for #1345, where we can't use on/offhours with resources in Elastic Beanstalk or in CF stacks that include EFS Volumes, as those services have tag value constraints that don't allow empty tag values, and don't allow many of the characters used in the tag-based scheduling.

* The on/offhours filter actually accepts any string that doesn't match as a schedule, as the default (i.e. ``on`` or ``foobar`` has the same operation as an empty tag value).
* Add tests to ensure that "on" operates identically to "" as a tag value.
* Document "on" as an alternative to the empty tag value.
* Add documentation of multi-policy workaround for EB apps and EFS