### PR TITLE
typo permission for DescribeRouteTables, neglected to add ec2: prefix

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -241,7 +241,7 @@ class SnapshotDelete(BaseAction):
 
     schema = type_schema(
         'delete', **{'skip-ami-snapshots': {'type': 'boolean'}})
-    permissions = ('ec2.DeleteSnapshot',)
+    permissions = ('ec2:DeleteSnapshot',)
 
     def process(self, snapshots):
         self.image_snapshots = set()

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1183,7 +1183,7 @@ class MissingRoute(Filter):
     """
 
     schema = type_schema('missing-route')
-    permissions = ('DescribeRouteTables',)
+    permissions = ('ec2:DescribeRouteTables',)
 
     def process(self, resources, event=None):
         tables = self.manager.get_resource_manager(


### PR DESCRIPTION
As the title suggests, this is a simple typo correction.