### PR TITLE
Add S3 delete-bucket-notification action

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -54,6 +54,7 @@ from botocore.client import Config
 from botocore.exceptions import ClientError
 from botocore.vendored.requests.exceptions import SSLError
 
+from collections import defaultdict
 from concurrent.futures import as_completed
 from dateutil.parser import parse as parse_date
 
@@ -669,6 +670,19 @@ class BucketActionBase(BaseAction):
     def get_permissions(self):
         return self.permissions
 
+    def process(self, buckets):
+        with self.executor_factory(max_workers=3) as w:
+            futures = {}
+            results = []
+            for b in buckets:
+                futures[w.submit(self.process_bucket, b)] = b
+            for f in as_completed(futures):
+                if f.exception():
+                    self.log.error('error modifying bucket:%s\n%s',
+                                   b['Name'], f.exception())
+                results += filter(None, [f.result()])
+            return results
+
 
 @filters.register('has-statement')
 class HasStatementFilter(Filter):
@@ -802,6 +816,98 @@ class MissingPolicyStatementFilter(Filter):
         if not required:
             return False
         return True
+
+
+@filters.register('bucket-notification')
+class BucketNotificationFilter(ValueFilter):
+    """Filter based on bucket notification configuration.
+
+    :example:
+
+        .. code-block: yaml
+
+            policies:
+              - name: delete-incorrect-notification
+                resource: s3
+                filters:
+                  - type: bucket-notification
+                    kind: lambda
+                    key: Id
+                    value: "IncorrectLambda"
+                    op: eq
+                actions:
+                  - type: delete-bucket-notification
+                    statement_ids: matched
+    """
+
+    schema = type_schema(
+        'bucket-notification',
+        required=['kind'],
+        kind={'type': 'string', 'enum': ['lambda', 'sns', 'sqs']},
+        rinherit=ValueFilter.schema)
+
+    annotation_key = 'c7n:MatchedNotificationConfigurationIds'
+
+    permissions = ('s3:GetBucketNotification',)
+
+    FIELDS = {
+        'lambda': 'LambdaFunctionConfigurations',
+        'sns': 'TopicConfigurations',
+        'sqs': 'QueueConfigurations'
+    }
+
+    def process(self, buckets, event=None):
+        return super(BucketNotificationFilter, self).process(buckets, event)
+
+    def __call__(self, bucket):
+
+        field = self.FIELDS[self.data['kind']]
+        found = False
+        for config in bucket.get('Notification', {}).get(field, []):
+            if self.match(config):
+                set_annotation(
+                    bucket,
+                    BucketNotificationFilter.annotation_key,
+                    config['Id'])
+                found = True
+        return found
+
+
+@actions.register('delete-bucket-notification')
+class DeleteBucketNotification(BucketActionBase):
+    """Action to delete S3 bucket notification configurations"""
+
+    schema = type_schema(
+        'delete-bucket-notification',
+        required=['statement_ids'],
+        statement_ids={'oneOf': [
+            {'enum': ['matched']},
+            {'type': 'array', 'items': {'type': 'string'}}]})
+
+    permissions = ('s3:PutBucketNotification',)
+
+    def process_bucket(self, bucket):
+        n = bucket['Notification']
+        if not n:
+            return
+
+        statement_ids = self.data.get('statement_ids')
+        if statement_ids == 'matched':
+            statement_ids = bucket.get(BucketNotificationFilter.annotation_key, ())
+        if not statement_ids:
+            return
+
+        cfg = defaultdict(list)
+
+        for t in six.itervalues(BucketNotificationFilter.FIELDS):
+            for c in n.get(t, []):
+                if c['Id'] not in statement_ids:
+                    cfg[t].append(c)
+
+        client = bucket_client(local_session(self.manager.session_factory), bucket)
+        client.put_bucket_notification_configuration(
+            Bucket=bucket['Name'],
+            NotificationConfiguration=cfg)
 
 
 @actions.register('no-op')

