### PR TITLE
Catch yaml loading errors and improve the error message (#1110)

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -45,6 +45,8 @@ else:
         except ImportError:
             SafeLoader = None
 
+log = logging.getLogger('custodian.utils')
+
 
 class VarsSubstitutionError(Exception):
     pass
@@ -80,7 +82,12 @@ def load_file(path, format=None, vars=None):
                 raise VarsSubstitutionError(msg)
 
         if format == 'yaml':
-            return yaml_load(contents)
+            try:
+                return yaml_load(contents)
+            except yaml.YAMLError as e:
+                log.error('Error while loading yaml file %s', path)
+                log.error('Skipping this file.  Error message below:\n%s', e)
+                return None
         elif format == 'json':
             return loads(contents)
 


### PR DESCRIPTION
@kapilt - In #1110 you mentioned a library called [yamllint](https://github.com/adrienverge/yamllint)  I tried that, but it doesn't have a programmatic API to lint a file, just a cli entry point.

I took an easier approach to this and I just catch yaml loading problems and print the error message rather than dumping a huge - and largely irrelevant - stack trace.

Note that this changes the behavior when a bad yaml file is encountered.  Instead of the program crashing it will continue on to any remaining files if any are present.  If that is not the desired behavior we can change it back to error out if a bad yaml file is encountered.

Here is example output for running with a tab character in the yaml file:

```
$ custodian run -s out policies/bad.yml 
2017-07-18 22:22:35,844: custodian.utils:ERROR Error while loading yaml file policies/bad.yml
2017-07-18 22:22:35,844: custodian.utils:ERROR Skipping this file.  Error message below:
while scanning for the next token
found character '\t' that cannot start any token
  in "<string>", line 9, column 1:
        - InstanceId: i-06ab6561012345678
    ^
2017-07-18 22:22:35,911: custodian.commands:WARNING Empty policy file(s).  Nothing to do.
```