### PR TITLE
Fixed the snapshot example as it was erroring out

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -886,10 +886,8 @@ class Snapshot(BaseAction):
         policies:
           - name: ec2-snapshots
             resource: ec2
-            filters:
-              - type: ebs
           actions:
-            - snapshot
+            - type: snapshot
               copy-tags:
                 - Name
     """


### PR DESCRIPTION
The example for snapshots in ec2.py was erroring out with the following error:
```
yaml.scanner.ScannerError: mapping values are not allowed here
  in "<string>", line 8, column 15:
         copy-tags:
```
once I changed - snapshot to - type: snapshot the policy no longer errored out but it returns no results until I removed the filters: statement.  Now it works