### PR TITLE
[wip] Record S3 object owner in Salactus

### DIFF
--- a/tools/c7n_salactus/c7n_salactus/cli.py
+++ b/tools/c7n_salactus/c7n_salactus/cli.py
@@ -88,7 +88,8 @@ CONFIG_SCHEMA = {
             'properties': {
                 'bucket': {'type': 'string'},
                 'prefix': {'type': 'string'},
-                'role': {'type': 'string'}
+                'role': {'type': 'string'},
+                'access-denied-owner': {'type': 'boolean'}
             }
         },
 
@@ -200,6 +201,11 @@ def run(config, tag, bucket, account, debug, region):
 
     with open(config) as fh:
         data = utils.yaml_load(fh.read())
+
+        # build map of canonical IDs to account name and ID
+        id_map = {account_info['canonical-id']: (account_info['name'], account_info['account-id'])
+                    for account_info in data.get('accounts', ())}
+
         for account_info in data.get('accounts', ()):
             if tag and tag not in account_info.get('tags', ()):
                 continue
@@ -216,6 +222,7 @@ def run(config, tag, bucket, account, debug, region):
                 account_info['buckets'] = bucket
             if region:
                 account_info['regions'] = region
+            account_info['id-map'] = id_map
 
             try:
                 worker.invoke(worker.process_account, account_info)

--- a/tools/c7n_salactus/c7n_salactus/inventory.py
+++ b/tools/c7n_salactus/c7n_salactus/inventory.py
@@ -47,18 +47,17 @@ def load_manifest_file(client, bucket, schema, versioned, ifilters, key_info):
         for key_set in chunks(reader, 1000):
             keys = []
             for kr in key_set:
-                k = kr[1]
+                # http://docs.aws.amazon.com/AmazonS3/latest/dev/storage-inventory.html#storage-inventory-contents
                 if inventory_filter(ifilters, schema, kr):
                     continue
+                k = kr[1]
                 if '%' in k:
                     k = unquote_plus(k)
+                key = {'Key': k}
                 if versioned:
-                    if kr[3] == 'true':
-                        keys.append((k, kr[2], True))
-                    else:
-                        keys.append((k, kr[2]))
-                else:
-                    keys.append(k)
+                    key['VersionId'] = kr[2]
+                    key['IsLatest'] = kr[3] == 'true'
+                keys.append(key)
             yield keys
 
 

--- a/tools/c7n_salactus/c7n_salactus/objectacl.py
+++ b/tools/c7n_salactus/c7n_salactus/objectacl.py
@@ -50,11 +50,16 @@ class ObjectAclCheck(object):
 
         if not grants:
             return False
+
+        result = {k: key[k] for k in ('Key', 'Owner')
+                    if k in key}
+        result['Grants'] = grants
+
         if self.data.get('report-only'):
-            return {'key': key['Key'], 'grants': grants}
+            return result
 
         self.remove_grants(client, bucket_name, key, acl, grants)
-        return {'key': key['Key'], 'grants': grants}
+        return result
 
     def process_version(self, client, bucket_name, key):
         acl = client.get_object_acl(
@@ -65,12 +70,10 @@ class ObjectAclCheck(object):
         if not grants:
             return False
 
-        result = {
-            'key': key['Key'],
-            'version': key['VersionId'],
-            'is_latest': key['IsLatest'],
-            'grants': grants
-        }
+        result = {k: key[k] for k in ('Key', 'VersionId', 'IsLatest', 'Owner')
+                    if k in key}
+        result['Grants'] = grants
+
         if self.data.get('report-only'):
             return result
 


### PR DESCRIPTION
If a Salactus operation reports _Access Denied_ AND object-level reporting is enabled AND the `access-denied-owner` flag is set in the object-level reporting configuration then add an object's owner canonical ID and name and any associated IAM account information that we can obtain from the account configuration file.
As part of this I simplified the structure of the message passed from loading inventory or object page iteration.