### PR TITLE
Fixed FlowLogs example

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -82,7 +82,7 @@ class FlowLogFilter(Filter):
                       op: equal
                       # equality operator applies to following keys
                       traffic-type: all
-                      status: success
+                      status: active
                       log-group: vpc-logs
 
     """


### PR DESCRIPTION
FlowLogs example was looking for status of success but the status for FlowLogs is actually 'active' not 'success'  Tested this policy and verified the change fixes the example