### PR TITLE
Add nat-gateway resource

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1337,6 +1337,33 @@ class InternetGateway(QueryResourceManager):
         id_prefix = "igw-"
 
 
+@resources.register('nat-gateway')
+class NATGateway(QueryResourceManager):
+
+    class resource_type(object):
+        service = 'ec2'
+        type = 'nat-gateway'
+        enum_spec = ('describe_nat_gateways', 'NatGateways', None)
+        name = id = 'NatGatewayId'
+        filter_name = 'NatGatewayIds'
+        filter_type = 'list'
+        dimension = None
+        date = 'CreateTime'
+        id_prefix = "nat-"
+
+
+@NATGateway.action_registry.register('delete')
+class DeleteNATGateway(BaseAction):
+
+    schema = type_schema('delete')
+    permissions = ('ec2:DeleteNatGateway',)
+
+    def process(self, resources):
+        client = local_session(self.manager.session_factory).client('ec2')
+        for r in resources:
+            client.delete_nat_gateway(NatGatewayId=r['NatGatewayId'])
+
+
 @resources.register('vpn-connection')
 class VPNConnection(QueryResourceManager):
 

--- a/tests/data/placebo/test_nat_gateways_delete/ec2.DeleteNatGateway_1.json
+++ b/tests/data/placebo/test_nat_gateways_delete/ec2.DeleteNatGateway_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d82a95ea-9221-4aea-8504-55251dca8d5b", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Fri, 08 Sep 2017 20:01:46 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_nat_gateways_delete/ec2.DescribeNatGateways_1.json
+++ b/tests/data/placebo/test_nat_gateways_delete/ec2.DescribeNatGateways_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "20eb721b-845d-40ce-8d67-2a1f72e780e8",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Fri, 08 Sep 2017 19:31:28 GMT"
+            }
+        },
+        "NatGateways": [
+            {
+                "NatGatewayAddresses": [
+                    {
+                        "PublicIp": "1.1.1.1",
+                        "NetworkInterfaceId": "eni-0000000",
+                        "AllocationId": "eipalloc-0000000",
+                        "PrivateIp": "1.1.1.1"
+                    }
+                ],
+                "VpcId": "vpc-0000000",
+                "Tags": [{"Key": "Name", "Value": "c7n_test"}],
+                "State": "available",
+                "NatGatewayId": "nat-0000000000000000",
+                "SubnetId": "subnet-0000000",
+                "CreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 9,
+                    "second": 16,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 8,
+                    "minute": 21
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_nat_gateways_query/ec2.DescribeNatGateways_1.json
+++ b/tests/data/placebo/test_nat_gateways_query/ec2.DescribeNatGateways_1.json
@@ -1,0 +1,43 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "20eb721b-845d-40ce-8d67-2a1f72e780e8",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Fri, 08 Sep 2017 19:31:28 GMT"
+            }
+        },
+        "NatGateways": [
+            {
+                "NatGatewayAddresses": [
+                    {
+                        "PublicIp": "1.1.1.1",
+                        "NetworkInterfaceId": "eni-0000000",
+                        "AllocationId": "eipalloc-0000000",
+                        "PrivateIp": "1.1.1.1"
+                    }
+                ],
+                "VpcId": "vpc-0000000",
+                "State": "available",
+                "NatGatewayId": "nat-0000000000000000",
+                "SubnetId": "subnet-0000000",
+                "CreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 9,
+                    "second": 16,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 8,
+                    "minute": 21
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_nat_gateways_tag/ec2.CreateTags_1.json
+++ b/tests/data/placebo/test_nat_gateways_tag/ec2.CreateTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d82a95ea-9221-4aea-8504-55251dca8d5b", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Fri, 08 Sep 2017 20:01:46 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_nat_gateways_tag/ec2.DescribeNatGateways_1.json
+++ b/tests/data/placebo/test_nat_gateways_tag/ec2.DescribeNatGateways_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "20eb721b-845d-40ce-8d67-2a1f72e780e8",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Fri, 08 Sep 2017 19:31:28 GMT"
+            }
+        },
+        "NatGateways": [
+            {
+                "NatGatewayAddresses": [
+                    {
+                        "PublicIp": "1.1.1.1",
+                        "NetworkInterfaceId": "eni-0000000",
+                        "AllocationId": "eipalloc-0000000",
+                        "PrivateIp": "1.1.1.1"
+                    }
+                ],
+                "VpcId": "vpc-0000000",
+                "Tags": [{"Key": "Name", "Value": "c7n_test"}],
+                "State": "available",
+                "NatGatewayId": "nat-0000000000000000",
+                "SubnetId": "subnet-0000000",
+                "CreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 9,
+                    "second": 16,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 8,
+                    "minute": 21
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_nat_gateways_tag/ec2.DescribeNatGateways_2.json
+++ b/tests/data/placebo/test_nat_gateways_tag/ec2.DescribeNatGateways_2.json
@@ -1,0 +1,53 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "624ace98-b441-4ae0-85cc-c08948efe009",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Fri, 08 Sep 2017 20:02:19 GMT"
+            }
+        },
+        "NatGateways": [
+            {
+                "NatGatewayAddresses": [
+                    {
+                        "PublicIp": "1.1.1.1",
+                        "NetworkInterfaceId": "eni-0000000",
+                        "AllocationId": "eipalloc-0000000",
+                        "PrivateIp": "1.1.1.1"
+                    }
+                ],
+                "VpcId": "vpc-0000000",
+                "Tags": [
+                    {
+                        "Value": "c7n_test",
+                        "Key": "Name"
+                    },
+                    {
+                        "Value": "hello world",
+                        "Key": "xyz"
+                    }
+                ],
+                "State": "available",
+                "NatGatewayId": "nat-0000000000000000",
+                "SubnetId": "subnet-0000000",
+                "CreateTime": {
+                    "hour": 19,
+                    "__class__": "datetime",
+                    "month": 9,
+                    "second": 16,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 8,
+                    "minute": 21
+                }
+            }
+        ]
+    }
+}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1163,3 +1163,53 @@ class SecurityGroupTest(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]['Tags'][0]['Value'], 'FancyTestVPC')
+
+
+class NATGatewayTest(BaseTest):
+
+    def test_query_nat_gateways(self):
+        factory = self.replay_flight_data('test_nat_gateways_query')
+        p = self.load_policy({
+            'name': 'get-nat-gateways',
+            'resource': 'nat-gateway',
+        }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['State'],
+            "available")
+
+    def test_tag_nat_gateways(self):
+        factory = self.replay_flight_data('test_nat_gateways_tag')
+        p = self.load_policy({
+            'name': 'tag-nat-gateways',
+            'resource': 'nat-gateway',
+            'filters': [
+                {'tag:Name': 'c7n_test'}],
+            'actions': [
+                {'type': 'tag', 'key': 'xyz', 'value': 'hello world'}],
+        }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        p = self.load_policy({
+            'name': 'get-nat-gateways',
+            'resource': 'nat-gateway',
+            'filters': [
+                {'tag:xyz': 'hello world'}],
+        }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_delete_nat_gateways(self):
+        factory = self.replay_flight_data('test_nat_gateways_delete')
+        p = self.load_policy({
+            'name': 'delete-nat-gateways',
+            'resource': 'nat-gateway',
+            'filters': [
+                {'tag:Name': 'c7n_test'}],
+            'actions': [
+                {'type': 'delete'}],
+        }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
Now that AWS has [added support](http://docs.aws.amazon.com/AmazonVPC/latest/UserGuide/vpc-nat-gateway.html#nat-gateway-tagging) for NAT gateway tagging, add a `nat-gateway` resource to Custodian.