### PR TITLE
Fix bug in 'remove_grants' which prevented object ACLs being remediated

### DIFF
--- a/tools/c7n_salactus/c7n_salactus/objectacl.py
+++ b/tools/c7n_salactus/c7n_salactus/objectacl.py
@@ -108,7 +108,7 @@ class ObjectAclCheck(object):
         return found
 
     def remove_grants(self, client, bucket, key, acl, grants):
-        params = {'Bucket': bucket, 'Key': 'Key'}
+        params = {'Bucket': bucket, 'Key': key['Key']}
 
         if 'VersionId' in key:
             params['VersionId'] = key['VersionId']

--- a/tools/c7n_salactus/c7n_salactus/worker.py
+++ b/tools/c7n_salactus/c7n_salactus/worker.py
@@ -913,7 +913,7 @@ def process_key_chunk(s3, bucket, kchunk, processor, object_reporting):
                 stats['denied'] += 1
                 if object_reporting:
                     stats['objects_denied'].append(k)
-            elif code in ('404', 'NoSuchKey'):  # Not Found
+            elif code in ('404', 'NoSuchKey', 'NoSuchVersion'):  # Not Found
                 stats['missing'] += 1
             elif code in ('503', '500', 'SlowDown'):  # Slow down, or throttle
                 time.sleep(3)


### PR DESCRIPTION
Typo prevents any S3 object ACL grants being removed.