### PR TITLE
Fixing the WORKER_COUNT

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -46,7 +46,7 @@ from c7n_org.utils import environ, account_tags
 log = logging.getLogger('c7n_org')
 
 
-WORKER_COUNT = os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count * 4)
+WORKER_COUNT = os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count() * 4)
 
 
 CONFIG_SCHEMA = {


### PR DESCRIPTION
This code was erroring out on the WORKER_COUNT line with the following error:
```
Traceback (most recent call last):
  File "/opt/cloud_custodian/bin/c7n-org", line 9, in <module>
    load_entry_point('c7n-org==0.0.1', 'console_scripts', 'c7n-org')()
  File "/opt/cloud_custodian/lib/python2.7/site-packages/pkg_resources.py", line 378, in load_entry_point
    return get_distribution(dist).load_entry_point(group, name)
  File "/opt/cloud_custodian/lib/python2.7/site-packages/pkg_resources.py", line 2566, in load_entry_point
    return ep.load()
  File "/opt/cloud_custodian/lib/python2.7/site-packages/pkg_resources.py", line 2260, in load
    entry = __import__(self.module_name, globals(),globals(), ['__name__'])
  File "/opt/cloud-custodian/tools/c7n_org/c7n_org/cli.py", line 49, in <module>
    WORKER_COUNT = os.environ.get('C7N_ORG_PARALLEL', multiprocessing.cpu_count * 4)
TypeError: unsupported operand type(s) for *: 'function' and 'int'
```
This was due to the cpu_count not having () at the end of it to call the function