### PR TITLE
S3 encrypt fix - kms sufficient 

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -341,8 +341,9 @@ class PullMode(PolicyExecutionMode):
                     " execution_time: %0.2f" % (
                         self.policy.name, a.name,
                         len(resources), time.time() - s))
-                self.policy._write_file(
-                    "action-%s" % a.name, utils.dumps(results))
+                if results:
+                    self.policy._write_file(
+                        "action-%s" % a.name, utils.dumps(results))
             self.policy.ctx.metrics.put_metric(
                 "ActionTime", time.time() - at, "Seconds", Scope="Policy")
             return resources

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1496,7 +1496,9 @@ class EncryptExtantKeys(ScanBucket):
 
         # If the data is already encrypted with KMS and the same key is provided
         # then we don't need to do anything
-        if info.get('ServerSideEncryption') == 'aws:kms' and self.kms_id:
+        if info.get('ServerSideEncryption') == 'aws:kms':
+            if not self.kms_id:
+                return False
             # Test using `in` because SSEKMSKeyId is the full ARN
             if self.kms_id in info.get('SSEKMSKeyId', ''):
                 return False

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1494,12 +1494,12 @@ class EncryptExtantKeys(ScanBucket):
         if info.get('ServerSideEncryption') == 'AES256' and not self.kms_id:
             return False
 
-        # If the data is already encrypted with KMS and the same key is provided
-        # then we don't need to do anything
         if info.get('ServerSideEncryption') == 'aws:kms':
+            # If we're not looking for a specific key any key will do.
             if not self.kms_id:
                 return False
-            # Test using `in` because SSEKMSKeyId is the full ARN
+            # If we're configured to use a specific key and the key matches
+            # note this is not a strict equality match.
             if self.kms_id in info.get('SSEKMSKeyId', ''):
                 return False
 

