### PR TITLE
Creating Additional/Fixing Existing Use Case Policy Examples

### DIFF
--- a/docs/source/usecases/accountflowlog.rst
+++ b/docs/source/usecases/accountflowlog.rst
@@ -3,8 +3,15 @@
 Account - Flow Log Configuration Check
 ======================================
 
-The following example policy will find any flow log in your region that is not
-properly configured and notify a group via email.
+The following example policy will find any VPC Flow Log in your region that is
+not properly configured and notify a group via email.  Ensuring VPC Flow Logs
+are enabled and setup properly is very important for compliance and security.
+Flow Logs themselves capture IP traffic information to and from network
+interfaces and can be used for troubleshooting traffic issues and montitoring
+network traffic as a security tool.  See more info on example dashboarding
+of VPC Flow Logs using Elasticsearch and Kibana
+https://aws.amazon.com/blogs/aws/cloudwatch-logs-subscription-consumer-elasticsearch-kibana-dashboards/
+
 
 .. code-block:: yaml
 

--- a/docs/source/usecases/accountflowlog.rst
+++ b/docs/source/usecases/accountflowlog.rst
@@ -1,0 +1,37 @@
+.. _accountaccountflowlog:
+
+Account - Flow Log Configuration Check
+=======================
+
+The following example policy will find any flow log in your region that is not
+properly configured and notify a group via email.
+
+.. code-block:: yaml
+
+   policies:
+     - name: account-flow-log-check
+       resource: account
+       filters:
+         - not:
+              - type: flow-logs
+                enabled: true
+                set-op: or
+                op: equal
+                traffic-type: all
+                log-group: myVPCFlowLogs
+                status: active
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "Cloud Custodian - VPC Flow Log(s) Not Setup Properly"
+           violation_desc: "The Following Flow Logs Are Invalid:"
+           action_desc: "Actions Taken:  Notification Only"
+           to:
+              - CloudCustodian@Company.com
+           transport:
+              type: sqs
+              queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+              region: us-east-1
+
+Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/accountflowlog.rst
+++ b/docs/source/usecases/accountflowlog.rst
@@ -12,7 +12,6 @@ network traffic as a security tool.  See more info on example dashboarding
 of VPC Flow Logs using Elasticsearch and Kibana
 https://aws.amazon.com/blogs/aws/cloudwatch-logs-subscription-consumer-elasticsearch-kibana-dashboards/
 
-
 .. code-block:: yaml
 
    policies:

--- a/docs/source/usecases/accountflowlog.rst
+++ b/docs/source/usecases/accountflowlog.rst
@@ -1,7 +1,7 @@
 .. _accountaccountflowlog:
 
 Account - Flow Log Configuration Check
-=======================
+======================================
 
 The following example policy will find any flow log in your region that is not
 properly configured and notify a group via email.

--- a/docs/source/usecases/accountinvalidiplogin.rst
+++ b/docs/source/usecases/accountinvalidiplogin.rst
@@ -1,0 +1,64 @@
+.. _accountinvalidiplogin:
+
+Account - Login From Invalid IP Address
+=======================================
+
+The following example policy will automatically create a CloudWatch Event Rule
+triggered Lambda function in your account and region which will be triggered
+anytime a user logs in from an invalid IP address. If the source IP address of
+the event is outside of the provided ranges in the policy then notify the admins
+security team for further investigation. Using the cloudtrail mode provides near
+real-time auto-remediation (typically within 1-2 mins) of the event occuring.
+Having such a quick auto-remediation action greatly reduces an attack window!
+By notifying the cloud admins or security team they can validate the login and
+revoke the login session if it's not valid followed by changing the password for
+or disabling the comprimised user etc.
+
+In the below example the filter being applied is regex and reads as follows:
+-Notify if the source IP address of the event is not from one of the valid IP CIDRs
+- 158.103.0.0/16
+- 142.179.0.0/16
+- 187.39.0.0/16
+- 12.0.0.0/8
+You can generate the Regex for IP ranges on a site like:
+http://www.analyticsmarket.com/freetools/ipregex
+
+.. code-block:: yaml
+
+   policies:
+
+     - name: invalid-ip-address-login-detected
+       resource: account
+       description: |
+         Notifies on invalid external IP console logins
+       mode:
+          type: cloudtrail
+          events:
+             - ConsoleLogin
+       filters:
+         - not:
+             - type: event
+               key: 'detail.sourceIPAddress'
+               value: |
+                  '^((158\.103\.|142\.179\.|187\.39\.)([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])
+                  \.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))|(12\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])
+                  \.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])\.([01]?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]))$'
+               op: regex
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "Login From Invalid IP Detected - [custodian {{ account }} - {{ region }}]"
+           violation_desc: "A User Has Logged In Externally From A Invalid IP Address Outside The Company's Range:"
+           action_desc: |
+               "Please investigate and revoke the invalid session along
+               with any other restrictive actions if appropriate"
+           to:
+             - CloudAdmins@Company.com
+             - SecurityTeam@Company.com
+           transport:
+             type: sqs
+             queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+             region: us-east-1
+
+Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/accountrootlogin.rst
+++ b/docs/source/usecases/accountrootlogin.rst
@@ -1,0 +1,49 @@
+.. _accountrootlogin:
+
+Account - Detect Root Logins
+============================
+
+The following example policy will automatically create a CloudWatch Event Rule
+triggered Lambda function in your account and region which will be triggered
+anytime the root user of the account logs in. Typically the root user of an AWS
+account should never need to login after the initial account setup and root user
+access should be very tightly controlled with hardware MFA and other controls
+as root has full control of everything in the account. Having this visibility
+to see if and when someone logs in as root is very important.
+
+.. code-block:: yaml
+
+   policies:
+
+     - name: root-user-login-detected
+       resource: account
+       description: |
+         Notifies Security and Cloud Admins teams on any AWS root user console logins
+       mode:
+          type: cloudtrail
+          events:
+             - ConsoleLogin
+       filters:
+          - type: event
+            key: "detail.userIdentity.type"
+            value_type: swap
+            op: in
+            value: Root
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "Root User Login Detected! - [custodian {{ account }} - {{ region }}]"
+           violation_desc: "A User Has Logged Into the AWS Console With The Root User:"
+           action_desc: |
+               "Please investigate and if needed revoke the root users session along
+               with any other restrictive actions if it's an unapproved root login"
+           to:
+             - CloudAdmins@Company.com
+             - SecurityTeam@Company.com
+           transport:
+             type: sqs
+             queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+             region: us-east-1
+
+Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/asginvalidconfig.rst
+++ b/docs/source/usecases/asginvalidconfig.rst
@@ -1,0 +1,37 @@
+.. _asginvalidconfig:
+
+AutoScaling Group - Verify ASGs have valid configurations
+=========================================================
+
+The following example policy will check all AutoScaling Groups for configuration
+issues which could prevent the ASG from functioning properly.  The following items
+are checked: invalid subnets, invalid security groups, invalid key pair name,
+invalid launch config volume snapshots, invalid amis, invalid elb health check etc.
+
+.. code-block:: yaml
+
+   policies:
+     - name: asg-invalid-configuration
+       resource: asg
+       filters:
+         - invalid
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "ASG-Invalid Config-[custodian {{ account }} - {{ region }}]"
+           violation_desc: |
+               "New ASG instances may fail to launch or scale! The following Autoscaling
+               Groups have invalid AMIs, SGs, KeyPairs, Launch Configs, or Health Checks"
+           action_desc: |
+               "Actions Taken:  Notification Only. Please investigate and fix your ASGs
+               configuration to prevent you from having any outages or issues"
+           to:
+              - CloudAdmins@Company.com
+              - resource-owner
+           transport:
+              type: sqs
+              queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+              region: us-east-1
+
+Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/asginvalidconfig.rst
+++ b/docs/source/usecases/asginvalidconfig.rst
@@ -3,10 +3,19 @@
 AutoScaling Group - Verify ASGs have valid configurations
 =========================================================
 
