### PR TITLE
fixes #1414 - implement tagging actions and filters for RDSCluster

### DIFF
--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.AddTagsToResource_1.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.AddTagsToResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "66823bbd-6bd0-11e7-b392-6379faaa3b00", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "66823bbd-6bd0-11e7-b392-6379faaa3b00", 
+                "date": "Tue, 18 Jul 2017 15:47:27 GMT", 
+                "content-length": "213", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.DescribeDBClusters_1.json
@@ -1,0 +1,99 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBClusters": [
+            {
+                "MasterUsername": "c7ntest", 
+                "ReaderEndpoint": "c7ntest.cluster-ro-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "ReadReplicaIdentifiers": [], 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-8b788fe2"
+                    }
+                ], 
+                "HostedZoneId": "Z2XHWR1WZ565X2", 
+                "Status": "available", 
+                "MultiAZ": true, 
+                "LatestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 57, 
+                    "microsecond": 477000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 45
+                }, 
+                "PreferredBackupWindow": "09:10-09:40", 
+                "DBSubnetGroup": "default", 
+                "AllocatedStorage": 1, 
+                "BackupRetentionPeriod": 1, 
+                "PreferredMaintenanceWindow": "sat:03:02-sat:03:32", 
+                "Engine": "aurora", 
+                "Endpoint": "c7ntest.cluster-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "AssociatedRoles": [], 
+                "EarliestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 43, 
+                    "microsecond": 758000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 22
+                }, 
+                "IAMDatabaseAuthenticationEnabled": false, 
+                "ClusterCreateTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 44, 
+                    "microsecond": 906000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 21
+                }, 
+                "EngineVersion": "5.6.10a", 
+                "DBClusterIdentifier": "c7ntest", 
+                "DbClusterResourceId": "cluster-R5WF6NWSEGLSIKCJCXV65ANRUE", 
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest"
+                    }, 
+                    {
+                        "IsClusterWriter": false, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest-us-east-2b"
+                    }
+                ], 
+                "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:c7ntest", 
+                "StorageEncrypted": false, 
+                "DatabaseName": "c7ntest", 
+                "DBClusterParameterGroup": "default.aurora5.6", 
+                "AvailabilityZones": [
+                    "us-east-2a", 
+                    "us-east-2b", 
+                    "us-east-2c"
+                ], 
+                "Port": 3306
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "66326e36-6bd0-11e7-893b-ab96af5b89ad", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "66326e36-6bd0-11e7-893b-ab96af5b89ad", 
+                "vary": "Accept-Encoding", 
+                "content-length": "3030", 
+                "content-type": "text/xml", 
+                "date": "Tue, 18 Jul 2017 15:47:26 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.DescribeDBClusters_2.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.DescribeDBClusters_2.json
@@ -1,0 +1,99 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBClusters": [
+            {
+                "MasterUsername": "c7ntest", 
+                "ReaderEndpoint": "c7ntest.cluster-ro-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "ReadReplicaIdentifiers": [], 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-8b788fe2"
+                    }
+                ], 
+                "HostedZoneId": "Z2XHWR1WZ565X2", 
+                "Status": "available", 
+                "MultiAZ": true, 
+                "LatestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 57, 
+                    "microsecond": 477000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 45
+                }, 
+                "PreferredBackupWindow": "09:10-09:40", 
+                "DBSubnetGroup": "default", 
+                "AllocatedStorage": 1, 
+                "BackupRetentionPeriod": 1, 
+                "PreferredMaintenanceWindow": "sat:03:02-sat:03:32", 
+                "Engine": "aurora", 
+                "Endpoint": "c7ntest.cluster-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "AssociatedRoles": [], 
+                "EarliestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 43, 
+                    "microsecond": 758000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 22
+                }, 
+                "IAMDatabaseAuthenticationEnabled": false, 
+                "ClusterCreateTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 44, 
+                    "microsecond": 906000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 21
+                }, 
+                "EngineVersion": "5.6.10a", 
+                "DBClusterIdentifier": "c7ntest", 
+                "DbClusterResourceId": "cluster-R5WF6NWSEGLSIKCJCXV65ANRUE", 
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest"
+                    }, 
+                    {
+                        "IsClusterWriter": false, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest-us-east-2b"
+                    }
+                ], 
+                "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:c7ntest", 
+                "StorageEncrypted": false, 
+                "DatabaseName": "c7ntest", 
+                "DBClusterParameterGroup": "default.aurora5.6", 
+                "AvailabilityZones": [
+                    "us-east-2a", 
+                    "us-east-2b", 
+                    "us-east-2c"
+                ], 
+                "Port": 3306
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "66f12abc-6bd0-11e7-8ae2-6d1eefe234f2", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "66f12abc-6bd0-11e7-8ae2-6d1eefe234f2", 
+                "vary": "Accept-Encoding", 
+                "content-length": "3030", 
+                "content-type": "text/xml", 
+                "date": "Tue, 18 Jul 2017 15:47:28 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.DescribeDBClusters_3.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.DescribeDBClusters_3.json
@@ -1,0 +1,99 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBClusters": [
+            {
+                "MasterUsername": "c7ntest", 
+                "ReaderEndpoint": "c7ntest.cluster-ro-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "ReadReplicaIdentifiers": [], 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-8b788fe2"
+                    }
+                ], 
+                "HostedZoneId": "Z2XHWR1WZ565X2", 
+                "Status": "available", 
+                "MultiAZ": true, 
+                "LatestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 57, 
+                    "microsecond": 477000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 45
+                }, 
+                "PreferredBackupWindow": "09:10-09:40", 
+                "DBSubnetGroup": "default", 
+                "AllocatedStorage": 1, 
+                "BackupRetentionPeriod": 1, 
+                "PreferredMaintenanceWindow": "sat:03:02-sat:03:32", 
+                "Engine": "aurora", 
+                "Endpoint": "c7ntest.cluster-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "AssociatedRoles": [], 
+                "EarliestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 43, 
+                    "microsecond": 758000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 22
+                }, 
+                "IAMDatabaseAuthenticationEnabled": false, 
+                "ClusterCreateTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 44, 
+                    "microsecond": 906000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 21
+                }, 
+                "EngineVersion": "5.6.10a", 
+                "DBClusterIdentifier": "c7ntest", 
+                "DbClusterResourceId": "cluster-R5WF6NWSEGLSIKCJCXV65ANRUE", 
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest"
+                    }, 
+                    {
+                        "IsClusterWriter": false, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest-us-east-2b"
+                    }
+                ], 
+                "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:c7ntest", 
+                "StorageEncrypted": false, 
+                "DatabaseName": "c7ntest", 
+                "DBClusterParameterGroup": "default.aurora5.6", 
+                "AvailabilityZones": [
+                    "us-east-2a", 
+                    "us-east-2b", 
+                    "us-east-2c"
+                ], 
+                "Port": 3306
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6739570b-6bd0-11e7-a4f7-696ce6484d55", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6739570b-6bd0-11e7-a4f7-696ce6484d55", 
+                "vary": "Accept-Encoding", 
+                "content-length": "3030", 
+                "content-type": "text/xml", 
+                "date": "Tue, 18 Jul 2017 15:47:28 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "665b79d8-6bd0-11e7-b392-6379faaa3b00", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "665b79d8-6bd0-11e7-b392-6379faaa3b00", 
+                "date": "Tue, 18 Jul 2017 15:47:27 GMT", 
+                "content-length": "438", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Resource does not meet policy: delete@2017/07/19", 
+                "Key": "custodian_next"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "66cbc7cf-6bd0-11e7-8110-65c21ac11bf6", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "66cbc7cf-6bd0-11e7-8110-65c21ac11bf6", 
+                "date": "Tue, 18 Jul 2017 15:47:27 GMT", 
+                "content-length": "438", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Resource does not meet policy: delete@2017/07/19", 
+                "Key": "custodian_next"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_3.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_3.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "67126e28-6bd0-11e7-8bc1-657a32d20107", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "67126e28-6bd0-11e7-8bc1-657a32d20107", 
+                "date": "Tue, 18 Jul 2017 15:47:27 GMT", 
+                "content-length": "438", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Resource does not meet policy: delete@2017/07/19", 
+                "Key": "custodian_next"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_4.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_4.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "675e924e-6bd0-11e7-a4f7-696ce6484d55", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "675e924e-6bd0-11e7-a4f7-696ce6484d55", 
+                "date": "Tue, 18 Jul 2017 15:47:28 GMT", 
+                "content-length": "438", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Resource does not meet policy: delete@2017/07/19", 
+                "Key": "custodian_next"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_5.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.ListTagsForResource_5.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "678ea2af-6bd0-11e7-8110-65c21ac11bf6", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "678ea2af-6bd0-11e7-8110-65c21ac11bf6", 
+                "date": "Tue, 18 Jul 2017 15:47:29 GMT", 
+                "content-length": "293", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_rdscluster_mark_and_match/rds.RemoveTagsFromResource_1.json
+++ b/tests/data/placebo/test_rdscluster_mark_and_match/rds.RemoveTagsFromResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "678071da-6bd0-11e7-8110-65c21ac11bf6", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "678071da-6bd0-11e7-8110-65c21ac11bf6", 
+                "date": "Tue, 18 Jul 2017 15:47:29 GMT", 
+                "content-length": "223", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.AddTagsToResource_1.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.AddTagsToResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c483b414-6bce-11e7-a67b-b3f0325f1236", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c483b414-6bce-11e7-a67b-b3f0325f1236", 
+                "date": "Tue, 18 Jul 2017 15:35:45 GMT", 
+                "content-length": "213", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.DescribeDBClusters_1.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.DescribeDBClusters_1.json
@@ -1,0 +1,99 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBClusters": [
+            {
+                "MasterUsername": "c7ntest", 
+                "ReaderEndpoint": "c7ntest.cluster-ro-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "ReadReplicaIdentifiers": [], 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-8b788fe2"
+                    }
+                ], 
+                "HostedZoneId": "Z2XHWR1WZ565X2", 
+                "Status": "available", 
+                "MultiAZ": true, 
+                "LatestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 1, 
+                    "microsecond": 326000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 34
+                }, 
+                "PreferredBackupWindow": "09:10-09:40", 
+                "DBSubnetGroup": "default", 
+                "AllocatedStorage": 1, 
+                "BackupRetentionPeriod": 1, 
+                "PreferredMaintenanceWindow": "sat:03:02-sat:03:32", 
+                "Engine": "aurora", 
+                "Endpoint": "c7ntest.cluster-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "AssociatedRoles": [], 
+                "EarliestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 43, 
+                    "microsecond": 758000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 22
+                }, 
+                "IAMDatabaseAuthenticationEnabled": false, 
+                "ClusterCreateTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 44, 
+                    "microsecond": 906000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 21
+                }, 
+                "EngineVersion": "5.6.10a", 
+                "DBClusterIdentifier": "c7ntest", 
+                "DbClusterResourceId": "cluster-R5WF6NWSEGLSIKCJCXV65ANRUE", 
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest"
+                    }, 
+                    {
+                        "IsClusterWriter": false, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest-us-east-2b"
+                    }
+                ], 
+                "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:c7ntest", 
+                "StorageEncrypted": false, 
+                "DatabaseName": "c7ntest", 
+                "DBClusterParameterGroup": "default.aurora5.6", 
+                "AvailabilityZones": [
+                    "us-east-2a", 
+                    "us-east-2b", 
+                    "us-east-2c"
+                ], 
+                "Port": 3306
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c4351f43-6bce-11e7-893b-ab96af5b89ad", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c4351f43-6bce-11e7-893b-ab96af5b89ad", 
+                "vary": "Accept-Encoding", 
+                "content-length": "3030", 
+                "content-type": "text/xml", 
+                "date": "Tue, 18 Jul 2017 15:35:45 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.DescribeDBClusters_2.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.DescribeDBClusters_2.json
@@ -1,0 +1,99 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBClusters": [
+            {
+                "MasterUsername": "c7ntest", 
+                "ReaderEndpoint": "c7ntest.cluster-ro-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "ReadReplicaIdentifiers": [], 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-8b788fe2"
+                    }
+                ], 
+                "HostedZoneId": "Z2XHWR1WZ565X2", 
+                "Status": "available", 
+                "MultiAZ": true, 
+                "LatestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 1, 
+                    "microsecond": 326000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 34
+                }, 
+                "PreferredBackupWindow": "09:10-09:40", 
+                "DBSubnetGroup": "default", 
+                "AllocatedStorage": 1, 
+                "BackupRetentionPeriod": 1, 
+                "PreferredMaintenanceWindow": "sat:03:02-sat:03:32", 
+                "Engine": "aurora", 
+                "Endpoint": "c7ntest.cluster-c4afdoxtvswa.us-east-2.rds.amazonaws.com", 
+                "AssociatedRoles": [], 
+                "EarliestRestorableTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 43, 
+                    "microsecond": 758000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 22
+                }, 
+                "IAMDatabaseAuthenticationEnabled": false, 
+                "ClusterCreateTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 44, 
+                    "microsecond": 906000, 
+                    "year": 2017, 
+                    "day": 18, 
+                    "minute": 21
+                }, 
+                "EngineVersion": "5.6.10a", 
+                "DBClusterIdentifier": "c7ntest", 
+                "DbClusterResourceId": "cluster-R5WF6NWSEGLSIKCJCXV65ANRUE", 
+                "DBClusterMembers": [
+                    {
+                        "IsClusterWriter": true, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest"
+                    }, 
+                    {
+                        "IsClusterWriter": false, 
+                        "DBClusterParameterGroupStatus": "in-sync", 
+                        "PromotionTier": 1, 
+                        "DBInstanceIdentifier": "c7ntest-us-east-2b"
+                    }
+                ], 
+                "DBClusterArn": "arn:aws:rds:us-east-2:123456789012:cluster:c7ntest", 
+                "StorageEncrypted": false, 
+                "DatabaseName": "c7ntest", 
+                "DBClusterParameterGroup": "default.aurora5.6", 
+                "AvailabilityZones": [
+                    "us-east-2a", 
+                    "us-east-2b", 
+                    "us-east-2c"
+                ], 
+                "Port": 3306
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c4d2978e-6bce-11e7-8bc1-657a32d20107", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c4d2978e-6bce-11e7-8bc1-657a32d20107", 
+                "vary": "Accept-Encoding", 
+                "content-length": "3030", 
+                "content-type": "text/xml", 
+                "date": "Tue, 18 Jul 2017 15:35:46 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c45f14de-6bce-11e7-8110-65c21ac11bf6", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c45f14de-6bce-11e7-8110-65c21ac11bf6", 
+                "date": "Tue, 18 Jul 2017 15:35:45 GMT", 
+                "content-length": "293", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_2.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c4abfc7b-6bce-11e7-b392-6379faaa3b00", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c4abfc7b-6bce-11e7-b392-6379faaa3b00", 
+                "date": "Tue, 18 Jul 2017 15:35:45 GMT", 
+                "content-length": "390", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "hello world", 
+                "Key": "xyz"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_3.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_3.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c4f42912-6bce-11e7-b392-6379faaa3b00", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c4f42912-6bce-11e7-b392-6379faaa3b00", 
+                "date": "Tue, 18 Jul 2017 15:35:46 GMT", 
+                "content-length": "390", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "hello world", 
+                "Key": "xyz"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_4.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.ListTagsForResource_4.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c5254b38-6bce-11e7-b392-6379faaa3b00", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c5254b38-6bce-11e7-b392-6379faaa3b00", 
+                "date": "Tue, 18 Jul 2017 15:35:46 GMT", 
+                "content-length": "293", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_rdscluster_tag_and_remove/rds.RemoveTagsFromResource_1.json
+++ b/tests/data/placebo/test_rdscluster_tag_and_remove/rds.RemoveTagsFromResource_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c51a9ca9-6bce-11e7-a4f7-696ce6484d55", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "c51a9ca9-6bce-11e7-a4f7-696ce6484d55", 
+                "date": "Tue, 18 Jul 2017 15:35:47 GMT", 
+                "content-length": "223", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}


### PR DESCRIPTION
This implements tagging for RDSCluster

* Actions:
  * mark/tag
  * unmark/remove-tag
  * mark-for-op
* Filters:
  * marked-for-op
  * tag-count

The implementation is virtually identical to the RDS (Instance) resource, as the RDS API makes use of common ``add_tags_to_resource`` / ``list_tags_for_resource`` / ``remove_tags_from_resource`` methods that just take an ARN.