--- a/tests/data/placebo/test_account_raise_service_limit_percent/support.RefreshTrustedAdvisorCheck_1.json
+++ b/tests/data/placebo/test_account_raise_service_limit_percent/support.RefreshTrustedAdvisorCheck_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200, 
+    "data": {
+        "status": {
+            "checkId": "eW7HH0l7J9", 
+            "status": "enqueued", 
+            "millisUntilNextRefreshable": 3599992
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cf3750f7-2118-11e7-9938-f15d99801c37", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cf3750f7-2118-11e7-9938-f15d99801c37", 
+                "date": "Fri, 14 Apr 2017 13:46:48 GMT", 
+                "content-length": "92", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/kms.ListAliases_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/kms.ListAliases_1.json
@@ -1,0 +1,125 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Truncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "a308c514-9de2-11e7-9598-f132b9810559", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "a308c514-9de2-11e7-9598-f132b9810559", 
+                "content-length": "3191", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "date": "Wed, 20 Sep 2017 09:03:58 GMT", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "Aliases": [
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/BlockStorageKey", 
+                "AliasName": "alias/BlockStorageKey", 
+                "TargetKeyId": "82645407-2faa-4d93-be71-7d6a8d59a5fc"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/CalTestS3", 
+                "AliasName": "alias/CalTestS3", 
+                "TargetKeyId": "662c9918-50cb-4644-bf82-e34fd4ae710c"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/CalTestS3-new", 
+                "AliasName": "alias/CalTestS3-new", 
+                "TargetKeyId": "cdd2c7da-f5f8-4aff-9542-241ac8e4d621"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/albtestkey", 
+                "AliasName": "alias/albtestkey", 
+                "TargetKeyId": "53947b7f-905f-45e8-947b-c1cb1b32a283"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/acm", 
+                "AliasName": "alias/aws/acm", 
+                "TargetKeyId": "7efe5f36-5599-4a81-97b9-4c4aa4b64f93"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/codecommit", 
+                "AliasName": "alias/aws/codecommit", 
+                "TargetKeyId": "aaac6583-1d5f-44a2-b535-0823b47ed00e"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/ebs", 
+                "AliasName": "alias/aws/ebs", 
+                "TargetKeyId": "798bc4bb-3079-4a9a-bc27-2c7f2b6c91d0"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/elasticfilesystem", 
+                "AliasName": "alias/aws/elasticfilesystem", 
+                "TargetKeyId": "d38e6df4-3a19-4516-9f4b-ab568e9bccc5"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/kinesis", 
+                "AliasName": "alias/aws/kinesis", 
+                "TargetKeyId": "f0108d2e-e1df-4a94-b1b6-9144085093cb"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/lambda", 
+                "AliasName": "alias/aws/lambda", 
+                "TargetKeyId": "f4441361-1c8d-4710-8d6d-0b6d7cd0be11"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/lightsail", 
+                "AliasName": "alias/aws/lightsail", 
+                "TargetKeyId": "7147f795-71ee-4b59-8dd1-2fa32a55423c"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/rds", 
+                "AliasName": "alias/aws/rds", 
+                "TargetKeyId": "b10f842a-feb7-4318-92d5-0640a75b7688"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/redshift", 
+                "AliasName": "alias/aws/redshift", 
+                "TargetKeyId": "e39ed135-2a46-4d5e-8c05-41b8d900d0c7"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/s3", 
+                "AliasName": "alias/aws/s3", 
+                "TargetKeyId": "d1305425-4cde-46ee-be31-e2043dd4df39"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/aws/ssm", 
+                "AliasName": "alias/aws/ssm"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/dhruv-test", 
+                "AliasName": "alias/dhruv-test", 
+                "TargetKeyId": "c8723291-0eea-4321-b354-b63c83b39b66"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/s3-custom", 
+                "AliasName": "alias/s3-custom", 
+                "TargetKeyId": "3f2ab3af-cc4e-427b-b96d-d4356f9764c4"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/scot-test", 
+                "AliasName": "alias/scot-test", 
+                "TargetKeyId": "5fd9f6d6-4294-4926-8719-1e85695e2ad6"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/skunk-s3", 
+                "AliasName": "alias/skunk-s3", 
+                "TargetKeyId": "845ab6f1-744c-4edc-b702-efae6836818a"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/skunk/trails", 
+                "AliasName": "alias/skunk/trails", 
+                "TargetKeyId": "36812ccf-daaf-49b1-a24b-0eef254ffe41"
+            }, 
+            {
+                "AliasArn": "arn:aws:kms:us-east-1:644160558196:alias/wyp927-test-2", 
+                "AliasName": "alias/wyp927-test-2", 
+                "TargetKeyId": "e7b1b4bf-35cc-4ab5-9372-4c5c9be94eb3"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.CreateBucket_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-encrypt-sufficient-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "HCaJxOXCfmtYI2mqRCi+ZBm7Tc5kX0Y3tyYavR29L00SZ3ENMldhGGADSr15AJDLAcDMmsRlKhE=", 
+            "RequestId": "D076780A33811CB0", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "HCaJxOXCfmtYI2mqRCi+ZBm7Tc5kX0Y3tyYavR29L00SZ3ENMldhGGADSr15AJDLAcDMmsRlKhE=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "D076780A33811CB0", 
+                "location": "/custodian-encrypt-sufficient-test", 
+                "date": "Wed, 20 Sep 2017 09:03:58 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "70/44nDFtexZ/OMIBXTatcvbkDPI+6s0451d2z/pJpGE9mlEw2oThU+535LewSuZXs9Cmwwbxww=", 
+            "RequestId": "574833A781556493", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "70/44nDFtexZ/OMIBXTatcvbkDPI+6s0451d2z/pJpGE9mlEw2oThU+535LewSuZXs9Cmwwbxww=", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "x-amz-request-id": "574833A781556493", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.DeleteObject_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.DeleteObject_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "FWfxAyKEp4T+yEj/0oSN8rgy+Ntgpk/h1KKZkn4lEPWA4Z6LQgWWcE8y8AQRRNGQL6UDzRUKccY=", 
+            "RequestId": "5FABDA12E86A55E4", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "FWfxAyKEp4T+yEj/0oSN8rgy+Ntgpk/h1KKZkn4lEPWA4Z6LQgWWcE8y8AQRRNGQL6UDzRUKccY=", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "x-amz-request-id": "5FABDA12E86A55E4", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.DeleteObject_2.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.DeleteObject_2.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "xjm/7rGP5XHobo4tsMyrXKQ1FYHwupwy30j0w4C8txqaSWqBCheOHNkRkIXmCd35NzaKib5vOi0=", 
+            "RequestId": "189AEA59D9F6B791", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "xjm/7rGP5XHobo4tsMyrXKQ1FYHwupwy30j0w4C8txqaSWqBCheOHNkRkIXmCd35NzaKib5vOi0=", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "x-amz-request-id": "189AEA59D9F6B791", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_1.json
@@ -1,0 +1,39 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AcceptRanges": "bytes", 
+        "ContentType": "binary/octet-stream", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "T+gqqxq5yS3F4ZdjBfekzYbJW1RbmYKvpamGIEehIaByJ4jFG+DBkdRN6VKlHJKSNcBjrRRxYBg=", 
+            "RequestId": "6ACCBF65EAA3150E", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "T+gqqxq5yS3F4ZdjBfekzYbJW1RbmYKvpamGIEehIaByJ4jFG+DBkdRN6VKlHJKSNcBjrRRxYBg=", 
+                "accept-ranges": "bytes", 
+                "server": "AmazonS3", 
+                "last-modified": "Wed, 20 Sep 2017 09:03:59 GMT", 
+                "x-amz-request-id": "6ACCBF65EAA3150E", 
+                "etag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "x-amz-server-side-encryption": "AES256", 
+                "content-type": "binary/octet-stream"
+            }
+        }, 
+        "LastModified": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 9, 
+            "second": 59, 
+            "microsecond": 0, 
+            "year": 2017, 
+            "day": 20, 
+            "minute": 3
+        }, 
+        "ContentLength": 0, 
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+        "ServerSideEncryption": "AES256", 
+        "Metadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_2.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_2.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AcceptRanges": "bytes", 
+        "ContentType": "binary/octet-stream", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "nJxp4I6diKP4LOZOtV2G3h8FlSdo/nsDRjeO8jmGUlE2kYO7L1XceQC2ppdsR7RWTp/dWjR/DH8=", 
+            "RequestId": "5663CCE92D22578D", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "nJxp4I6diKP4LOZOtV2G3h8FlSdo/nsDRjeO8jmGUlE2kYO7L1XceQC2ppdsR7RWTp/dWjR/DH8=", 
+                "accept-ranges": "bytes", 
+                "server": "AmazonS3", 
+                "last-modified": "Wed, 20 Sep 2017 09:03:59 GMT", 
+                "x-amz-server-side-encryption-aws-kms-key-id": "arn:aws:kms:us-east-1:644160558196:key/d1305425-4cde-46ee-be31-e2043dd4df39", 
+                "x-amz-request-id": "5663CCE92D22578D", 
+                "etag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "x-amz-server-side-encryption": "aws:kms", 
+                "content-type": "binary/octet-stream"
+            }
+        }, 
+        "LastModified": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 9, 
+            "second": 59, 
+            "microsecond": 0, 
+            "year": 2017, 
+            "day": 20, 
+            "minute": 3
+        }, 
+        "ContentLength": 0, 
+        "ETag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+        "ServerSideEncryption": "aws:kms", 
+        "SSEKMSKeyId": "arn:aws:kms:us-east-1:644160558196:key/d1305425-4cde-46ee-be31-e2043dd4df39", 
+        "Metadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_3.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_3.json
@@ -1,0 +1,39 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AcceptRanges": "bytes", 
+        "ContentType": "binary/octet-stream", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "lh5G3lU/ipxmLKyr5SWTYMg/AzANBaezaz+Hk6nSTA4ksdehREbyAP3GDHDNoHfLwMLRgCVvTqM=", 
+            "RequestId": "105AAE84534D0E3C", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "lh5G3lU/ipxmLKyr5SWTYMg/AzANBaezaz+Hk6nSTA4ksdehREbyAP3GDHDNoHfLwMLRgCVvTqM=", 
+                "accept-ranges": "bytes", 
+                "server": "AmazonS3", 
+                "last-modified": "Wed, 20 Sep 2017 09:03:59 GMT", 
+                "x-amz-request-id": "105AAE84534D0E3C", 
+                "etag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "x-amz-server-side-encryption": "AES256", 
+                "content-type": "binary/octet-stream"
+            }
+        }, 
+        "LastModified": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 9, 
+            "second": 59, 
+            "microsecond": 0, 
+            "year": 2017, 
+            "day": 20, 
+            "minute": 3
+        }, 
+        "ContentLength": 0, 
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+        "ServerSideEncryption": "AES256", 
+        "Metadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_4.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.HeadObject_4.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AcceptRanges": "bytes", 
+        "ContentType": "binary/octet-stream", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "9Mw3V4GkTRGzrdEvyfL/8tc22CBXkVTBMD6BSAx9Ar9cSsxjARTo0BOXJFbabwjQNOhsM6yDeg8=", 
+            "RequestId": "F77D3FB9FE5A611C", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "9Mw3V4GkTRGzrdEvyfL/8tc22CBXkVTBMD6BSAx9Ar9cSsxjARTo0BOXJFbabwjQNOhsM6yDeg8=", 
+                "accept-ranges": "bytes", 
+                "server": "AmazonS3", 
+                "last-modified": "Wed, 20 Sep 2017 09:03:59 GMT", 
+                "x-amz-server-side-encryption-aws-kms-key-id": "arn:aws:kms:us-east-1:644160558196:key/d1305425-4cde-46ee-be31-e2043dd4df39", 
+                "x-amz-request-id": "F77D3FB9FE5A611C", 
+                "etag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "x-amz-server-side-encryption": "aws:kms", 
+                "content-type": "binary/octet-stream"
+            }
+        }, 
+        "LastModified": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 9, 
+            "second": 59, 
+            "microsecond": 0, 
+            "year": 2017, 
+            "day": 20, 
+            "minute": 3
+        }, 
+        "ContentLength": 0, 
+        "ETag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+        "ServerSideEncryption": "aws:kms", 
+        "SSEKMSKeyId": "arn:aws:kms:us-east-1:644160558196:key/d1305425-4cde-46ee-be31-e2043dd4df39", 
+        "Metadata": {}
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.ListBuckets_1.json
@@ -1,0 +1,116 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 2, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 40, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 15, 
+                    "minute": 5
+                }, 
+                "Name": "c7n-fire-logs"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 39, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 5, 
+                    "minute": 26
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 58, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 20, 
+                    "minute": 3
+                }, 
+                "Name": "custodian-encrypt-sufficient-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 27, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 16, 
+                    "minute": 49
+                }, 
+                "Name": "custodian-log-archive"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 56, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 5, 
+                    "minute": 26
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 19, 
+                    "minute": 23
+                }, 
+                "Name": "index-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 13, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 42, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 14, 
+                    "minute": 54
+                }, 
+                "Name": "kit-test-bucket"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "/jl6LMDc6++Etq2v1HaAV9nOUBfs0bgqW3Nijp96PEx49KpUNjE/6qTJL+QnYVusOUUbIa3/9Wg=", 
+            "RequestId": "0C835A6B69107BEF", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "/jl6LMDc6++Etq2v1HaAV9nOUBfs0bgqW3Nijp96PEx49KpUNjE/6qTJL+QnYVusOUUbIa3/9Wg=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "0C835A6B69107BEF", 
+                "date": "Wed, 20 Sep 2017 09:03:59 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.ListObjects_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.ListObjects_1.json
@@ -1,0 +1,68 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Name": "custodian-encrypt-sufficient-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "ghaHAfn081CgmWcD8QICRJZI1mAMHTTRQ1XFHyrjCwNvNwLHbYJsCp6/ScT9mGL8kwwXQ79CyXo=", 
+            "RequestId": "BA4F0112EF83536B", 
+            "HTTPHeaders": {
+                "x-amz-bucket-region": "us-east-1", 
+                "x-amz-id-2": "ghaHAfn081CgmWcD8QICRJZI1mAMHTTRQ1XFHyrjCwNvNwLHbYJsCp6/ScT9mGL8kwwXQ79CyXo=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "BA4F0112EF83536B", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "MaxKeys": 1000, 
+        "Prefix": "", 
+        "Marker": "", 
+        "EncodingType": "url", 
+        "IsTruncated": false, 
+        "Contents": [
+            {
+                "LastModified": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 20, 
+                    "minute": 3
+                }, 
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+                "StorageClass": "STANDARD", 
+                "Key": "testing-123", 
+                "Owner": {
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Size": 0
+            }, 
+            {
+                "LastModified": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 20, 
+                    "minute": 3
+                }, 
+                "ETag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+                "StorageClass": "STANDARD", 
+                "Key": "testing-abc", 
+                "Owner": {
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Size": 0
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.ListObjects_2.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.ListObjects_2.json
@@ -1,0 +1,68 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Name": "custodian-encrypt-sufficient-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "G4gbrq2IKmSsvpYUixTHvrqJoTC+TU9t3g+2tN/6lJtVZwfP9+2LWT/U+AQLOvYEzcx5akT/5n4=", 
+            "RequestId": "9D63FC3F55AF6A85", 
+            "HTTPHeaders": {
+                "x-amz-bucket-region": "us-east-1", 
+                "x-amz-id-2": "G4gbrq2IKmSsvpYUixTHvrqJoTC+TU9t3g+2tN/6lJtVZwfP9+2LWT/U+AQLOvYEzcx5akT/5n4=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "9D63FC3F55AF6A85", 
+                "date": "Wed, 20 Sep 2017 09:04:00 GMT", 
+                "content-type": "application/xml"
+            }
+        }, 
+        "MaxKeys": 1000, 
+        "Prefix": "", 
+        "Marker": "", 
+        "EncodingType": "url", 
+        "IsTruncated": false, 
+        "Contents": [
+            {
+                "LastModified": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 20, 
+                    "minute": 3
+                }, 
+                "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+                "StorageClass": "STANDARD", 
+                "Key": "testing-123", 
+                "Owner": {
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Size": 0
+            }, 
+            {
+                "LastModified": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 9, 
+                    "second": 59, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 20, 
+                    "minute": 3
+                }, 
+                "ETag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+                "StorageClass": "STANDARD", 
+                "Key": "testing-abc", 
+                "Owner": {
+                    "DisplayName": "mandeep.bal", 
+                    "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+                }, 
+                "Size": 0
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.PutObject_1.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.PutObject_1.json
@@ -1,0 +1,24 @@
+{
+    "status_code": 200, 
+    "data": {
+        "SSEKMSKeyId": "arn:aws:kms:us-east-1:644160558196:key/d1305425-4cde-46ee-be31-e2043dd4df39", 
+        "ETag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "AGPAUHKwvodaOnoHix89JTTlh1HB//1uQjcq0qqodMKoEQMsXee4hnZcjcnERdoPKUj1ZIG9Pc0=", 
+            "RequestId": "DA666DDF473C52BE", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "AGPAUHKwvodaOnoHix89JTTlh1HB//1uQjcq0qqodMKoEQMsXee4hnZcjcnERdoPKUj1ZIG9Pc0=", 
+                "server": "AmazonS3", 
+                "x-amz-server-side-encryption-aws-kms-key-id": "arn:aws:kms:us-east-1:644160558196:key/d1305425-4cde-46ee-be31-e2043dd4df39", 
+                "x-amz-request-id": "DA666DDF473C52BE", 
+                "etag": "\"338dabb292d2616c3c2236dd08aba77a\"", 
+                "date": "Wed, 20 Sep 2017 09:03:59 GMT", 
+                "x-amz-server-side-encryption": "aws:kms"
+            }
+        }, 
+        "ServerSideEncryption": "aws:kms"
+    }
+}

--- a/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.PutObject_2.json
+++ b/tests/data/placebo/test_s3_encrypt_aes256_sufficient/s3.PutObject_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ETag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "rsiLGbyzpeaSv1dMfblBGr51UbyPuygeqYdOO4SkqA3vR49XE48kqjAiECPf5uz66quFA5JpfkY=", 
+            "RequestId": "A158989BD1B6855B", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "rsiLGbyzpeaSv1dMfblBGr51UbyPuygeqYdOO4SkqA3vR49XE48kqjAiECPf5uz66quFA5JpfkY=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "A158989BD1B6855B", 
+                "etag": "\"d41d8cd98f00b204e9800998ecf8427e\"", 
+                "date": "Wed, 20 Sep 2017 09:03:59 GMT", 
+                "x-amz-server-side-encryption": "AES256"
+            }
+        }, 
+        "ServerSideEncryption": "AES256"
+    }
+}

--- a/tests/test_account.py
+++ b/tests/test_account.py
@@ -447,7 +447,7 @@ class AccountTests(BaseTest):
                 'amount-increase': 10,
                 'percent-increase': 10,
             }]},
-        self.assertRaises(ValidationError, self.load_policy, policy)
+        self.assertRaises(ValidationError, self.load_policy, policy, validate=True)
 
 
     def test_enable_trail(self):


### PR DESCRIPTION
closes and tests a regression introduced in #1233 .. namely that any kms encryption is sufficient when encrypting with aes256. also drive by fix trunk ci regression issue from #1526