### PR TITLE
Add 'set-statements' action for S3 buckets

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -464,13 +464,12 @@ class Notify(EventAction):
         return p
 
     def process(self, resources, event=None):
-        aliases = self.manager.session_factory().client(
-            'iam').list_account_aliases().get('AccountAliases', ())
-        account_name = aliases and aliases[0] or ''
+        alias = utils.get_account_alias_from_sts(
+            utils.local_session(self.manager.session_factory))
         message = {
             'event': event,
             'account_id': self.manager.config.account_id,
-            'account': account_name,
+            'account': alias,
             'region': self.manager.config.region,
             'policy': self.manager.data}
         message['action'] = self.expand_variables(message)

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -219,6 +219,12 @@ def get_account_id_from_sts(session):
     return response.get('Account')
 
 
+def get_account_alias_from_sts(session):
+    response = session.client('iam').list_account_aliases()
+    aliases = response.get('AccountAliases', ())
+    return aliases and aliases[0] or ''
+
+
 def query_instances(session, client=None, **query):
     """Return a list of ec2 instances for the query.
     """
@@ -461,3 +467,24 @@ def get_profile_session(options):
     profile = getattr(options, 'profile', None)
     _profile_session = boto3.Session(profile_name=profile)
     return _profile_session
+
+
+def format_string_values(obj, *args, **kwargs):
+    """
+    Format all string values in an object.
+    Return the updated object
+    """
+    if isinstance(obj, dict):
+        new = {}
+        for key in obj.keys():
+            new[key] = format_string_values(obj[key], *args, **kwargs)
+        return new
+    elif isinstance(obj, list):
+        new = []
+        for item in obj:
+            new.append(format_string_values(item, *args, **kwargs))
+        return new
+    elif isinstance(obj, six.string_types):
+        return obj.format(*args, **kwargs)
+    else:
+        return obj