-The following example policy will check all AutoScaling Groups for configuration
-issues which could prevent the ASG from functioning properly.  The following items
-are checked: invalid subnets, invalid security groups, invalid key pair name,
-invalid launch config volume snapshots, invalid amis, invalid elb health check etc.
+The following example policy will check all AutoScaling Groups in the current
+account and region for configuration issues which could prevent the ASG from
+functioning properly or launching an instance. Then the ASG resource owner
+and a cloud admins group get an email showing the affected ASG(s).
+
+The following ASG items are checked when using the `` - invalid `` filter:
+  * invalid subnets
+  * invalid security groups
+  * invalid key pair name
+  * invalid launch config volume snapshots
+  * invalid AMIs
+  * invalid ELB health check
+
 
 .. code-block:: yaml
 

--- a/docs/source/usecases/ebssnapshots.rst
+++ b/docs/source/usecases/ebssnapshots.rst
@@ -1,0 +1,36 @@
+.. _ebssnapshots:
+
+EBS - Create and Manage Snapshots
+=================================
+
+The following example policy will snapshot all EBS volumes attached to EC2 instances and
+copy the instances tags to the snapshot. Then when the snapshots are 7 days old they will
+get deleted so you always have a rolling 7 days worth of snapshots.
+
+.. code-block:: yaml
+
+   policies:
+     - name: ec2-create-ebs-snapshots
+       resource: ec2
+       actions:
+          - type: snapshot
+            copy-tags:
+                - CreatorName
+                - "Resource Contact"
+                - "Resource Purpose"
+                - Environment
+                - "Billing Cost Center"
+                - Name
+
+     - name: ebs-delete-old-ebs-snapshots
+       resource: ebs
+       filters:
+           - type: age
+             days: 7
+             op: ge
+           - type: value
+             key: Description
+             op: regex
+             value: ^(Automated,Backup,-?)\w+
+       actions:
+           - delete

--- a/docs/source/usecases/ec2poweronstoppedforpatching.rst
+++ b/docs/source/usecases/ec2poweronstoppedforpatching.rst
@@ -3,9 +3,9 @@
 EC2 - Power On For Scheduled Patching
 =====================================
 
-The following example policies will automatically create CloudWatch cron/rate
+The following example policies will automatically create CloudWatch cron rate
 triggered Lambda functions in your account and region. The Lambda funtions will
-be triggered on the cron/rate expression schedule you provide in the mode section
+be triggered on the cron rate expression schedule you provide in the mode section
 of the policy. The following example policies find all EC2 instances that are
 both in a stopped state, and have a tag called ``Patch Group`` with a value of
 ``Linux Dev``.  Those instances are then started and tagged with an additional
@@ -18,9 +18,9 @@ When the patching window is done the last 2 policies in this example will remove
 the PatchingInProgress tag from all instances in that group and remove the
 PowerOffWhenDone tag and stop those instances that were previously stopped. The
 cron expressions for this example read as the following:
