### PR TITLE
Updating mailer resource_format for log-group

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -196,9 +196,11 @@ def resource_format(resource, resource_type):
             len(resource.get('IpPermissions', ())),
             len(resource.get('IpPermissionsEgress', ())))
     elif resource_type == 'log-group':
-        return "name: %s last_write: %s" % (
-            resource['logGroupName'],
-            resource['lastWrite'])
+        if 'lastWrite' in resource:
+            return "name: %s last_write: %s" % (
+                resource['logGroupName'],
+                resource['lastWrite'])
+        return "name: %s" % (resource['logGroupName'])
     elif resource_type == 'cache-cluster':
         return "name: %s created: %s status: %s" % (
             resource['CacheClusterId'],


### PR DESCRIPTION
We have a cloud custodian policy that referencing the 'log-group' resource that doesn't specify a 'last-write' filter. Therefore the 'response' input to the ```resource_format``` function doesn't include a "lastWrite"  key and the mailer will fail with a KeyError. This fix will allow sending with just the logGroupName if lastWrite isn't provided.