--- a/tests/data/placebo/test_s3_policy_statements/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_s3_policy_statements/iam.ListAccountAliases_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cf1d538f-d426-11e6-aa54-495189d818bc", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cf1d538f-d426-11e6-aa54-495189d818bc", 
+                "date": "Fri, 06 Jan 2017 15:43:02 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_policy_statements/s3.CreateBucket_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-test-data", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "eNbmqTw2a9k+2Ub3mJU71p8jgZ+vC+gyWCqzMRYglcM4J+/sOubzAY7WJyVdl3EUCoThIcYPz0s=", 
+            "RequestId": "3415E4693C23948D", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "eNbmqTw2a9k+2Ub3mJU71p8jgZ+vC+gyWCqzMRYglcM4J+/sOubzAY7WJyVdl3EUCoThIcYPz0s=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "3415E4693C23948D", 
+                "location": "/custodian-test-data", 
+                "date": "Fri, 26 May 2017 10:08:53 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_policy_statements/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "avdgCPwqhOXXxGlBruGCM0ilGsHR+U4QlF9nQ1xbFp65uYYXx/vWKoIPE0YED0V0znodyL4WcLQ=", 
+            "RequestId": "C37F96B59F0BBA09", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "avdgCPwqhOXXxGlBruGCM0ilGsHR+U4QlF9nQ1xbFp65uYYXx/vWKoIPE0YED0V0znodyL4WcLQ=", 
+                "date": "Fri, 26 May 2017 10:08:57 GMT", 
+                "x-amz-request-id": "C37F96B59F0BBA09", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements/s3.GetBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_policy_statements/s3.GetBucketPolicy_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"CustodianTest\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::custodian-test-data/*\",\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"true\"}}}]}",
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "HostId": "1Rq9CYkzRw13z+nNcPXScbwhIwws5pStt1y23ja/ezc1EzMXgLnyURepJV2PFyBGoOM/QYId5yw=",
+            "RequestId": "476030C476C830D0"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_policy_statements/s3.ListBuckets_1.json
@@ -1,0 +1,103 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 26, 
+                    "minute": 8
+                }, 
+                "Name": "custodian-inv"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 27, 
+                    "minute": 14
+                }, 
+                "Name": "custodian-log-archive"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 18
+                }, 
+                "Name": "custodian-skunk-billing"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 8, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 50
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 26, 
+                    "minute": 8
+                }, 
+                "Name": "custodian-test-data"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "xVB7b0mWfEkjOETl+fLKnN4Ea4H7ley1maCkmU95CoiDBx3ga/Nh0AJkOPH9FXcMTDRfGSEeAoY=", 
+            "RequestId": "58F380792274FB2D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "xVB7b0mWfEkjOETl+fLKnN4Ea4H7ley1maCkmU95CoiDBx3ga/Nh0AJkOPH9FXcMTDRfGSEeAoY=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "58F380792274FB2D", 
+                "date": "Fri, 26 May 2017 10:08:54 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements/s3.PutBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_policy_statements/s3.PutBucketPolicy_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "2xRb4GQ6RzbdwCW53WpTDe05TkTe8evhJ2gcYAIOZJgu/bsV08ElrVgNWPTMcjKbY/qdpX0K5ys=", 
+            "RequestId": "DD252336B88E6FD4"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements_no_change/iam.ListAccountAliases_1.json
+++ b/tests/data/placebo/test_s3_policy_statements_no_change/iam.ListAccountAliases_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccountAliases": [
+            "custodian-skunk-works"
+        ], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "cf1d538f-d426-11e6-aa54-495189d818bc", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "cf1d538f-d426-11e6-aa54-495189d818bc", 
+                "date": "Fri, 06 Jan 2017 15:43:02 GMT", 
+                "content-length": "400", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements_no_change/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_policy_statements_no_change/s3.CreateBucket_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-test-data", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "eNbmqTw2a9k+2Ub3mJU71p8jgZ+vC+gyWCqzMRYglcM4J+/sOubzAY7WJyVdl3EUCoThIcYPz0s=", 
+            "RequestId": "3415E4693C23948D", 
+            "HTTPHeaders": {
+                "content-length": "0", 
+                "x-amz-id-2": "eNbmqTw2a9k+2Ub3mJU71p8jgZ+vC+gyWCqzMRYglcM4J+/sOubzAY7WJyVdl3EUCoThIcYPz0s=", 
+                "server": "AmazonS3", 
+                "x-amz-request-id": "3415E4693C23948D", 
+                "location": "/custodian-test-data", 
+                "date": "Fri, 26 May 2017 10:08:53 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements_no_change/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_policy_statements_no_change/s3.DeleteBucket_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "RetryAttempts": 0, 
+            "HostId": "avdgCPwqhOXXxGlBruGCM0ilGsHR+U4QlF9nQ1xbFp65uYYXx/vWKoIPE0YED0V0znodyL4WcLQ=", 
+            "RequestId": "C37F96B59F0BBA09", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "avdgCPwqhOXXxGlBruGCM0ilGsHR+U4QlF9nQ1xbFp65uYYXx/vWKoIPE0YED0V0znodyL4WcLQ=", 
+                "date": "Fri, 26 May 2017 10:08:57 GMT", 
+                "x-amz-request-id": "C37F96B59F0BBA09", 
+                "server": "AmazonS3"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements_no_change/s3.GetBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_policy_statements_no_change/s3.GetBucketPolicy_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200,
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"CustodianTest\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:GetObject\",\"Resource\":\"arn:aws:s3:::custodian-test-data/*\",\"Condition\":{\"Bool\":{\"aws:SecureTransport\":\"true\"}}}]}",
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200,
+            "HostId": "1Rq9CYkzRw13z+nNcPXScbwhIwws5pStt1y23ja/ezc1EzMXgLnyURepJV2PFyBGoOM/QYId5yw=",
+            "RequestId": "476030C476C830D0"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_policy_statements_no_change/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_policy_statements_no_change/s3.ListBuckets_1.json
@@ -1,0 +1,103 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "mandeep.bal", 
+            "ID": "e7c8bb65a5fc49cf906715eae09de9e4bb7861a96361ba79b833aa45f6833b15"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 14, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 38
+                }, 
+                "Name": "config-bucket-644160558196"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 26, 
+                    "minute": 8
+                }, 
+                "Name": "custodian-inv"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 4, 
+                    "second": 38, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 27, 
+                    "minute": 14
+                }, 
+                "Name": "custodian-log-archive"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 21, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 20, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 6, 
+                    "minute": 18
+                }, 
+                "Name": "custodian-skunk-billing"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 8, 
+                    "__class__": "datetime", 
+                    "month": 7, 
+                    "second": 21, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 24, 
+                    "minute": 50
+                }, 
+                "Name": "custodian-skunk-trails"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 53, 
+                    "microsecond": 0, 
+                    "year": 2017, 
+                    "day": 26, 
+                    "minute": 8
+                }, 
+                "Name": "custodian-test-data"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "RetryAttempts": 0, 
+            "HostId": "xVB7b0mWfEkjOETl+fLKnN4Ea4H7ley1maCkmU95CoiDBx3ga/Nh0AJkOPH9FXcMTDRfGSEeAoY=", 
+            "RequestId": "58F380792274FB2D", 
+            "HTTPHeaders": {
+                "x-amz-id-2": "xVB7b0mWfEkjOETl+fLKnN4Ea4H7ley1maCkmU95CoiDBx3ga/Nh0AJkOPH9FXcMTDRfGSEeAoY=", 
+                "server": "AmazonS3", 
+                "transfer-encoding": "chunked", 
+                "x-amz-request-id": "58F380792274FB2D", 
+                "date": "Fri, 26 May 2017 10:08:54 GMT", 
+                "content-type": "application/xml"
+            }
+        }
+    }
+}

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -230,7 +230,7 @@ class UtilTest(unittest.TestCase):
               u'PrefixListIds': [],
               u'UserIdGroupPairs': [{u'GroupId': u'sg-6c7fa917',
                                      u'UserId': u'644160558196'}]}])
-                         
+
     def test_camel_case(self):
         d = {'zebraMoon': [{'instanceId': 123}, 'moon'],
              'color': {'yellow': 1, 'green': 2}}
@@ -338,3 +338,11 @@ class UtilTest(unittest.TestCase):
         json_file = os.path.join(os.path.dirname(__file__), 'data', 'ec2-instance.json')
         data = utils.load_file(json_file)
         self.assertTrue(data['InstanceId'] == 'i-1aebf7c0')
+
+    def test_format_string_values(self):
+        obj = {'Key1': 'Value1', 'Key2': 42, 'Key3': '{xx}', u'Key4': [True, {u'K': u'{yy}'}, '{xx}']}
+        fmt = utils.format_string_values(obj, **{'xx': 'aa', 'yy': 'bb'})
+
+        self.assertEqual(fmt['Key3'], 'aa')
+        self.assertEqual(fmt['Key4'][2], 'aa')
+        self.assertEqual(fmt['Key4'][1]['K'], 'bb')


### PR DESCRIPTION
`set-statements` adds or replaces S3 bucket policy statements based on the statement ID.
We can use a format string syntax to substitute parts of the policy statement, so added the idea of _standard format arguments_ for S3 actions:
* account ID
* policy region
* bucket name
* bucket region

and a new function `format_string_values()` in `utils.py` to recursively format string values in an object.
Fixes https://github.com/capitalone/cloud-custodian/issues/1744.