### PR TITLE
s3 encryption_statement NotResource

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -746,8 +746,10 @@ class EncryptionEnabledFilter(Filter):
                 encryption_statement["Sid"] = s["Sid"]
             except:
                 log.info("Bucket:%s doesn't have Sid" % b['Name'])
-
-            encryption_statement["Resource"] = s["Resource"]
+            try:
+                encryption_statement["Resource"] = s["Resource"]
+            except:
+                log.info("Bucket:%s doesn't have Resource" % b['Name'])
             if s == encryption_statement:
                 log.info(
                     "Bucket:%s contains correct encryption policy", b['Name'])


### PR DESCRIPTION
Currently, if an s3 bucket policy statement has the "NotResource" key instead of the "Resource" key, the s3 filter on bucket policies will fail. This change will catch the error when the "Resource" key does not exist