### PR TITLE
make it so LambdaMode policies can be shared without leaking your acc…

### DIFF
--- a/docs/source/usecases/ec2-auto-tag-user.rst
+++ b/docs/source/usecases/ec2-auto-tag-user.rst
@@ -10,7 +10,10 @@ EC2 - auto-tag aws userName on resources
        resource: ec2
        mode:
          type: cloudtrail
-         role: arn:aws:iam::123456789000:role/custodian-auto-tagger
+         role: arn:aws:iam::{account_id}:role/custodian-auto-tagger
+         # note {account_id} is optional. If you put that there instead of
+         # your actual account number, when the policy is provisioned it
+         # will automatically inherit the account_id properly
          events:
            - RunInstances
        filters:


### PR DESCRIPTION
…ount numbers

note, the primary purpose of this PR is two things:
1. I can write a lambda policy and easily run it on many accounts, without needing to regex 'replace' the account string in my policies before each run.
2. I can share my policies without leaking my account id, this one is the main reason I think this is useful. If we make it optional to remove sensitive information from policies, they'll get shared more and the custodian policy libraries can grow to be more impressive.