--- a/tests/data/placebo/test_s3_delete_bucket_notification/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/s3.CreateBucket_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/c7n-delete-bucket-notification-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "XZ1DulqMqgEXE9MWBD0RyA5oLFW6aJxT1cXbFQMgu262+KJH6P9aSA1IuuO38fbGZf9SiAkgbEA=", 
+            "RequestId": "1F262BF47CDF2872", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "XZ1DulqMqgEXE9MWBD0RyA5oLFW6aJxT1cXbFQMgu262+KJH6P9aSA1IuuO38fbGZf9SiAkgbEA=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "1F262BF47CDF2872", 
+                "location": "/c7n-delete-bucket-notification-test", 
+                "date": "Fri, 15 Sep 2017 19:55:12 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "l9MKaftCjZgH1yL7bifKHF/TwkA1G0oI5+6R1iDSRUeKvu404AWYgvLXbPzC/kAqnDb/aydNHZo=", 
+            "RequestId": "1693D8A89E6938F6", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "l9MKaftCjZgH1yL7bifKHF/TwkA1G0oI5+6R1iDSRUeKvu404AWYgvLXbPzC/kAqnDb/aydNHZo=", 
+                "date": "Fri, 15 Sep 2017 19:55:13 GMT", 
+                "x-amz-request-id": "1693D8A89E6938F6", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/s3.GetBucketNotificationConfiguration_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/s3.GetBucketNotificationConfiguration_1.json
@@ -1,0 +1,34 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "+Ya03jbhZuD7BzOUyya0hK/VQwjNrrt7IL4pDhBKNS0iQRYZNdSKxB+3HfCIsvcuwuWz/Xjpono=", 
+            "RequestId": "22AB8864FA9C4D43", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "+Ya03jbhZuD7BzOUyya0hK/VQwjNrrt7IL4pDhBKNS0iQRYZNdSKxB+3HfCIsvcuwuWz/Xjpono=", 
+                "date": "Fri, 15 Sep 2017 19:55:13 GMT", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "22AB8864FA9C4D43", 
+                "server": "AmazonS3"
+            }
+        }, 
+        "TopicConfigurations": [
+            {
+                "Id": "c7n-notify-1", 
+                "TopicArn": "arn:aws:sns:us-east-1:644160558196:bucket-notification-test", 
+                "Events": [
+                    "s3:ObjectCreated:*"
+                ]
+            }, 
+            {
+                "Id": "another1", 
+                "TopicArn": "arn:aws:sns:us-east-1:644160558196:bucket-notification-test", 
+                "Events": [
+                    "s3:ObjectRemoved:*"
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/s3.GetBucketNotificationConfiguration_2.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/s3.GetBucketNotificationConfiguration_2.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RetryAttempts": 0,
+            "HostId": "+Ya03jbhZuD7BzOUyya0hK/VQwjNrrt7IL4pDhBKNS0iQRYZNdSKxB+3HfCIsvcuwuWz/Xjpono=",
+            "RequestId": "22AB8864FA9C4D43",
+            "HTTPHeaders": {
+                "x-amz-id-2": "+Ya03jbhZuD7BzOUyya0hK/VQwjNrrt7IL4pDhBKNS0iQRYZNdSKxB+3HfCIsvcuwuWz/Xjpono=",
+                "date": "Fri, 15 Sep 2017 19:55:13 GMT",
+                "transfer-encoding": "chunked",
+                "x-amz-request-id": "22AB8864FA9C4D43",
+                "server": "AmazonS3"
+            }
+        },
+        "TopicConfigurations": [
+            {
+                "Id": "another1",
+                "TopicArn": "arn:aws:sns:us-east-1:644160558196:bucket-notification-test",
+                "Events": [
+                    "s3:ObjectRemoved:*"
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/s3.ListBuckets_1.json
@@ -1,0 +1,64 @@
+{
+    "status_code": 200,
+    "data": {
+        "Owner": {
+            "DisplayName": "xxx",
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        },
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 2,
+                    "__class__": "datetime",
+                    "month": 9,
+                    "second": 40,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 15,
+                    "minute": 5
+                },
+                "Name": "custodian-delete-bucket-notification-test"
+            },
+            {
+                "CreationDate": {
+                    "hour": 20,
+                    "__class__": "datetime",
+                    "month": 9,
+                    "second": 52,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 15,
+                    "minute": 2
+                },
+                "Name": "cskunk-empty"
+            },
+            {
+                "CreationDate": {
+                    "hour": 13,
+                    "__class__": "datetime",
+                    "month": 9,
+                    "second": 42,
+                    "microsecond": 0,
+                    "year": 2017,
+                    "day": 14,
+                    "minute": 54
+                },
+                "Name": "kit-test-bucket"
+            }
+        ],
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RetryAttempts": 0,
+            "HostId": "7woS1c/cLRL1AA048ZfaGd3GiizHzA4U94DcorNeE/r51WamQY7BM74NLSkuJKZLinXrwp6jX+w=",
+            "RequestId": "BEFE67EDC12B3F74",
+            "HTTPHeaders": {
+                "x-amz-id-2": "7woS1c/cLRL1AA048ZfaGd3GiizHzA4U94DcorNeE/r51WamQY7BM74NLSkuJKZLinXrwp6jX+w=",
+                "server": "AmazonS3",
+                "transfer-encoding": "chunked",
+                "x-amz-request-id": "BEFE67EDC12B3F74",
+                "date": "Fri, 15 Sep 2017 20:11:08 GMT",
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/s3.ListObjects_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/s3.ListObjects_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200,
+    "data": {
+        "MaxKeys": 1000,
+        "Prefix": "",
+        "Name": "c7n-delete-bucket-notification-test",
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "RetryAttempts": 0,
+            "HostId": "J63DJ0U9QJjYTxqZ6014OJdOLaNMb7hLJKueDJKX5mbUGGMyGXkx9p5xRJgrA9VH",
+            "RequestId": "86F7B21E3B1EAE5B",
+            "HTTPHeaders": {
+                "x-amz-bucket-region": "us-east-1",
+                "x-amz-id-2": "J63DJ0U9QJjYTxqZ6014OJdOLaNMb7hLJKueDJKX5mbUGGMyGXkx9p5xRJgrA9VH",
+                "server": "AmazonS3",
+                "transfer-encoding": "chunked",
+                "x-amz-request-id": "86F7B21E3B1EAE5B",
+                "date": "Fri, 15 Sep 2017 20:06:08 GMT",
+                "content-type": "application/xml"
+            }
+        },
+        "Marker": "",
+        "EncodingType": "url",
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/s3.PutBucketNotificationConfiguration_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/s3.PutBucketNotificationConfiguration_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "Im6setL8JoDZgjlJrse6AQuZnyemaJxcRAOIcrR5VUKBuqAUiO9kCXUE1svyvvItLshGmoIZzDo=", 
+            "RequestId": "BE5D36F168F09F1B", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "Im6setL8JoDZgjlJrse6AQuZnyemaJxcRAOIcrR5VUKBuqAUiO9kCXUE1svyvvItLshGmoIZzDo=", 
+                "date": "Fri, 15 Sep 2017 19:55:13 GMT", 
+                "content-length": "0", 
+                "x-amz-request-id": "BE5D36F168F09F1B", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/sns.CreateTopic_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/sns.CreateTopic_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "76271bc4-e3d5-5734-86d1-49f2d18a5d20", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "76271bc4-e3d5-5734-86d1-49f2d18a5d20", 
+                "date": "Fri, 15 Sep 2017 19:55:11 GMT", 
+                "content-length": "331", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TopicArn": "arn:aws:sns:us-east-1:644160558196:bucket-notification-test"
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/sns.DeleteTopic_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/sns.DeleteTopic_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "834ca799-4014-5b32-8c71-f5af7274882e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "834ca799-4014-5b32-8c71-f5af7274882e", 
+                "date": "Fri, 15 Sep 2017 19:55:12 GMT", 
+                "content-length": "201", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_delete_bucket_notification/sns.SetTopicAttributes_1.json
+++ b/tests/data/placebo/test_s3_delete_bucket_notification/sns.SetTopicAttributes_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ceca4009-a4e7-5003-9f7a-123f9687b8b6", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ceca4009-a4e7-5003-9f7a-123f9687b8b6", 
+                "date": "Fri, 15 Sep 2017 19:55:12 GMT", 
+                "content-length": "215", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/capitalone/cloud-custodian/issues/1548.
Adds:
* `delete-bucket-notification` action on the `s3` resource
* `bucket-notification` filter on the `s3` resource