### PR TITLE
adding tag functionality to elasticsearch

### DIFF
--- a/tests/data/placebo/test_elasticsearch_add_tag/es.AddTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_add_tag/es.AddTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "44445dec-d515-11e7-a8bf-13a0b36337cb", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "44445dec-d515-11e7-a8bf-13a0b36337cb", 
+                "date": "Wed, 29 Nov 2017 14:54:57 GMT", 
+                "content-length": "0", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_add_tag/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_add_tag/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,57 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatusList": [
+            {
+                "ElasticsearchClusterConfig": {
+                    "DedicatedMasterEnabled": false, 
+                    "InstanceCount": 1, 
+                    "ZoneAwarenessEnabled": false, 
+                    "InstanceType": "t2.small.elasticsearch"
+                }, 
+                "DomainId": "644160558196/c7n-test", 
+                "VPCOptions": {
+                    "SubnetIds": [
+                        "subnet-3a334610"
+                    ], 
+                    "VPCId": "vpc-d2d616b5", 
+                    "SecurityGroupIds": [
+                        "sg-6c7fa917"
+                    ], 
+                    "AvailabilityZones": [
+                        "us-east-1d"
+                    ]
+                }, 
+                "Created": true, 
+                "Deleted": false, 
+                "EBSOptions": {
+                    "VolumeSize": 10, 
+                    "VolumeType": "gp2", 
+                    "EBSEnabled": true
+                }, 
+                "Processing": true, 
+                "DomainName": "c7n-test", 
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 0
+                }, 
+                "ElasticsearchVersion": "5.5", 
+                "AccessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/c7n-test/*\"}]}", 
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true"
+                }, 
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/c7n-test"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "43e881df-d515-11e7-a08a-8587e9f249da", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "43e881df-d515-11e7-a08a-8587e9f249da", 
+                "date": "Wed, 29 Nov 2017 14:54:56 GMT", 
+                "content-length": "1118", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_add_tag/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_add_tag/es.ListDomainNames_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "43a8936a-d515-11e7-8638-c37bee1d5a2c", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "43a8936a-d515-11e7-8638-c37bee1d5a2c", 
+                "date": "Wed, 29 Nov 2017 14:54:56 GMT", 
+                "content-length": "43", 
+                "content-type": "application/json"
+            }
+        }, 
+        "DomainNames": [
+            {
+                "DomainName": "c7n-test"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_add_tag/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_add_tag/es.ListTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "43ff3e17-d515-11e7-ba78-a5133c12b219", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "43ff3e17-d515-11e7-ba78-a5133c12b219", 
+                "date": "Wed, 29 Nov 2017 14:54:56 GMT", 
+                "content-length": "14", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_add_tag/es.ListTags_2.json
+++ b/tests/data/placebo/test_elasticsearch_add_tag/es.ListTags_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "449c1ae8-d515-11e7-82a3-a7fc6ecf510b", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "449c1ae8-d515-11e7-82a3-a7fc6ecf510b", 
+                "date": "Wed, 29 Nov 2017 14:54:57 GMT", 
+                "content-length": "47", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "MyValue", 
+                "Key": "MyTag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markedforop/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_markedforop/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,57 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatusList": [
+            {
+                "ElasticsearchClusterConfig": {
+                    "DedicatedMasterEnabled": false, 
+                    "InstanceCount": 1, 
+                    "ZoneAwarenessEnabled": false, 
+                    "InstanceType": "t2.small.elasticsearch"
+                }, 
+                "DomainId": "644160558196/c7n-test", 
+                "VPCOptions": {
+                    "SubnetIds": [
+                        "subnet-3a334610"
+                    ], 
+                    "VPCId": "vpc-d2d616b5", 
+                    "SecurityGroupIds": [
+                        "sg-6c7fa917"
+                    ], 
+                    "AvailabilityZones": [
+                        "us-east-1d"
+                    ]
+                }, 
+                "Created": true, 
+                "Deleted": false, 
+                "EBSOptions": {
+                    "VolumeSize": 10, 
+                    "VolumeType": "gp2", 
+                    "EBSEnabled": true
+                }, 
+                "Processing": false, 
+                "DomainName": "c7n-test", 
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 0
+                }, 
+                "ElasticsearchVersion": "5.5", 
+                "AccessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/c7n-test/*\"}]}", 
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true"
+                }, 
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/c7n-test"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6eb55b9d-d518-11e7-95fa-41b9ecc7b94b", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6eb55b9d-d518-11e7-95fa-41b9ecc7b94b", 
+                "date": "Wed, 29 Nov 2017 15:17:37 GMT", 
+                "content-length": "1119", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markedforop/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_markedforop/es.ListDomainNames_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6e58bcb9-d518-11e7-80db-8ddc92db4711", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6e58bcb9-d518-11e7-80db-8ddc92db4711", 
+                "date": "Wed, 29 Nov 2017 15:17:35 GMT", 
+                "content-length": "43", 
+                "content-type": "application/json"
+            }
+        }, 
+        "DomainNames": [
+            {
+                "DomainName": "c7n-test"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markedforop/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_markedforop/es.ListTags_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6ecbca29-d518-11e7-9acd-e5eb5b6138fe", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6ecbca29-d518-11e7-9acd-e5eb5b6138fe", 
+                "date": "Wed, 29 Nov 2017 15:17:37 GMT", 
+                "content-length": "103", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Resource does not meet policy: delete@2017/11/30", 
+                "Key": "es_custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markforop/es.AddTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_markforop/es.AddTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f76365c5-d517-11e7-9dc4-83abc52f7805", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f76365c5-d517-11e7-9dc4-83abc52f7805", 
+                "date": "Wed, 29 Nov 2017 15:14:16 GMT", 
+                "content-length": "0", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markforop/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_markforop/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,57 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatusList": [
+            {
+                "ElasticsearchClusterConfig": {
+                    "DedicatedMasterEnabled": false, 
+                    "InstanceCount": 1, 
+                    "ZoneAwarenessEnabled": false, 
+                    "InstanceType": "t2.small.elasticsearch"
+                }, 
+                "DomainId": "644160558196/c7n-test", 
+                "VPCOptions": {
+                    "SubnetIds": [
+                        "subnet-3a334610"
+                    ], 
+                    "VPCId": "vpc-d2d616b5", 
+                    "SecurityGroupIds": [
+                        "sg-6c7fa917"
+                    ], 
+                    "AvailabilityZones": [
+                        "us-east-1d"
+                    ]
+                }, 
+                "Created": true, 
+                "Deleted": false, 
+                "EBSOptions": {
+                    "VolumeSize": 10, 
+                    "VolumeType": "gp2", 
+                    "EBSEnabled": true
+                }, 
+                "Processing": true, 
+                "DomainName": "c7n-test", 
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 0
+                }, 
+                "ElasticsearchVersion": "5.5", 
+                "AccessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/c7n-test/*\"}]}", 
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true"
+                }, 
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/c7n-test"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f6e81be6-d517-11e7-ba7e-11e869b13741", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f6e81be6-d517-11e7-ba7e-11e869b13741", 
+                "date": "Wed, 29 Nov 2017 15:14:16 GMT", 
+                "content-length": "1118", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markforop/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_markforop/es.ListDomainNames_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f697b17a-d517-11e7-a65b-5562b460f00d", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f697b17a-d517-11e7-a65b-5562b460f00d", 
+                "date": "Wed, 29 Nov 2017 15:14:14 GMT", 
+                "content-length": "43", 
+                "content-type": "application/json"
+            }
+        }, 
+        "DomainNames": [
+            {
+                "DomainName": "c7n-test"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markforop/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_markforop/es.ListTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f7073c20-d517-11e7-a6f4-e591b8b2f4a6", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f7073c20-d517-11e7-a6f4-e591b8b2f4a6", 
+                "date": "Wed, 29 Nov 2017 15:14:15 GMT", 
+                "content-length": "14", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_markforop/es.ListTags_2.json
+++ b/tests/data/placebo/test_elasticsearch_markforop/es.ListTags_2.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f7c1b324-d517-11e7-8f39-3758e481c5a9", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "f7c1b324-d517-11e7-8f39-3758e481c5a9", 
+                "date": "Wed, 29 Nov 2017 15:14:17 GMT", 
+                "content-length": "103", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Resource does not meet policy: delete@2017/11/30", 
+                "Key": "es_custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_tag/es.DescribeElasticsearchDomains_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_tag/es.DescribeElasticsearchDomains_1.json
@@ -1,0 +1,57 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DomainStatusList": [
+            {
+                "ElasticsearchClusterConfig": {
+                    "DedicatedMasterEnabled": false, 
+                    "InstanceCount": 1, 
+                    "ZoneAwarenessEnabled": false, 
+                    "InstanceType": "t2.small.elasticsearch"
+                }, 
+                "DomainId": "644160558196/c7n-test", 
+                "VPCOptions": {
+                    "SubnetIds": [
+                        "subnet-3a334610"
+                    ], 
+                    "VPCId": "vpc-d2d616b5", 
+                    "SecurityGroupIds": [
+                        "sg-6c7fa917"
+                    ], 
+                    "AvailabilityZones": [
+                        "us-east-1d"
+                    ]
+                }, 
+                "Created": true, 
+                "Deleted": false, 
+                "EBSOptions": {
+                    "VolumeSize": 10, 
+                    "VolumeType": "gp2", 
+                    "EBSEnabled": true
+                }, 
+                "Processing": true, 
+                "DomainName": "c7n-test", 
+                "SnapshotOptions": {
+                    "AutomatedSnapshotStartHour": 0
+                }, 
+                "ElasticsearchVersion": "5.5", 
+                "AccessPolicies": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Effect\":\"Allow\",\"Principal\":{\"AWS\":\"arn:aws:iam::644160558196:root\"},\"Action\":\"es:*\",\"Resource\":\"arn:aws:es:us-east-1:644160558196:domain/c7n-test/*\"}]}", 
+                "AdvancedOptions": {
+                    "rest.action.multi.allow_explicit_index": "true"
+                }, 
+                "ARN": "arn:aws:es:us-east-1:644160558196:domain/c7n-test"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "453ffc38-d515-11e7-a6b7-53431c2e5165", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "453ffc38-d515-11e7-a6b7-53431c2e5165", 
+                "date": "Wed, 29 Nov 2017 14:54:59 GMT", 
+                "content-length": "1118", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_tag/es.ListDomainNames_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_tag/es.ListDomainNames_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4500d02b-d515-11e7-a8bf-13a0b36337cb", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "4500d02b-d515-11e7-a8bf-13a0b36337cb", 
+                "date": "Wed, 29 Nov 2017 14:54:58 GMT", 
+                "content-length": "43", 
+                "content-type": "application/json"
+            }
+        }, 
+        "DomainNames": [
+            {
+                "DomainName": "c7n-test"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_tag/es.ListTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_tag/es.ListTags_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "455cd29f-d515-11e7-8fed-d52e8a23b7ff", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "455cd29f-d515-11e7-8fed-d52e8a23b7ff", 
+                "date": "Wed, 29 Nov 2017 14:54:59 GMT", 
+                "content-length": "47", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "MyValue", 
+                "Key": "MyTag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_tag/es.ListTags_2.json
+++ b/tests/data/placebo/test_elasticsearch_remove_tag/es.ListTags_2.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "45f08794-d515-11e7-a6b7-53431c2e5165", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "45f08794-d515-11e7-a6b7-53431c2e5165", 
+                "date": "Wed, 29 Nov 2017 14:55:00 GMT", 
+                "content-length": "14", 
+                "content-type": "application/json"
+            }
+        }, 
+        "TagList": []
+    }
+}

--- a/tests/data/placebo/test_elasticsearch_remove_tag/es.RemoveTags_1.json
+++ b/tests/data/placebo/test_elasticsearch_remove_tag/es.RemoveTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "45a21973-d515-11e7-9c02-e35cb3edc87d", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "45a21973-d515-11e7-9c02-e35cb3edc87d", 
+                "date": "Wed, 29 Nov 2017 14:54:59 GMT", 
+                "content-length": "0", 
+                "content-type": "application/json"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Per #1671 AWS now supports tagging of the ElasticSearch Domain resource. Extending functionality to Custodian.

- adding 'tag', 'remove-tag', 'mark-for-op' actions
- adding 'marked-for-op' filter
- adding unittests