### PR TITLE
Include botocore in lambda package

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -232,15 +232,17 @@ def custodian_archive(packages=None):
     Lambda archive currently always includes c7n, pkg_resources and ipaddress. Add additional
     packages in the mode block
 
-    Exmaple:
+    :example:
 
-        policy:
-          name: lambda-archive-example
-          resource: s3
-          mode:
-            - packages:
-              - boto3
-              - botocore
+        .. code-block: yaml
+
+            policy:
+              name: lambda-archive-example
+              resource: s3
+              mode:
+                - packages:
+                  - boto3
+                  - botocore
 
     Args:
         packages (set, optional): List of additional packages to include in the lambda archive.

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -228,7 +228,7 @@ def checksum(fh, hasher, blocksize=65536):
 
 def custodian_archive():
     """Create a lambda code archive for running custodian."""
-    return PythonPackageArchive('c7n', 'pkg_resources', 'ipaddress')
+    return PythonPackageArchive('c7n', 'pkg_resources', 'ipaddress', 'botocore')
 
 
 class LambdaManager(object):

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -231,7 +231,7 @@ def custodian_archive(*args):
     modules = filter(None, ('c7n', 'pkg_resources', 'ipaddress') + args)
     # remove duplicates
     modules = tuple(set(modules))
-    return PythonPackageArchive(modules)
+    return PythonPackageArchive(*modules)
 
 
 class LambdaManager(object):
@@ -660,7 +660,7 @@ class PolicyLambda(AbstractLambdaFunction):
 
     def __init__(self, policy):
         self.policy = policy
-        self.archive = custodian_archive(self.packages)
+        self.archive = custodian_archive(*self.packages)
 
     @property
     def name(self):

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -229,23 +229,23 @@ def checksum(fh, hasher, blocksize=65536):
 def custodian_archive(packages=None):
     """Create a lambda code archive for running custodian.
 
-    Lambda archive currently always includes c7n, pkg_resources and ipaddress. Add additional
+    Lambda archive currently always includes `c7n, pkg_resources and ipaddress`. Add additional
     packages in the mode block
 
-    :example:
+    Example policy that includes additional packages
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
-            policy:
-              name: lambda-archive-example
-              resource: s3
-              mode:
-                - packages:
-                  - boto3
-                  - botocore
+        policy:
+          name: lambda-archive-example
+          resource: s3
+          mode:
+            - packages:
+              - boto3
+              - botocore
 
-    Args:
-        packages (set, optional): List of additional packages to include in the lambda archive.
+    Kwargs:
+        packages (set): List of additional packages to include in the lambda archive.
     """
     modules = {'c7n', 'pkg_resources', 'ipaddress'}
     if packages:

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -521,6 +521,21 @@ class PolicyLambdaProvision(BaseTest):
         tags = mgr.client.list_tags(Resource=result['FunctionArn'])['Tags']
         self.assert_items(tags, {'Foo': 'Baz', 'Bah': 'Bug'})
 
+    def test_optional_packages(self):
+        p = Policy({
+            'resources': 's3',
+            'name': 's3-lambda-extra',
+            'resource': 's3',
+            'mode': {
+                'type': 'cloudtrail',
+                'packages': ['boto3', 'botocore'],
+                'events': ['CreateBucket'],
+                }}, Config.empty())
+        pl = PolicyLambda(p)
+        pl.archive.close()
+        self.assertTrue('boto3/utils.py' in pl.archive.get_filenames())
+        self.assertTrue('botocore/utils.py' in pl.archive.get_filenames())
+
 
 class PythonArchiveTest(unittest.TestCase):
 


### PR DESCRIPTION
Lambda functions include boto3, but are not always up-to-date.  Current lambda botocore is 1.7.37 and does not include bucket encryption functions.  Until they can update botocore supplied to lambda, we will have to ship with botocore