### PR TITLE
remove filter_name and filter_type from kinesis resource as per #1398

### DIFF
--- a/c7n/resources/kinesis.py
+++ b/c7n/resources/kinesis.py
@@ -29,8 +29,8 @@ class KinesisStream(QueryResourceManager):
         detail_spec = (
             'describe_stream', 'StreamName', None, 'StreamDescription')
         name = id = 'StreamName'
-        filter_name = 'StreamNames'
-        filter_type = 'list'
+        filter_name = None
+        filter_type = None
         date = None
         dimension = 'StreamName'
 


### PR DESCRIPTION
Regarding #1398:

Kinesis resources are listed using the [`list_streams`](http://boto3.readthedocs.io/en/latest/reference/services/kinesis.html#Kinesis.Client.list_streams) command which returns a list of `StreamNames` as strings, not dicts. This is similar to the DynamoDB [`list_tables`](http://boto3.readthedocs.io/en/latest/reference/services/dynamodb.html#DynamoDB.Client.list_tables)

`list_streams` response:
```
{
    'StreamNames': [
        'string',
    ],
    'HasMoreStreams': True|False
}
```

`list_tables` response:

```
{
    'TableNames': [
        'string',
    ],
    'LastEvaluatedTableName': 'string'
}
```

`query.py`:
```python
            # This logic was added to prevent the issue from:
            # https://github.com/capitalone/cloud-custodian/issues/1398
            if all(map(lambda r: isinstance(r, six.string_types), resources)):
                resources = [r for r in resources if r in identities]
            else:
                resources = [r for r in resources if r[m.id] in identities]

```