### PR TITLE
Add a template function for calculating the age from a date

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -21,8 +21,6 @@ import re
 import six
 from botocore.exceptions import ClientError
 from dateutil.parser import parse
-from datetime import datetime
-from dateutil.tz import tzutc
 from concurrent.futures import as_completed
 
 from c7n.actions import (
@@ -318,8 +316,6 @@ class InstanceImageBase(object):
         image = instance.get('c7n:instance-image', None)
         if not image:
             image = instance['c7n:instance-image'] = self.image_map.get(instance['ImageId'], None)
-            image['ImageAge'] = instance['c7n:instance-image']['ImageAge'] = (
-                datetime.now(tz=tzutc()) - parse(image['CreationDate'])).days
         return image
 
     def get_local_image_mapping(self, image_ids):

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -21,6 +21,8 @@ import re
 import six
 from botocore.exceptions import ClientError
 from dateutil.parser import parse
+from datetime import datetime
+from dateutil.tz import tzutc
 from concurrent.futures import as_completed
 
 from c7n.actions import (
@@ -316,6 +318,8 @@ class InstanceImageBase(object):
         image = instance.get('c7n:instance-image', None)
         if not image:
             image = instance['c7n:instance-image'] = self.image_map.get(instance['ImageId'], None)
+            image['ImageAge'] = instance['c7n:instance-image']['ImageAge'] = (
+                datetime.now(tz=tzutc()) - parse(image['CreationDate'])).days
         return image
 
     def get_local_image_mapping(self, image_ids):

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -13,14 +13,14 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-import datetime
 import jinja2
 import json
 import os
 from ruamel import yaml
 
 from dateutil import parser
-from dateutil.tz import gettz
+from dateutil.tz import gettz, tzutc
+from datetime import datetime, timedelta
 
 
 def get_jinja_env():
@@ -28,6 +28,7 @@ def get_jinja_env():
     env.filters['yaml_safe'] = yaml.safe_dump
     env.filters['date_time_format'] = date_time_format
     env.filters['get_date_time_delta'] = get_date_time_delta
+    env.filters['get_date_age'] = get_date_age
     env.globals['format_resource'] = resource_format
     env.globals['format_struct'] = format_struct
     env.globals['get_resource_tag_value'] = get_resource_tag_value
@@ -109,8 +110,10 @@ def date_time_format(utc_str, tz_str='US/Eastern', format='%Y %b %d %H:%M %Z'):
 
 
 def get_date_time_delta(delta):
-    return str(datetime.datetime.now().replace(tzinfo=gettz('UTC')) + datetime.timedelta(delta))
+    return str(datetime.now().replace(tzinfo=gettz('UTC')) + timedelta(delta))
 
+def get_date_age(date):
+    return (datetime.now(tz=tzutc()) - parser.parse(date)).days
 
 def format_struct(evt):
     return json.dumps(evt, indent=2, ensure_ascii=False)


### PR DESCRIPTION
Currently when using `image` and `image-age` filters in `ec2`, we can only get the creation date of the image. 

Calculating the age of the image when augmenting the image detail in the `resources.json` so that we can extract the age directly (Usage like... providing it in the email to resource-owners)

Thanks!