### PR TITLE
Fix error message that prints when an exception is raised during `validate` #1640

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -184,7 +184,7 @@ def validate(options):
                     p.validate()
                 except Exception as e:
                     msg = "Policy: %s is invalid: %s" % (
-                        p.get('name', 'unknown'), e)
+                        p.data.get('name', 'unknown'), e)
                     errors.append(msg)
         if not errors:
             log.info("Configuration valid: {}".format(config_file))


### PR DESCRIPTION
Issue #1640 

Regression occurred in f27e4f2b (`p` was overwritten from being the policy contents in yaml to become a policy object)