### PR TITLE
Add tenancy filter

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1166,6 +1166,7 @@ EC2_VALID_FILTERS = {
     'tag-key': str,
     'tag-value': str,
     'tag:': str,
+    'tenancy': ('dedicated', 'default', 'host'),
     'vpc-id': str}
 
 

--- a/docs/source/policy/resources/ec2.rst
+++ b/docs/source/policy/resources/ec2.rst
@@ -30,6 +30,7 @@ Query
        'tag-key': str,
        'tag-value': str,
        'tag:': str,
+       'tenancy': ('dedicated', 'default', 'host'),
        'vpc-id': str}
 
 Filters


### PR DESCRIPTION
Resolves #1508 

Adds support for tenancy filter per [docs](http://awsdocs.s3.amazonaws.com/EC2/ec2-clt.pdf) Page 378:

```
tenancy
The tenancy of an instance.
Type: String
Valid values: dedicated | default | host
```