### PR TITLE
Mailer replay fix - fixes #1514

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/replay.py
+++ b/tools/c7n_mailer/c7n_mailer/replay.py
@@ -55,7 +55,7 @@ class MailerTester(object):
             mime = emd.get_mimetext_message(
                 self.data, self.data['resources'], ['foo@example.com']
             )
-            print('Send mail with subject: "%s"' % mime['Subject'])
+            logger.info('Send mail with subject: "%s"', mime['Subject'])
             print(mime.get_payload())
             return
         if dry_run:

--- a/tools/c7n_mailer/c7n_mailer/replay.py
+++ b/tools/c7n_mailer/c7n_mailer/replay.py
@@ -50,7 +50,7 @@ class MailerTester(object):
         self.session = boto3.Session()
 
     def run(self, dry_run=False, print_only=False):
-        emd = EmailDelivery(self.config, self.session, None)
+        emd = EmailDelivery(self.config, self.session, logger)
         addrs_to_msgs = emd.get_to_addrs_email_messages_map(self.data)
         logger.info('Would send email to: %s', addrs_to_msgs.keys())
         if print_only:


### PR DESCRIPTION
The code that I submitted in #1514 is actually broken after the refactor in #1201. This fixes ``c7n-mailer-replay`` to actually work. It also adds the ability to dump the plain-text JSON from a base64-encoded, gzipped SQS message.