### PR TITLE
Adding support for dynamodb-table resource in c7n_mailer

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -261,6 +261,11 @@ def resource_format(resource, resource_type):
     elif resource_type == 'iam-profile':
         return " %s " % (
             resource['InstanceProfileId'])
+    elif resource_type == 'dynamodb-table':
+        return "name: %s created: %s status: %s" % (
+            resource['TableName'],
+            resource['CreationDateTime'],
+            resource['TableStatus'])
     else:
         print("Unknown resource type", resource_type)
         return "%s" % format_struct(resource)


### PR DESCRIPTION
Adding support for dynamodb-table resource in c7n_mailer

Without this a notify message processed by the mailer will error out with:
`TypeError: unicode argument expected, got 'str'`