### PR TITLE
Adding Region field to the request limit increase

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -500,7 +500,7 @@ class RequestLimitIncrease(BaseAction):
     permissions = ('support:CreateCase',)
 
     default_subject = 'Raise the account limit of {service} - {limits} in {region}'
-    default_template = 'Please raise the account limit of {service} - {limits} by {percent}%'
+    default_template = 'Please raise the account limit of {service} - {limits} by {percent}% in {region}'
     default_severity = 'normal'
 
     service_code_mapping = {

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -537,7 +537,8 @@ class RequestLimitIncrease(BaseAction):
             body = body.format(**{
                 'service': service,
                 'limits': limits,
-                'percent': self.data.get('percent-increase')
+                'percent': self.data.get('percent-increase'),
+                'region': region
             })
 
             client.create_case(

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -500,7 +500,7 @@ class RequestLimitIncrease(BaseAction):
     permissions = ('support:CreateCase',)
 
     default_subject = 'Raise the account limit of {service} - {limits} in {region}'
-    default_template = 'Please raise the account limit of {service} - {limits} by {percent}% in {region}'
+    default_template = 'Please raise the limit of {service} - {limits} by {percent}% in {region}'
     default_severity = 'normal'
 
     service_code_mapping = {


### PR DESCRIPTION
I have added a region field to the body of the request limit increase email and the default_template variable as many AWS technicians miss the region in the subject and then reply to my auto-generated cases asking me to confirm what region to increase the limit in.  Adding it to the case body will make this a lot clearer and prevent users from having to manually respond to AWS to complete the limit increases.