### PR TITLE
Fixing the example code for Instance Profile

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1100,7 +1100,7 @@ class SetInstanceProfile(BaseAction, StateTransitionFilter):
         policies:
           - name: set-default-instance-profile
             resource: ec2
-            filter:
+            filters:
               - IamInstanceProfile: absent
             actions:
               - type: set-instance-profile

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1100,7 +1100,7 @@ class SetInstanceProfile(BaseAction, StateTransitionFilter):
         policies:
           - name: set-default-instance-profile
             resource: ec2
-            query:
+            filter:
               - IamInstanceProfile: absent
             actions:
               - type: set-instance-profile


### PR DESCRIPTION
The example policy for finding instance profiles was incorrect as it was listed as a query: instead of a filters:
simple fix