### PR TITLE
S3 lifecycle fixes

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2582,7 +2582,7 @@ class Lifecycle(BucketActionBase):
         s3 = bucket_client(local_session(self.manager.session_factory), bucket)
 
         # Adjust the existing lifecycle by adding/deleting/overwriting rules as necessary
-        config = (bucket['Lifecycle'] or {}).get('Rules', [])
+        config = (bucket.get('Lifecycle') or {}).get('Rules', [])
         for rule in self.data['rules']:
             for index, existing_rule in enumerate(config):
                 if rule['ID'] == existing_rule['ID']:

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2498,7 +2498,7 @@ class Lifecycle(BucketActionBase):
                                 'And': {
                                     'type': 'object',
                                     'additionalProperties': False,
-                                    'items': {
+                                    'properties': {
                                         'Prefix': {'type': 'string'},
                                         'Tags': {
                                             'type': 'array',
@@ -2506,7 +2506,7 @@ class Lifecycle(BucketActionBase):
                                                 'type': 'object',
                                                 'required': ['Key', 'Value'],
                                                 'additionalProperties': False,
-                                                'items': {
+                                                'properties': {
                                                     'Key': {'type': 'string'},
                                                     'Value': {'type': 'string'},
                                                 },
@@ -2542,14 +2542,14 @@ class Lifecycle(BucketActionBase):
                         'NoncurrentVersionExpiration': {
                             'type': 'object',
                             'additionalProperties': False,
-                            'items': {
+                            'properties': {
                                 'NoncurrentDays': {'type': 'integer'},
                             },
                         },
                         'AbortIncompleteMultipartUpload': {
                             'type': 'object',
                             'additionalProperties': False,
-                            'items': {
+                            'properties': {
                                 'DaysAfterInitiation': {'type': 'integer'},
                             },
                         },

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2581,6 +2581,10 @@ class Lifecycle(BucketActionBase):
     def process_bucket(self, bucket):
         s3 = bucket_client(local_session(self.manager.session_factory), bucket)
 
+        if 'get_bucket_lifecycle_configuration' in bucket.get('c7n:DeniedMethods', []):
+            log.warning("Access Denied Bucket:%s while reading lifecycle" % bucket['Name'])
+            return
+
         # Adjust the existing lifecycle by adding/deleting/overwriting rules as necessary
         config = (bucket.get('Lifecycle') or {}).get('Rules', [])
         for rule in self.data['rules']:


### PR DESCRIPTION
@kapilt - @jtroberts83 helped me fix two issues with the S3 lifecycle code.  One question inline.

1) I was using `items` instead of `properties` for four of the objects.  This PR fixes it.
2) When the user did not have permission to get or put a lifecycle for a bucket it would crash the entire run.  I hardened it to log a warning and skip these ones.

Issue #1830 


