### PR TITLE
Making the ec2 auto-tag-owner example easier to read and understand

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -552,8 +552,8 @@ class AutoTagUser(EventAction):
         - name: ec2-auto-tag-ownercontact
           resource: ec2
           description: |
-            Triggered when a new EC2 Instance is launched. Checks to see if 
-            it's missing the OwnerContact tag. If missing it gets created 
+            Triggered when a new EC2 Instance is launched. Checks to see if
+            it's missing the OwnerContact tag. If missing it gets created
             with the value of the ID of whomever called the RunInstances API
           mode:
             type: cloudtrail

--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -549,15 +549,19 @@ class AutoTagUser(EventAction):
     .. code-block:: yaml
 
       policies:
-        - name: ec2-auto-tag-owner
+        - name: ec2-auto-tag-ownercontact
           resource: ec2
+          description: |
+            Triggered when a new EC2 Instance is launched. Checks to see if 
+            it's missing the OwnerContact tag. If missing it gets created 
+            with the value of the ID of whomever called the RunInstances API
           mode:
             type: cloudtrail
             role: arn:aws:iam::123456789000:role/custodian-auto-tagger
             events:
               - RunInstances
           filters:
-           - tag:Owner: absent
+           - tag:OwnerContact: absent
           actions:
            - type: auto-tag-user
              tag: OwnerContact


### PR DESCRIPTION
The filter tag of Owner was different then the actions tag of OwnerContact which was bothering me for some reason so I just modified the example a little to make it clearer and added description.