### PR TITLE
py3 compat bug - fix format:text resolver

### DIFF
--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -141,4 +141,4 @@ class ValuesFrom(object):
                 return jmespath.search(self.data['expr'], data)
             return data
         elif format == 'txt':
-            return [s.strip() for s in io.StringIO(contents).readlines()]
+            return [s.strip() for s in io.BytesIO(contents).readlines()]

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -141,4 +141,5 @@ class ValuesFrom(object):
                 return jmespath.search(self.data['expr'], data)
             return data
         elif format == 'txt':
-            return [s.strip() for s in io.BytesIO(contents).readlines()]
+            return [s.strip().decode('utf8')
+                    for s in io.BytesIO(contents).readlines()]

--- a/tests/test_resolver.py
+++ b/tests/test_resolver.py
@@ -100,9 +100,9 @@ class UrlValueTest(BaseTest):
         self.assertRaises(ValueError, values.get_values)
 
     def test_txt(self):
-        out = io.StringIO()
+        out = io.BytesIO()
         for i in ['a', 'b', 'c', 'd']:
-            out.write('%s\n' % i)
+            out.write(('%s\n' % i).encode('utf8'))
         values = self.get_values_from({'url': 'letters.txt'}, out.getvalue())
         self.assertEqual(
             values.get_values(),


### PR DESCRIPTION
work on py3 compat caused a regression for py2 compatibility when using resolver with format text