### PR TITLE
log error if the policy file extension is wrong

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -162,6 +162,8 @@ def validate(options):
                 data = yaml.safe_load(fh.read())
             if format in ('json',):
                 data = json.load(fh)
+            else:
+                log.error("The config file must end in .json, .yml or .yaml")
 
         errors += schema.validate(data, schm)
         conf_policy_names = {p['name'] for p in data.get('policies', ())}

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -163,7 +163,8 @@ def validate(options):
             if format in ('json',):
                 data = json.load(fh)
             else:
-                log.error("The config file must end in .json, .yml or .yaml")
+                log.error("The config file must end in .json, .yml or .yaml.")
+                raise ValueError("The config file must end in .json, .yml or .yaml.")
 
         errors += schema.validate(data, schm)
         conf_policy_names = {p['name'] for p in data.get('policies', ())}

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -160,7 +160,7 @@ def validate(options):
         with open(config_file) as fh:
             if format in ('yml', 'yaml'):
                 data = yaml.safe_load(fh.read())
-            if format in ('json',):
+            elif format in ('json',):
                 data = json.load(fh)
             else:
                 log.error("The config file must end in .json, .yml or .yaml.")

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -119,7 +119,7 @@ class ValidateTest(CliTest):
         json_file = self.write_policy_file(invalid_policies, format='json')
 
         # YAML validation
-        self.run_and_expect_failure(['custodian', 'validate', yaml_file], 1)
+        self.run_and_expect_exception(['custodian', 'validate', yaml_file], SystemExit)
 
         # JSON validation
         self.run_and_expect_failure(['custodian', 'validate', json_file], 1)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -33,7 +33,7 @@ class CommandsValidateTest(BaseTest):
             subparser='validate',
             verbose=False
         )
-        with self.assertRaises(SystemExit) as exit:
+        with self.assertRaises((SystemExit, ValueError)) as exit:
             validate_yaml_policies(yaml_validate_options)
         # if there is a bad policy in the batch being validated, there should be an exit 1
         self.assertEqual(exit.exception.code, 1)


### PR DESCRIPTION
This will log an error if the policy extension is wrong. Currently if the policy file ends in something other than yaml, yml, or json it will produce the confusing error below:

```
Traceback (most recent call last):
  File "/usr/local/bin/custodian", line 11, in <module>
    load_entry_point('c7n', 'console_scripts', 'custodian')()
  File "/src/c7n/cli.py", line 400, in main
    command(options)
  File "/src/c7n/commands.py", line 167, in validate
    errors += schema.validate(data, schm)
UnboundLocalError: local variable 'data' referenced before assignment
```