### PR TITLE
Fixes a bug generating a report for account resource

### DIFF
--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -157,7 +157,7 @@ class Formatter(object):
             mfields = [model.id]
             if model.name != model.id:
                 mfields.append(model.name)
-            if model.date:
+            if getattr(model, 'date', None):
                 mfields.append(model.date)
 
         if include_default_fields:


### PR DESCRIPTION
#1441 

The account resource does not have a `date` attribute on its model.  The report code assumes this will always exist, and crashes when trying to generate a report.