### PR TITLE
Unused access keys bug 842

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -21,7 +21,6 @@ import itertools
 import time
 
 from concurrent.futures import as_completed
-from dateutil.parser import parse
 from dateutil.tz import tzutc
 import six
 from botocore.exceptions import ClientError

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -854,7 +854,6 @@ class UserRemoveAccessKey(BaseAction):
 
         if age:
             threshold_date = datetime.datetime.now(tz=tzutc()) - timedelta(age)
-
         for r in resources:
             if 'AccessKeys' not in r:
                 r['AccessKeys'] = client.list_access_keys(
@@ -862,7 +861,7 @@ class UserRemoveAccessKey(BaseAction):
             keys = r['AccessKeys']
             for k in keys:
                 if age:
-                    if not parse(k['CreateDate']) < threshold_date:
+                    if not k['CreateDate'] < threshold_date:
                         continue
                 if disable:
                     client.update_access_key(

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -854,6 +854,7 @@ class UserRemoveAccessKey(BaseAction):
 
         if age:
             threshold_date = datetime.datetime.now(tz=tzutc()) - timedelta(age)
+
         for r in resources:
             if 'AccessKeys' not in r:
                 r['AccessKeys'] = client.list_access_keys(


### PR DESCRIPTION
parse is not needed as k['CreateDate'] is already a datetime object.

Adjusting the policy in https://github.com/capitalone/cloud-custodian/issues/842 and setting the `action` phase to the following solves this issue.

```
    actions:
      - type: remove-keys
        disable: true
        age: 90
```

