### PR TITLE
Fix the error message for duplicate policies (#1601)

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -55,7 +55,7 @@ def validate(data, schema=None):
         if dupes:
             return [ValueError(
                 "Only one policy with a given name allowed, duplicates: %s" % (
-                    ", ".join(dupes)))]
+                    ", ".join(dupes))), dupes[0]]
         return []
     try:
         resp = specific_error(errors[0])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -72,7 +72,7 @@ class SchemaTest(BaseTest):
                 ]}
 
         result = validate(data)
-        self.assertEqual(len(result), 1)
+        self.assertEqual(len(result), 2)
         self.assertTrue(isinstance(result[0], ValueError))
         self.assertTrue('monday-morning' in str(result[0]))
 


### PR DESCRIPTION
#1601 

@kapilt - Oddly, this code path hadn't been touched in a long time.  I think we have a few different validation points in the code, but iirc they are hard to merge.  I made the simplest fix I could (I made the return value from `schema.py:validate()` more consistent).