-cron(0 3 ? 1/1 SUN#1 *) means trigger on the 1st Sunday of every month at 3:00 UTC
-then cron(0 13 ? 1/1 SUN#1 *) is the same day at 13:00 UTC which allows for a 10
-Hour patching window.  Learn more on AWS cron/rate expressions
+r```cron(0 3 ? 1/1 SUN#1 *)``` means trigger on the 1st Sunday of every month at 3:00 UTC
+then r```cron(0 13 ? 1/1 SUN#1 *)``` is the same day at 13:00 UTC which allows for a 10
+Hour patching window.  Learn more on AWS cron rate expressions
 https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 
 .. code-block:: yaml

--- a/docs/source/usecases/ec2poweronstoppedforpatching.rst
+++ b/docs/source/usecases/ec2poweronstoppedforpatching.rst
@@ -6,9 +6,7 @@ EC2 - Power On For Scheduled Patching
 The following example policies will automatically create CloudWatch cron/rate
 triggered Lambda functions in your account and region. The Lambda funtions will
 be triggered on the cron/rate expression schedule you provide in the mode section
-of the policy.
-
-The following example policies find all EC2 instances that are
+of the policy. The following example policies find all EC2 instances that are
 both in a stopped state, and have a tag called ``Patch Group`` with a value of
 ``Linux Dev``.  Those instances are then started and tagged with an additional
 tag of ``PowerOffWhenDone`` and a value of ``True`` so that they can be stopped
@@ -18,9 +16,8 @@ The PatchingInProgress tag can be used by other policies such as offhours polici
 where the presence of that tag would exclude it from being stopped by the offhours.
 When the patching window is done the last 2 policies in this example will remove
 the PatchingInProgress tag from all instances in that group and remove the
-PowerOffWhenDone tag and stop those instances that were previously stopped.
-
-The cron expressions for this example read as the following:
+PowerOffWhenDone tag and stop those instances that were previously stopped. The
+cron expressions for this example read as the following:
 cron(0 3 ? 1/1 SUN#1 *) means trigger on the 1st Sunday of every month at 3:00 UTC
 then cron(0 13 ? 1/1 SUN#1 *) is the same day at 13:00 UTC which allows for a 10
 Hour patching window.  Learn more on AWS cron/rate expressions

--- a/docs/source/usecases/ec2poweronstoppedforpatching.rst
+++ b/docs/source/usecases/ec2poweronstoppedforpatching.rst
@@ -1,0 +1,96 @@
+.. _ec2poweronstoppedforpatching:
+
+EC2 - Power On For Scheduled Patching
+=====================================
+
+The following example policies will automatically create CloudWatch cron/rate
+triggered Lambda functions in your account and region. The Lambda funtions will
+be triggered on the cron/rate expression schedule you provide in the mode section
+of the policy.
+
+The following example policies find all EC2 instances that are
+both in a stopped state, and have a tag called ``Patch Group`` with a value of
+``Linux Dev``.  Those instances are then started and tagged with an additional
+tag of ``PowerOffWhenDone`` and a value of ``True`` so that they can be stopped
+again after the patching window. Then all instances with the ``Linux Dev`` Patch
+Group get another tag called ``PatchingInProgress`` with a value of ``True``.
+The PatchingInProgress tag can be used by other policies such as offhours policies
+where the presence of that tag would exclude it from being stopped by the offhours.
+When the patching window is done the last 2 policies in this example will remove
+the PatchingInProgress tag from all instances in that group and remove the
+PowerOffWhenDone tag and stop those instances that were previously stopped.
+
+The cron expressions for this example read as the following:
+cron(0 3 ? 1/1 SUN#1 *) means trigger on the 1st Sunday of every month at 3:00 UTC
+then cron(0 13 ? 1/1 SUN#1 *) is the same day at 13:00 UTC which allows for a 10
+Hour patching window.  Learn more on AWS cron/rate expressions
+https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
+
+.. code-block:: yaml
+
+   policies:
+
+     - name: power-on-patch-group-linux-dev
+       resource: ec2
+       mode:
+            type: periodic
+            schedule: "cron(0 3 ? 1/1 SUN#1 *)"
+       filters:
+            - "State.Name": stopped
+            - type: value
+              key: tag:Patch Group
+              op: eq
+              value: "Linux Dev"
+       actions:
+            - start
+            - type: tag
+              key: PowerOffWhenDone
+              value: "True"
+
+     - name: patching-exception-tag-linux-dev
+       resource: ec2
+       mode:
+            type: periodic
+            schedule: "cron(0 3 ? 1/1 SUN#1 *)"
+       filters:
+            - type: value
+              key: tag:Patch Group
+              op: eq
+              value: "Linux Dev"
+       actions:
+            - type: tag
+              key: PatchingInProgress
+              value: "True"
+
+     - name: patching-exception-removal-linux-dev
+       resource: ec2
+       mode:
+            type: periodic
+            schedule: "cron(0 13 ? 1/1 SUN#1 *)"
+       filters:
+            - type: value
+              key: tag:Patch Group
+              op: eq
+              value: "Linux Dev"
+       actions:
+            - type: unmark
+              tags: ["PatchingInProgress"]
+
+     - name: power-down-patch-group-linux-dev
+       resource: ec2
+       mode:
+            type: periodic
+            schedule: "cron(0 13 ? 1/1 SUN#1 *)"
+       filters:
+            - "State.Name": running
+            - "tag:PowerOffWhenDone": present
+            - type: value
+              key: tag:Patch Group
+              op: eq
+              value: "Linux Dev"
+       actions:
+            - stop
+            - type: unmark
+              tags: ["PowerOffWhenDone"]
+
+Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/ec2poweronstoppedforpatching.rst
+++ b/docs/source/usecases/ec2poweronstoppedforpatching.rst
@@ -18,8 +18,8 @@ When the patching window is done the last 2 policies in this example will remove
 the PatchingInProgress tag from all instances in that group and remove the
 PowerOffWhenDone tag and stop those instances that were previously stopped. The
 cron expressions for this example read as the following:
-``cron(0 3 ? 1/1 SUN#1 /*)`` means trigger on the 1st Sunday of every month at 3:00 UTC
-then ``cron(0 13 ? 1/1 SUN#1 /*)`` is the same day at 13:00 UTC which allows for a 10
+cron(0 3 ? 1/1 SUN#1 \*) means trigger on the 1st Sunday of every month at 3:00 UTC
+then cron(0 13 ? 1/1 SUN#1 \*) is the same day at 13:00 UTC which allows for a 10
 Hour patching window.  Learn more on AWS cron rate expressions
 https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 

--- a/docs/source/usecases/ec2poweronstoppedforpatching.rst
+++ b/docs/source/usecases/ec2poweronstoppedforpatching.rst
@@ -18,8 +18,8 @@ When the patching window is done the last 2 policies in this example will remove
 the PatchingInProgress tag from all instances in that group and remove the
 PowerOffWhenDone tag and stop those instances that were previously stopped. The
 cron expressions for this example read as the following:
-r```cron(0 3 ? 1/1 SUN#1 *)``` means trigger on the 1st Sunday of every month at 3:00 UTC
-then r```cron(0 13 ? 1/1 SUN#1 *)``` is the same day at 13:00 UTC which allows for a 10
+``cron(0 3 ? 1/1 SUN#1 /*)`` means trigger on the 1st Sunday of every month at 3:00 UTC
+then ``cron(0 13 ? 1/1 SUN#1 /*)`` is the same day at 13:00 UTC which allows for a 10
 Hour patching window.  Learn more on AWS cron rate expressions
 https://docs.aws.amazon.com/AmazonCloudWatch/latest/events/ScheduledEvents.html
 

--- a/docs/source/usecases/ec2unpatchedworkflow.rst
+++ b/docs/source/usecases/ec2unpatchedworkflow.rst
@@ -7,10 +7,12 @@ The following example policy workflow uses the mark-for-op and marked-for-op fil
 actions to chain together a set of policies to accomplish a task.  In this example it will
 find and tag any instances that are in a stopped state.  The example specifies a custom tag
 called c7n_stopped_instance and the value of the tag will be an op action of terminate for
-60 days in the future.
+60 days in the future.  The reasoning behind terminating unpatchable instances is after 60
+days the instance will be far enough behind on patching and virus defs(if used) that
+starting the instance after 60 days would  present too large of a security risk. 
 
-Note the use of the skew option with the marked-for-op filter to notify customers X number
-of days ahead of the scheduled marked-for-op action date.
+Note the use of the skew option with the marked-for-op filter in some of the policies to
+notify the resource owners X number of days ahead of the scheduled marked-for-op action date.
 
 .. code-block:: yaml
 

--- a/docs/source/usecases/ec2unpatchedworkflow.rst
+++ b/docs/source/usecases/ec2unpatchedworkflow.rst
@@ -1,0 +1,131 @@
+.. _ec2unpatchedworkflow:
+
+EC2 - Terminate Unpatchable Instances
+=====================================
+
+The following example policy workflow uses the mark-for-op and marked-for-op filters and
+actions to chain together a set of policies to accomplish a task.  In this example it will
+find and tag any instances that are in a stopped state.  The example specifies a custom tag
+called c7n_stopped_instance and the value of the tag will be an op action of terminate for
+60 days in the future.
+
+Note the use of the skew option with the marked-for-op filter to notify customers X number
+of days ahead of the scheduled marked-for-op action date.
+
+.. code-block:: yaml
+
+   policies:
+
+     - name: ec2-mark-stopped-instance
+       resource: ec2
+       description: |
+         Mark any stopped ec2 instance for deletion in 60 days
+         If an instance has not been started for 60 days or over
+         then they will be deleted similar to internal policies as it wont be patched.
+       filters:
+         - "tag:c7n_stopped_instance": absent
+         - "State.Name": stopped
+       actions:
+         - type: mark-for-op
+           tag: c7n_stopped_instance
+           op: terminate
+           days: 60
+
+     - name: ec2-unmark-previously-stopped
+       resource: ec2
+       description: |
+         Unmark/untag any ec2 instance that was scheduled for deletion due to being stopped
+         if they are currently running.
+       filters:
+         - "State.Name": running
+         - "tag:c7n_stopped_instance": present
+       actions:
+         - type: unmark
+           tags: ["c7n_stopped_instance"]
+
+     - name: ec2-notify-before-delete-marked-14-days
+       resource: ec2
+       description: |
+         Notify on any ec2 instances that will be deleted in 14 days if not started
+       comments: |
+         Your EC2 server will be terminated in 14 days if not started and patched by then.
+         Please start your stopped servers and leave them on for 24 hours minimum to
+         allow for patching to occur.
+       filters:
+         - type: marked-for-op
+           tag: c7n_stopped_instance
+           op: terminate
+           skew: 14
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 2
+           subject: "EC2 Stopped Instance Termination Scheduled! [custodian {{ account }} - {{ region }}]"
+           violation_desc: "EC2(s) have been in a stopped state for 45 days and at 60 days will be termianted:"
+           action_desc: |
+               Your EC2 server will be terminated in 14 days if not started and patched by then.
+               Please start your stopped servers and leave them on for 24 hours minimum to
+               allow for patching to occur.
+           to:
+             - CloudCustodian@Company.com
+             - resource-owner
+           transport:
+             type: sqs
+             queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+             region: us-east-1
+
+     - name: ec2-notify-before-delete-marked-7-days
+       resource: ec2
+       description: |
+         Notify on any ec2 instances that will be deleted in 7 days if not started
+       filters:
+         - type: marked-for-op
+           tag: c7n_stopped_instance
+           op: terminate
+           skew: 7
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "EC2 Stopped Instance Termination Scheduled! [custodian {{ account }} - {{ region }}]"
+           violation_desc: "EC2(s) have been in a stopped state for 53 days and at 60 days will be termianted:"
+           action_desc: |
+               Your EC2 server will be terminated in 7 days if not started and patched by then.
+               Please start your stopped servers and leave them on for 24 hours minimum to
+               allow for patching to occur.
+           to:
+             - CloudCustodian@Company.com
+             - resource-owner
+           transport:
+             type: sqs
+             queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+             region: us-east-1
+
+     - name: ec2-delete-marked
+       resource: ec2
+       description: |
+         Terminate and notify on any ec2 instances that were scheduled
+         for deletion if its been stopped for 60 days
+         and no longer up-to-date on patching.
+       filters:
+         - type: marked-for-op
+           tag: c7n_stopped_instance
+           op: stop
+       actions:
+         - type: terminate
+           force: true
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "EC2 Stopped Instance Terminated [custodian {{ account }} - {{ region }}]"
+           violation_desc: "EC2(s) had been stopped for 60 days and have now been terminated:"
+           action_desc: |
+               Your EC2 server has been terminated as its patching is too far out-of-date and
+               beyond the 60 day window.
+           to:
+             - CloudCustodian@Company.com
+             - resource-owner
+           transport:
+             type: sqs
+             queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+             region: us-east-1

--- a/docs/source/usecases/elbdeleteinetfacing.rst
+++ b/docs/source/usecases/elbdeleteinetfacing.rst
@@ -1,0 +1,58 @@
+.. _elbdeleteinetfacing:
+
+ELB - Delete New Internet-Facing ELBs
+=====================================
+
+The following example policy will automatically create a CloudWatch Event Rule
+triggered Lambda function in your account and region which will be triggered
+anytime a user creates a new classic Elastic Load Balancer. If the ELB is set to
+be internet-facing then delete it right away at launch. This provides near 
+real-time auto-remediation (typically within 1-2 mins) of the ELB being created.
+Having such a quick auto-remediation action greatly reduces an attack window!
+By notifying the customer who tried to perform the action it helps drive user
+behaviour as well and lets them know why their ELBs keep deleting at launch! ;)
+
+.. code-block:: yaml
+
+   policies:
+
+     - name: elb-delete-new-internet-facing
+       resource: elb
+       mode:
+         type: cloudtrail
+         events:
+            - CreateLoadBalancer
+       description: |
+         Any newly created Classic Load Balanacers launched with
+         a internet-facing schema will be deleted right away.
+       filters:
+         - type: event
+           key: "detail.requestParameters.scheme"
+           op: eq
+           value: "internet-facing"
+       actions:
+         - delete
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "Deleted New Internet-Facing ELB - [custodian {{ account }} - {{ region }}]"
+           violation_desc: "Internet-Facing ELBs are not allowed and are deleted at launch."
+           action_desc: |
+              "Actions Taken: Your new ELB has been deleted.
+              Please launch a new non-internet-facing ELB"
+           to:
+              - CloudCustodian@Company.com
+              - event-owner
+           transport:
+              type: sqs
+              queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+              region: us-east-1
+
+By including ``- event-owner`` in the notify's to: field it tells Cloud Custodian
+to extract the id of the user who made the API call for the event and email them.
+Being that the above policy runs in a cloudtrail mode the API call's metadata event
+is present which is why the example uses event-owner.  If you were to remove the ``mode:``
+statement on the example policy and run it in a poll mode instead you could change
+``- event-owner`` to ``- resource-owner`` which would rely on the resources tags for
+a id or email to send the notification to as no API event would be available at that time.
+Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/elbgarbagecollection.rst
+++ b/docs/source/usecases/elbgarbagecollection.rst
@@ -1,0 +1,86 @@
+.. _elbgarbagecollection:
+
+ELB - Delete Unused Elastic Load Balancers
+=====================================================
+
+The following example policy workflow uses the mark-for-op and marked-for-op filters and
+actions to chain together a set of policies to accomplish a task.  In this example it
+will find any ELB that isn't attached to any instances and tag it with a delete op
+and date 14 days out.  The policy workflow will also email the ELB resource owner to
+inform them of the upcoming deletion if the ELB remains unused.  If the customer adds
+an instance back to their ELB it will get unmarked so it doesn't get deleted.
+
+Note the use of the notify action requires the Cloud Custodian mailer to be installed
+and configured.
+
+.. code-block:: yaml
+
+   policies:
+
+    - name: elb-mark-unused-for-deletion
+      resource: elb
+      description: |
+        Mark any ELB with no instances attached for deletion in 14 days.
+        Also send an email to the ELB resource owner informing them its unused.
+      filters:
+        - "tag:maid_status": absent
+        - Instances: []
+      actions:
+        - type: mark-for-op
+          tag: maid_status
+          msg: "Unused ELB No Instances: {op}@{action_date}"
+          op: delete
+          days: 14
+        - type: notify
+          template: default.html
+          priority_header: 1
+          subject: "ELB - No Instances Attached - [custodian {{ account }} - {{ region }}]"
+          violation_desc: "No Instances Are Attached To The Following ELB(s):"
+          action_desc: |
+             "Actions Taken: The unused ELBs have been marked for deletion in 14 if they
+             remain unused. If you still need the ELBs listed below, please attach instances
+             to them, otherwise please delete them if not needed anymore."
+          to:
+             - CloudCustodian@Company.com
+             - resource-owner
+          transport:
+               type: sqs
+               queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+               region: us-east-1
+
+    - name: elb-unmark-if-in-use
+      resource: elb
+      description: |
+        Remove the maid_status tag from any elb which has instances attached
+        so it doesn't get deleted by the following policy
+      filters:
+        - "tag:maid_status": not-null
+        - not:
+              - Instances: []
+      actions:
+        - type: remove-tag
+          tags: [maid_status]
+
+    - name: elb-delete-unused
+      resource: elb
+      description: |
+        Delete any marked ELB which has no instances attached
+        if it has been that way for 14 days or more.
+      filters:
+        - type: marked-for-op
+          op: delete
+      actions:
+        - delete
+        - type: notify
+          template: default.html
+          priority_header: 1
+          subject: "ELB - Deleted Stale ELB - [custodian {{ account }} - {{ region }}]"
+          violation_desc: "No Instances Are Attached To ELB for over 14 days:"
+          action_desc: "Actions Taken:  The ELB has been deleted"
+          to:
+             - CloudCustodian@Company.com
+             - resource-owner
+          transport:
+               type: sqs
+               queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+               region: us-east-1

--- a/docs/source/usecases/rdsdeleteunused.rst
+++ b/docs/source/usecases/rdsdeleteunused.rst
@@ -1,0 +1,221 @@
+.. _rdsdeleteunused:
+
+RDS - Delete Unused Databases With No Connections
+=================================================
+
+The following example policy workflow uses the mark-for-op and marked-for-op filters and
+actions to chain together a set of policies to accomplish a task.  In this example it
+will find any RDS that is older than 14 days that has had no connections to it in the last
+14 days and tag it with a delete op and date 14 days out. The policy workflow will also
+email the RDS resource owner to inform them of the upcoming stopping and deletion if the
+RDS remains unused. If a customer connects to the RDS before the 14 day window it will
+get unmarked so it doesn't get deleted.
+
+Note the use of the notify action requires the Cloud Custodian mailer to be installed
+and configured.
+
+.. code-block:: yaml
+
+     vars:
+       metrics-filters: &metrics-filter
+             type: metrics
+             name: DatabaseConnections
+             days: 14
+             value: 0
+             op: equal
+     
+     policies:
+
+     - name: rds-unused-databases-notify-step1
+       resource: rds
+       description: |
+         Take the average number of connections over 14 days for databases that are greater than 14
+         days old and notify the resources owner on any unused RDS and mark for delete action in 14 days.
+       filters:
+         - "tag:c7n_rds_unused": absent
+         - type: value
+           value_type: age
+           key: InstanceCreateTime
+           value: 14
+           op: greater-than
+         - <<: *metrics-filter
+         - or:
+             - "tag:Resource Contact": present
+             - "tag:CreatorName": present
+       actions:
+         - type: mark-for-op
+           tag: c7n_rds_unused
+           op: delete
+           days: 14
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "RDS - Unused Database - [custodian {{ account }} - {{ region }}]"
+           violation_desc: "RDS Instance has had no connections in the last 2 weeks and is unused:"
+           action_desc: |
+               "Actions Taken:  Database deletion has been scheduled for 14 days from now.
+               At this point we are just notifying you of the upcoming deletion if not used."
+           to:
+             - CloudCustodian@Company.com
+             - resource-owner
+           transport:
+               type: sqs
+               queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+               region: us-east-1
+
+     - name: rds-unused-databases-notify-step2
+       resource: rds
+       description: |
+         Take the average number of connections over 21
+         days and notify on any unused RDS that have already been marked for delete
+       filters:
+         - "tag:c7n_rds_unused": present
+         - type: marked-for-op
+           tag: c7n_rds_unused
+           op: delete
+           skew: 7
+         - type: value
+           value_type: age
+           key: InstanceCreateTime
+           value: 21
+           op: gte
+         - <<: *metrics-filter
+         - or:
+             - "tag:Resource Contact": present
+             - "tag:CreatorName": present
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "RDS - URGENT - Unused Database - [custodian {{ account }} - {{ region }}]"
+           violation_desc: |
+               "RDS Instance has had no connections in the last 3 weeks and is unused and will be stopped
+               hourly in 5 days (if supported by DB type) and then deleted 2 days after its stopped:"
+           action_desc: |
+               "Actions Taken:  Hourly database stopping and email will occur in 5 days and deleted will occur in 7 days.
+               At this point we are just notifying you of the upcoming stoppage and deleted if not used"
+           to:
+             - resource-owner
+           transport:
+               type: sqs
+               queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+               region: us-east-1
+
+     - name: rds-unused-databases-stop-and-nag-hourly-step3
+       resource: rds
+       mode:
+           type: periodic
+           schedule: "rate(1 hour)"
+           timeout: 300
+       description: |
+         This policy deploys a Lambda function with an hourly CloudWatch Event Schedule trigger.  
+         The policy takes the average number of connections over 26 days and stops the RDS and
+         notifies the resource owner hourly on any of their unused databases that have already
+         been marked for deletion.
+       filters:
+         - "tag:c7n_rds_unused": present
+         - type: marked-for-op
+           tag: c7n_rds_unused
+           op: delete
+           skew: 1
+         - type: value
+           value_type: age
+           key: InstanceCreateTime
+           value: 26
+           op: gte
+         - <<: *metrics-filter
+         - or:
+             - "tag:Resource Contact": present
+             - "tag:CreatorName": present
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "RDS - URGENT!!! - Unused Database! - [custodian {{ account }} - {{ region }}]"
+           violation_desc: |
+               "RDS Instance has had no connections in the last 26 days and is unused
+               and will be deleted in less than 48 hours"
+           action_desc: |
+               "Actions Taken: Hourly Stopping of RDS and notify.  Deletion will occur in less than
+               48 hours. Please connect to the RDS or snapshot it if you don't need it at this time."
+           to:
+             - resource-owner
+           transport:
+               type: sqs
+               queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+               region: us-east-1
+
+     - name: rds-unused-databases-delete-step4
+       resource: rds
+       description: |
+         Take the average number of connections over 28 days and delete
+         any unused databases that have already been marked for delete
+       filters:
+         - "tag:c7n_rds_unused": present
+         - type: marked-for-op
+           tag: c7n_rds_unused
+           op: delete
+         - type: value
+           value_type: age
+           key: InstanceCreateTime
+           value: 28
+           op: gte
+         - <<: *metrics-filter
+         - or:
+             - "tag:Resource Contact": present
+             - "tag:CreatorName": present
+       actions:
+         - type: delete
+           skip-snapshot: true
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "RDS - URGENT!!! - Unused Database Deleted! - [custodian {{ account }} - {{ region }}]"
+           violation_desc: "RDS Instance has had no connections in the last 28 days and has been deleted."
+           action_desc: "Actions Taken: RDS Instance(s) have been deleted."
+           to:
+             - CloudCustodian@Company.com
+             - resource-owner
+           transport:
+               type: sqs
+               queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+               region: us-east-1
+
+     - name: rds-unused-databases-unmark
+       resource: rds
+       description: |
+         The policy takes the average number of connections over 14 days and if there are connections
+         then unmark the RDS instance and notify the resource owner.
+       filters:
+         - "tag:c7n_rds_unused": present
+         - type: value
+           value_type: age
+           key: InstanceCreateTime
+           value: 14
+           op: gte
+         - type: metrics
+           name: DatabaseConnections
+           days: 14
+           value: 0
+           op: gt
+         - or:
+             - "tag:Resource Contact": present
+             - "tag:CreatorName": present
+       actions:
+         - type: unmark
+           tags: ["c7n_rds_unused"]
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "RDS - Previously Unused DB Unmarked! - [custodian {{ account }} - {{ region }}]"
+           violation_desc: |
+               "RDS Instance that previously had no connections for over 2 weeks is now showing
+               connections and it has been unmarked for deletion."
+           action_desc: "Actions Taken: RDS Instance(s) have been unmarked. No further action needed"
+           to:
+             - CloudCustodian@Company.com
+             - resource-owner
+           transport:
+               type: sqs
+               queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+               region: us-east-1

--- a/docs/source/usecases/securitygroupsdetectremediate.rst
+++ b/docs/source/usecases/securitygroupsdetectremediate.rst
@@ -5,8 +5,8 @@ Security Groups - Detect and Remediate Violations
 
 The following example policy will automatically create a CloudWatch Event Rule
 triggered Lambda function in your account and region which will be triggered
-anytime a user creates or modifies a security group. This provides auto-remediation
-and near real-time action (typically within a minute) of the security group change.
+anytime a user creates or modifies a security group. This provides near real-time
+auto-remediation action (typically within a minute) of the security group change.
 By notifying the customer who tried to perform the action it helps drive user
 behaviour and lets them know why the security group keeps reverting their 0.0.0.0/0
 rule additions on them!

--- a/docs/source/usecases/securitygroupsdetectremediate.rst
+++ b/docs/source/usecases/securitygroupsdetectremediate.rst
@@ -1,0 +1,60 @@
+.. _securitygroupsdetectremediate:
+
+Security Groups - Detect and Remediate Violations
+=================================================
+
+The following example policy will automatically create a CloudWatch Event Rule
+triggered Lambda function in your account and region which will be triggered
+anytime a user creates or modifies a security group. This provides auto-remediation
+and near real-time action (typically within a minute) of the security group change.
+By notifying the customer who tried to perform the action it helps drive user
+behaviour and lets them know why the security group keeps reverting their 0.0.0.0/0
+rule additions on them!
+
+.. code-block:: yaml
+
+   policies:
+     - name: high-risk-security-groups-remediate
+       resource: security-group
+       description: |
+         Remove any rule from a security group that allows 0.0.0.0/0 ingress
+         and notify the user  who added the violating rule.
+       mode:
+           type: cloudtrail
+           events:
+             - source: ec2.amazonaws.com
+               event: AuthorizeSecurityGroupIngress
+               ids: "requestParameters.groupId"
+             - source: ec2.amazonaws.com
+               event: AuthorizeSecurityGroupEgress
+               ids: "requestParameters.groupId"
+             - source: ec2.amazonaws.com
+               event: RevokeSecurityGroupEgress
+               ids: "requestParameters.groupId"
+             - source: ec2.amazonaws.com
+               event: RevokeSecurityGroupIngress
+               ids: "requestParameters.groupId"
+       filters:
+         - type: ingress
+           Cidr:
+               value: "0.0.0.0/0"
+       actions:
+           - type: remove-permissions
+             ingress: matched
+           - type: notify
+             template: default.html
+             priority_header: 1
+             subject: "Open Security Group Rule Created-[custodian {{ account }} - {{ region }}]"
+             violation_desc: "Security Group(s) Which Had Rules Open To The World:"
+             action_desc: |
+                 "Actions Taken:  The Violating Security Group Rule Has Been Removed As It
+                 Violates Our Company's Cloud Policy.  Please Refer To The Cloud FAQ."
+             to:
+                 - CloudCustodian@Company.com
+                 - event-owner
+             transport:
+                 type: sqs
+                 queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
+                 region: us-east-1
+
+Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/securitygroupsdetectremediate.rst
+++ b/docs/source/usecases/securitygroupsdetectremediate.rst
@@ -7,6 +7,7 @@ The following example policy will automatically create a CloudWatch Event Rule
 triggered Lambda function in your account and region which will be triggered
 anytime a user creates or modifies a security group. This provides near real-time
 auto-remediation action (typically within a minute) of the security group change.
+Having such a quick auto-remediation action greatly reduces any attack window!
 By notifying the customer who tried to perform the action it helps drive user
 behaviour and lets them know why the security group keeps reverting their 0.0.0.0/0
 rule additions on them!
@@ -57,4 +58,11 @@ rule additions on them!
                  queue: https://sqs.us-east-1.amazonaws.com/12345678900/cloud-custodian-mailer
                  region: us-east-1
 
+By including ``- event-owner`` in the notify's to: field it tells Cloud Custodian
+to extract the id of the user who made the API call for the event and email them.
+Being that the above policy runs in a cloudtrail mode the API call's metadata event
+is present which is why the example uses event-owner.  If you were to remove the ``mode:``
+statement on the example policy and run it in a poll mode instead you could change
+``- event-owner`` to ``- resource-owner`` which would rely on the resources tags for
+a id or email to send the notification to as no API event would be available at that time.
 Note that the ``notify`` action requires the cloud custodian mailer tool to be installed.

--- a/docs/source/usecases/tagcompliance.rst
+++ b/docs/source/usecases/tagcompliance.rst
@@ -31,9 +31,10 @@ Report on Tag Compliance
          comment: |
            Report on total count of non compliant instances
          filters:
-           - "tag:Owner": absent
-           - "tag:CostCenter": absent
-           - "tag:Project": absent
+           - or:
+               - "tag:Owner": absent
+               - "tag:CostCenter": absent
+               - "tag:Project": absent
 
 
 Enforce Tag Compliance
@@ -52,9 +53,10 @@ Enforce Tag Compliance
        filters:
          - "tag:aws:autoscaling:groupName": absent
          - "tag:c7n_status": absent
-         - "tag:Owner": absent
-         - "tag:CostCenter": absent
-         - "tag:Project": absent
+         - or:
+             - "tag:Owner": absent
+             - "tag:CostCenter": absent
+             - "tag:Project": absent
        actions:
          - type: mark-for-op
            op: stop
@@ -84,11 +86,12 @@ Enforce Tag Compliance
          policies.
        filters:
          - "tag:aws:autoscaling:groupName": absent
-         - "tag:Owner": absent
-         - "tag:CostCenter": absent
-         - "tag:Project": absent
          - type: marked-for-op
            op: stop
+         - or:
+             - "tag:Owner": absent
+             - "tag:CostCenter": absent
+             - "tag:Project": absent
        actions:
          - stop
          - type: mark-for-op
@@ -102,11 +105,12 @@ Enforce Tag Compliance
          by today's date.
        filters:
          - "tag:aws:autoscaling:groupName": absent
-         - "tag:Owner": absent
-         - "tag:CostCenter": absent
-         - "tag:Project": absent
          - type: marked-for-op
            op: terminate
+         - or:
+             - "tag:Owner": absent
+             - "tag:CostCenter": absent
+             - "tag:Project": absent
        actions:
          - type: terminate
            force: true
@@ -118,12 +122,13 @@ Enforce Tag Compliance
          starting 1 day before their termination.
        filters:
          - "tag:aws:autoscaling:groupName": absent
-         - "tag:CostCenter": absent
-         - "tag:Owner": absent
-         - "tag:Project": absent
          - type: marked-for-op
            op: terminate
            skew: 1
+         - or:
+             - "tag:CostCenter": absent
+             - "tag:Owner": absent
+             - "tag:Project": absent
        actions:
          - stop
 


### PR DESCRIPTION
Adding additional policy examples for the Docs use-cases section.  This should help give new users a little more of a jump-start and idea of some of the capabilities of c7n.