### PR TITLE
Add `InvalidSnapshotID.Malformed` to `not-encrypted` filter

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -526,7 +526,8 @@ class NotEncryptedFilter(Filter, LaunchConfigFilterBase):
             try:
                 result = ec2.describe_snapshots(SnapshotIds=snap_ids)
             except ClientError as e:
-                if e.response['Error']['Code'] in ['InvalidSnapshot.NotFound', 'InvalidSnapshotID.Malformed']:
+                if e.response['Error']['Code'] in (
+                        'InvalidSnapshot.NotFound', 'InvalidSnapshotID.Malformed'):
                     if e.response['Error']['Code'] == 'InvalidSnapshotID.Malformed':
                         msg = e.response['Error']['Message']
                         e_snap_id = msg[msg.find('"') + 1:msg.rfind('"')]


### PR DESCRIPTION
While filtering-in unencrypted ASGs using `not-encrypted` filter, `InvalidSnapshotID.Malformed` is returned as an error, which currently is not handled by the code. This PR adds the functionality to handle that error code. 

Thanks.