### PR TITLE
py3 compatiblity bug fix - iam credential report filter

### DIFF
--- a/.lgtm
+++ b/.lgtm
@@ -1,2 +1,0 @@
-approvals = 1
-

--- a/MAINTAINERS
+++ b/MAINTAINERS
@@ -1,2 +1,0 @@
-kapilt
-ewbankkit

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -561,7 +561,10 @@ class CredentialReport(Filter):
             return report
         data = self.fetch_credential_report()
         report = {}
-        reader = csv.reader(io.StringIO(data))
+        if isinstance(data, six.binary_type):
+            reader = csv.reader(io.BytesIO(data))
+        else:
+            reader = csv.reader(io.StringIO(data))
         headers = next(reader)
         for line in reader:
             info = dict(zip(headers, line))

--- a/c7n/version.py
+++ b/c7n/version.py
@@ -12,4 +12,4 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-version = u"0.8.24.4"
+version = u"0.8.24.5"

--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ def read(fname):
 
 setup(
     name="c7n",
-    version='0.8.24.4',
+    version='0.8.24.5',
     description="Cloud Custodian - Policy Rules Engine",
     long_description=read('README.rst'),
     classifiers=[


### PR DESCRIPTION
py3 compat work caused a regression in credential report, it looks like unit tests always return unicode data . closes #1427