### PR TITLE
Fix Kinesis mailer template to display StreamName and change filter_type to list for Kinesis resource

### DIFF
--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -30,7 +30,7 @@ class KinesisStream(QueryResourceManager):
             'describe_stream', 'StreamName', None, 'StreamDescription')
         name = id = 'StreamName'
         filter_name = None
-        filter_type = 'list' 
+        filter_type = 'list'
         date = None
         dimension = 'StreamName'
 

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -29,7 +29,7 @@ class KinesisStream(QueryResourceManager):
         detail_spec = (
             'describe_stream', 'StreamName', None, 'StreamDescription')
         name = id = 'StreamName'
-        filter_name = None
+        filter_name = 'StreamNames' 
         filter_type = 'list'
         date = None
         dimension = 'StreamName'

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -29,7 +29,7 @@ class KinesisStream(QueryResourceManager):
         detail_spec = (
             'describe_stream', 'StreamName', None, 'StreamDescription')
         name = id = 'StreamName'
-        filter_name = 'StreamNames' 
+        filter_name = 'StreamNames'
         filter_type = 'list'
         date = None
         dimension = 'StreamName'

--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -30,7 +30,7 @@ class KinesisStream(QueryResourceManager):
             'describe_stream', 'StreamName', None, 'StreamDescription')
         name = id = 'StreamName'
         filter_name = None
-        filter_type = None
+        filter_type = 'list' 
         date = None
         dimension = 'StreamName'
 

--- a/tools/c7n_mailer/msg-templates/default.html.j2
+++ b/tools/c7n_mailer/msg-templates/default.html.j2
@@ -200,7 +200,7 @@ Additional parameters can be passed in from the policy - i.e. action_desc, viola
 			{{ createTable(columnNames, resources, '50') }}					
 
 		{% elif policy['resource'] == "kinesis" %}
-			{% set columnNames = ['KinesisName'] %}
+			{% set columnNames = ['StreamName'] %}
 			{{ createTable(columnNames, resources, '50') }}						
 
 		{% elif policy['resource'] == "launch-config" %}


### PR DESCRIPTION
* The default template outputs the entire kinesis resource json object rather than the StreamName, fixed to display just the StreamName

* Fixed the `filter_type` to be `'list'`. According to [Kinesis boto3 docs](http://boto3.readthedocs.io/en/latest/reference/services/kinesis.html#Kinesis.Client.list_streams) `StreamNames` is a list of strings, not dicts.
