### PR TITLE
Updated core.py to include a intersection OP

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -63,6 +63,9 @@ def operator_in(x, y):
 def operator_ni(x, y):
     return x not in y
 
+## intersect function will allow the comparison of 2 lists
+def intersect(x, y):
+    return bool(set(x).intersection(y))
 
 OPERATORS = {
     'eq': operator.eq,
@@ -82,7 +85,8 @@ OPERATORS = {
     'in': operator_in,
     'ni': operator_ni,
     'not-in': operator_ni,
-    'contains': operator.contains}
+    'contains': operator.contains,
+    'intersect': intersect}
 
 
 class FilterRegistry(PluginRegistry):

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -69,7 +69,7 @@ def intersect(x, y):
     return bool(set(x).intersection(y))
 
 
-    """Filter RDS based on subnet group. Uses op: intersect option to compare
+    """Filter RDS based on subnet group. Uses op intersect option to compare
     the databases Subnet-Group list against a user provided list.
 
     :example:

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -64,47 +64,8 @@ def operator_ni(x, y):
     return x not in y
 
 
-# intersect function will allow the comparison of 2 lists
 def intersect(x, y):
     return bool(set(x).intersection(y))
-
-    """Filter RDS based on subnet group. Uses op intersect option to compare
-    the databases Subnet-Group list against a user provided list.
-
-    :example:
-        .. code-block: yaml
-
-            policies:
-              - name: find-rds-on-public-subnets-using-s3-list
-                description: |
-                   This policy will compare rds instances subnet group list
-                   against a user provided list of public subnets from a s3 txt file.
-                comment:  |
-                   The txt file needs to be in utf-8 no BOM format and contain one
-                   subnet per line in the file no quotes around the subnets either.
-                resource: rds
-                filters:
-                    - type: value
-                      key: "DBSubnetGroup.Subnets[].SubnetIdentifier"
-                      op: intersect
-                value_from:
-                    url: s3://cloud-custodian-bucket/PublicSubnets.txt
-                    format: txt
-
-             - name: find-rds-on-public-subnets-using-inline-list
-               description: |
-                  This policy will compare rds instances subnet group list against a
-                  inline user provided list of public subnets.
-               resource: rds
-               filters:
-                   - type: value
-                     key: "DBSubnetGroup.Subnets[].SubnetIdentifier"
-                     op: intersect
-                     value:
-                         - subnet-2a8374658
-                         - subnet-1b8474522
-                         - subnet-2d2736444
-    """
 
 
 OPERATORS = {

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -69,6 +69,45 @@ def intersect(x, y):
     return bool(set(x).intersection(y))
 
 
+    """Filter RDS based on subnet group comparisons using 2 lists.
+    
+    :example:
+        .. code-block: yaml
+            policies:
+              - name: find-rds-on-public-subnets-using-s3-list
+                description: |
+                   This policy will compare rds instances subnet group list against a list
+                   of public subnets from a s3 txt file.
+                comment:  |
+                   The txt file needs to be in utf-8 no BOM format and contain one subnet per line in the file
+                   no quotes around the subnets either.
+                resource: rds
+                filters:
+                    - type: value
+                      key: "DBSubnetGroup.Subnets[].SubnetIdentifier"
+                      op: intersect
+                value_from:
+                    url: s3://cloud-custodian-bucket/PublicSubnets.txt
+                    format: txt
+
+
+             - name: find-rds-on-public-subnets-using-inline-list
+               description: |
+                  This policy will compare rds instances subnet group list against a
+                  inline list of public subnets.
+               resource: rds
+               filters:
+                   - type: value
+                     key: "DBSubnetGroup.Subnets[].SubnetIdentifier"
+                     op: intersect
+                     value: 
+                         - subnet-2a8374658
+                         - subnet-1b8474522
+                         - subnet-2d2736444
+
+    """
+
+    
 OPERATORS = {
     'eq': operator.eq,
     'equal': operator.eq,

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -68,7 +68,6 @@ def operator_ni(x, y):
 def intersect(x, y):
     return bool(set(x).intersection(y))
 
-
     """Filter RDS based on subnet group. Uses op intersect option to compare
     the databases Subnet-Group list against a user provided list.
 

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -69,18 +69,19 @@ def intersect(x, y):
     return bool(set(x).intersection(y))
 
 
-    """Filter RDS based on subnet group.  Uses op: intersect option to compare
+    """Filter RDS based on subnet group. Uses op: intersect option to compare
     the databases Subnet-Group list against a user provided list.
-    
+
     :example:
         .. code-block: yaml
+
             policies:
               - name: find-rds-on-public-subnets-using-s3-list
                 description: |
                    This policy will compare rds instances subnet group list
                    against a user provided list of public subnets from a s3 txt file.
                 comment:  |
-                   The txt file needs to be in utf-8 no BOM format and contain one 
+                   The txt file needs to be in utf-8 no BOM format and contain one
                    subnet per line in the file no quotes around the subnets either.
                 resource: rds
                 filters:
@@ -100,13 +101,13 @@ def intersect(x, y):
                    - type: value
                      key: "DBSubnetGroup.Subnets[].SubnetIdentifier"
                      op: intersect
-                     value: 
+                     value:
                          - subnet-2a8374658
                          - subnet-1b8474522
                          - subnet-2d2736444
     """
 
-    
+
 OPERATORS = {
     'eq': operator.eq,
     'equal': operator.eq,

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -69,8 +69,7 @@ def intersect(x, y):
     return bool(set(x).intersection(y))
 
 
-    """Filter RDS based on subnet group.  Uses op: intersect option to compare
-       the databases Subnet-Group list against a user provided list.
+    """Filter RDS based on subnet group.  Uses op: intersect option to compare the databases Subnet-Group list against a user provided list.
     
     :example:
         .. code-block: yaml
@@ -80,8 +79,8 @@ def intersect(x, y):
                    This policy will compare rds instances subnet group list
                    against a user provided list of public subnets from a s3 txt file.
                 comment:  |
-                   The txt file needs to be in utf-8 no BOM format and contain one subnet per line in the file
-                   no quotes around the subnets either.
+                   The txt file needs to be in utf-8 no BOM format and contain one 
+                   subnet per line in the file no quotes around the subnets either.
                 resource: rds
                 filters:
                     - type: value
@@ -90,7 +89,6 @@ def intersect(x, y):
                 value_from:
                     url: s3://cloud-custodian-bucket/PublicSubnets.txt
                     format: txt
-
 
              - name: find-rds-on-public-subnets-using-inline-list
                description: |
@@ -105,7 +103,6 @@ def intersect(x, y):
                          - subnet-2a8374658
                          - subnet-1b8474522
                          - subnet-2d2736444
-
     """
 
     

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -63,9 +63,11 @@ def operator_in(x, y):
 def operator_ni(x, y):
     return x not in y
 
-## intersect function will allow the comparison of 2 lists
+
+# intersect function will allow the comparison of 2 lists
 def intersect(x, y):
     return bool(set(x).intersection(y))
+
 
 OPERATORS = {
     'eq': operator.eq,

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -69,15 +69,16 @@ def intersect(x, y):
     return bool(set(x).intersection(y))
 
 
-    """Filter RDS based on subnet group comparisons using 2 lists.
+    """Filter RDS based on subnet group.  Uses op: intersect option to compare
+       the databases Subnet-Group list against a user provided list.
     
     :example:
         .. code-block: yaml
             policies:
               - name: find-rds-on-public-subnets-using-s3-list
                 description: |
-                   This policy will compare rds instances subnet group list against a list
-                   of public subnets from a s3 txt file.
+                   This policy will compare rds instances subnet group list
+                   against a user provided list of public subnets from a s3 txt file.
                 comment:  |
                    The txt file needs to be in utf-8 no BOM format and contain one subnet per line in the file
                    no quotes around the subnets either.
@@ -94,7 +95,7 @@ def intersect(x, y):
              - name: find-rds-on-public-subnets-using-inline-list
                description: |
                   This policy will compare rds instances subnet group list against a
-                  inline list of public subnets.
+                  inline user provided list of public subnets.
                resource: rds
                filters:
                    - type: value

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -69,7 +69,8 @@ def intersect(x, y):
     return bool(set(x).intersection(y))
 
 
-    """Filter RDS based on subnet group.  Uses op: intersect option to compare the databases Subnet-Group list against a user provided list.
+    """Filter RDS based on subnet group.  Uses op: intersect option to compare
+    the databases Subnet-Group list against a user provided list.
     
     :example:
         .. code-block: yaml


### PR DESCRIPTION
The intersection Operation I added will allow for comparison operations against 2 lists.
Examples:
```
policies:

- name: find-rds-on-public-subnets-using-s3-list
  description: |
    This policy will compare rds instances subnet group list against a list
    of public subnets from a s3 txt file.
  comment:  |
    The txt file needs to be in utf-8 no BOM format and contain one subnet per line in the file
    no quotes around the subnets either.
  resource: rds
  filters:
    - type: value
      key: "DBSubnetGroup.Subnets[].SubnetIdentifier"
      op: intersect
      value_from:
         url: s3://cloud-custodian-bucket/PublicSubnets.txt
         format: txt


- name: find-rds-on-public-subnets-using-inline-list
  description: |
    This policy will compare rds instances subnet group list against a
    inline list of public subnets.
  resource: rds
  filters:
    - type: value
      key: "DBSubnetGroup.Subnets[].SubnetIdentifier"
      op: intersect
      value: 
          - subnet-2a8374658
          - subnet-1b8474522
          - subnet-2d2736444

```