### PR TITLE
service-limit in regions other than us-east-1

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -385,8 +385,14 @@ class ServiceLimit(Filter):
                 filters:
                   - type: service-limit
                     services:
-                      - IAM
+                      - EC2
                     threshold: 1.0
+              - name: specify-region-for-global-service
+                resource: account
+                filters:
+                  - type: service-limit
+                    services:
+                      - IAM
     """
 
     schema = type_schema(

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -408,7 +408,11 @@ class ServiceLimit(Filter):
         checks = client.describe_trusted_advisor_check_result(
             checkId=self.check_id, language='en')['result']
 
+        region = self.manager.config.region
+        checks['flaggedResources'] = [r for r in checks['flaggedResources']
+            if r['metadata'][0] == region]
         resources[0]['c7n:ServiceLimits'] = checks
+
         delta = timedelta(self.data.get('refresh_period', 1))
         check_date = parse_date(checks['timestamp'])
         if datetime.now(tz=tzutc()) - delta > check_date:

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -388,6 +388,7 @@ class ServiceLimit(Filter):
                       - EC2
                     threshold: 1.0
               - name: specify-region-for-global-service
+                region: us-east-1
                 resource: account
                 filters:
                   - type: service-limit

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -403,7 +403,8 @@ class ServiceLimit(Filter):
     check_limit = ('region', 'service', 'check', 'limit', 'extant', 'color')
 
     def process(self, resources, event=None):
-        client = local_session(self.manager.session_factory).client('support')
+        client = local_session(self.manager.session_factory).client(
+            'support', region_name='us-east-1')
         checks = client.describe_trusted_advisor_check_result(
             checkId=self.check_id, language='en')['result']
 
@@ -488,7 +489,7 @@ class RequestLimitIncrease(BaseAction):
 
     def process(self, resources):
         session = local_session(self.manager.session_factory)
-        client = session.client('support')
+        client = session.client('support', region_name='us-east-1')
 
         services_done = set()
         for resource in resources[0].get('c7n:ServiceLimitsExceeded', []):

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -410,7 +410,7 @@ class ServiceLimit(Filter):
 
         region = self.manager.config.region
         checks['flaggedResources'] = [r for r in checks['flaggedResources']
-            if r['metadata'][0] == region]
+            if r['metadata'][0] == region or (r['metadata'][0] == '-' and region == 'us-east-1')]
         resources[0]['c7n:ServiceLimits'] = checks
 
         delta = timedelta(self.data.get('refresh_period', 1))

--- a/docs/source/usecases/accountservicelimit.rst
+++ b/docs/source/usecases/accountservicelimit.rst
@@ -1,0 +1,43 @@
+.. _accountservicelimit:
+
+Account - Service Limit
+=======================
+
+The following example policy will find any service in your region that is using 
+more than 50% of the limit and raise the limit for 25%.
+
+.. code-block:: yaml
+
+   policies:
+     - name: account-service-limits
+       resource: account
+       filters:
+         - type: service-limit
+           threshold: 50
+       actions:
+         - type: request-limit-increase
+           percent-increase: 25
+
+Noted that the ``thresold`` in ``service-limit`` filter is an optional field. If
+not mentioned on the policy, the default value is 80.
+
+
+Global Services
+  Services like IAM are not region-based. Custodian will put the limit 
+  information only in ``us-east-1``. When running the policy above in multiple 
+  regions, the limit of global services will ONLY be raised in us-east-1.
+
+  Additionally, if you want to target any the global services on the policy, you
+  will need to target the region as us-east-1 on the policy. Here is an example.
+
+  .. code-block:: yaml
+
+     policies:
+       - name: account-service-limits
+         resource: account
+         region: us-east-1
+         filters:
+           - type: service-limit
+             services:
+               - IAM
+             threshold: 50

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -198,8 +198,9 @@ class AccountTests(BaseTest):
         p = self.load_policy({
             'name': 'service-limit',
             'resource': 'account',
+            'region': 'us-east-1',
             'filters': [{
-                'type': 'service-limit', 'services': ['EC2'], 'threshold': 0
+                'type': 'service-limit', 'services': ['IAM'], 'threshold': 1.0
             }]},
             session_factory=session_factory)
         resources = p.run()
@@ -207,8 +208,8 @@ class AccountTests(BaseTest):
         self.assertEqual(
             set([l['service'] for l
                  in resources[0]['c7n:ServiceLimitsExceeded']]),
-            set(['EC2']))
-        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 1)
+            set(['IAM']))
+        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 2)
 
     def test_service_limit_global_service(self):
         policy = {

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from .common import BaseTest
 from c7n.utils import local_session
+from c7n.filters import FilterValidationError
 
 
 TRAIL = 'nosetest'
@@ -163,7 +164,7 @@ class AccountTests(BaseTest):
                 'threshold': 0}]}, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 50)
+        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 10)
 
     def test_service_limit_specific_check(self):
         session_factory = self.replay_flight_data('test_account_service_limit')
@@ -185,12 +186,12 @@ class AccountTests(BaseTest):
         self.assertEqual(
             set([l['region'] for l
                  in resources[0]['c7n:ServiceLimitsExceeded']]),
-            set(['us-east-1', 'us-west-2', 'us-west-1']))
+            set(['us-east-1']))
         self.assertEqual(
             set([l['check'] for l
                  in resources[0]['c7n:ServiceLimitsExceeded']]),
             set(['DB security groups']))
-        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 3)
+        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 1)
 
     def test_service_limit_specific_service(self):
         session_factory = self.replay_flight_data('test_account_service_limit')
@@ -198,7 +199,7 @@ class AccountTests(BaseTest):
             'name': 'service-limit',
             'resource': 'account',
             'filters': [{
-                'type': 'service-limit', 'services': ['IAM'], 'threshold': 1.0
+                'type': 'service-limit', 'services': ['EC2'], 'threshold': 0
             }]},
             session_factory=session_factory)
         resources = p.run()
@@ -206,8 +207,17 @@ class AccountTests(BaseTest):
         self.assertEqual(
             set([l['service'] for l
                  in resources[0]['c7n:ServiceLimitsExceeded']]),
-            set(['IAM']))
-        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 2)
+            set(['EC2']))
+        self.assertEqual(len(resources[0]['c7n:ServiceLimitsExceeded']), 1)
+
+    def test_service_limit_global_service(self):
+        policy = {
+            'name': 'service-limit',
+            'resource': 'account',
+            'filters': [{
+                'type': 'service-limit', 'services': ['IAM']
+            }]}
+        self.assertRaises(FilterValidationError, self.load_policy, policy)
 
     def test_service_limit_no_threshold(self):
         # only warns when the default threshold goes to warning or above


### PR DESCRIPTION
Fixes for #1403 

- [x] Separate the ServiceLimits information by region with a caveat of global services get an explicit validation error message and must be targeted in us-east-1 (via region: us-east-1 on the policy)
- [x] Update test cases
- [x] raise the limit written up as a use case example for the docs