### PR TITLE
Add tagging actions/filters for datapipeline

### DIFF
--- a/c7n/resources/datapipeline.py
+++ b/c7n/resources/datapipeline.py
@@ -18,15 +18,23 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from botocore.exceptions import ClientError
 
 from c7n.actions import BaseAction
+from c7n.filters import FilterRegistry
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
 from c7n.utils import chunks, local_session, get_retry, type_schema
+from c7n.tags import RemoveTag, Tag, TagActionFilter, TagDelayedAction
+
+
+filters = FilterRegistry('datapipeline.filters')
+filters.register('marked-for-op', TagActionFilter)
 
 
 @resources.register('datapipeline')
 class DataPipeline(QueryResourceManager):
 
     retry = staticmethod(get_retry(('Throttled',)))
+
+    filter_registry = filters
 
     class resource_type(object):
         service = 'datapipeline'
@@ -115,3 +123,103 @@ class Delete(BaseAction):
         except ClientError as e:
             self.log.exception(
                 "Exception deleting pipeline:\n %s" % e)
+
+
+@DataPipeline.action_registry.register('mark-for-op')
+class MarkForOpPipeline(TagDelayedAction):
+    """Action to specify an action to occur at a later date
+    :example:
+        .. code-block: yaml
+            policies:
+              - name: pipeline-delete-unused
+                resource: datapipeline
+                filters:
+                  - "tag:custodian_cleanup": absent
+                actions:
+                  - type: mark-for-op
+                    tag: custodian_cleanup
+                    msg: "Unused data pipeline: {op}@{action_date}"
+                    op: delete
+                    days: 7
+    """
+
+    permissions = ('datapipeline:AddTags',)
+
+    def process_resource_set(self, pipelines, tags):
+        client = local_session(self.manager.session_factory).client(
+            'datapipeline')
+        tag_array = []
+        for t in tags:
+            tag_array.append(dict(key=t['Key'], value=t['Value']))
+        for pipeline in pipelines:
+            try:
+                client.add_tags(pipelineId=pipeline['id'], tags=tag_array)
+            except Exception as err:
+                self.log.exception(
+                    'Exception tagging data pipeline %s: %s',
+                    pipeline['id'], err)
+                continue
+
+
+@DataPipeline.action_registry.register('tag')
+class TagPipeline(Tag):
+    """Action to create tag(s) on a pipeline
+    :example:
+        .. code-block: yaml
+            policies:
+              - name: tag-pipeline
+                resource: datapipeline
+                filters:
+                  - "tag:target-tag": absent
+                actions:
+                  - type: tag
+                    key: target-tag
+                    value: target-tag-value
+    """
+
+    permissions = ('datapipeline:AddTags',)
+
+    def process_resource_set(self, pipelines, tags):
+        client = local_session(self.manager.session_factory).client(
+            'datapipeline')
+        tag_array = []
+        for t in tags:
+            tag_array.append(dict(key=t['Key'], value=t['Value']))
+        for pipeline in pipelines:
+            try:
+                client.add_tags(pipelineId=pipeline['id'], tags=tag_array)
+            except Exception as err:
+                self.log.exception(
+                    'Exception tagging data pipeline %s: %s',
+                    pipeline['id'], err)
+                continue
+
+
+@DataPipeline.action_registry.register('remove-tag')
+class UntagPipeline(RemoveTag):
+    """Action to remove tag(s) on a pipeline
+    :example:
+        .. code-block: yaml
+            policies:
+              - name: pipeline-remove-tag
+                resource: datapipeline
+                filters:
+                  - "tag:OutdatedTag": present
+                actions:
+                  - type: remove-tag
+                    tags: ["OutdatedTag"]
+    """
+
+    permissions = ('datapipeline:RemoveTags',)
+
+    def process_resource_set(self, pipelines, tags):
+        client = local_session(self.manager.session_factory).client(
+            'datapipeline')
+        for pipeline in pipelines:
+            try:
+                client.remove_tags(pipelineId=pipeline['id'], tagKeys=tags)
+            except Exception as err:
+                self.log.exception(
+                    'Exception while removing tags from data pipeline %s: %s',
+                    pipeline['id'], err)
+                continue

--- a/c7n/resources/datapipeline.py
+++ b/c7n/resources/datapipeline.py
@@ -128,8 +128,11 @@ class Delete(BaseAction):
 @DataPipeline.action_registry.register('mark-for-op')
 class MarkForOpPipeline(TagDelayedAction):
     """Action to specify an action to occur at a later date
+
     :example:
+
         .. code-block: yaml
+
             policies:
               - name: pipeline-delete-unused
                 resource: datapipeline
@@ -164,7 +167,9 @@ class MarkForOpPipeline(TagDelayedAction):
 @DataPipeline.action_registry.register('tag')
 class TagPipeline(Tag):
     """Action to create tag(s) on a pipeline
+
     :example:
+
         .. code-block: yaml
             policies:
               - name: tag-pipeline
@@ -198,7 +203,9 @@ class TagPipeline(Tag):
 @DataPipeline.action_registry.register('remove-tag')
 class UntagPipeline(RemoveTag):
     """Action to remove tag(s) on a pipeline
+
     :example:
+
         .. code-block: yaml
             policies:
               - name: pipeline-remove-tag

--- a/tests/data/placebo/test_datapipeline_mark/datapipeline.AddTags_1.json
+++ b/tests/data/placebo/test_datapipeline_mark/datapipeline.AddTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ac798972-d7c3-11e7-b1c5-edcc08620081", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ac798972-d7c3-11e7-b1c5-edcc08620081", 
+                "date": "Sun, 03 Dec 2017 00:48:26 GMT", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_mark/datapipeline.CreatePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_mark/datapipeline.CreatePipeline_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "pipelineId": "df-000297435B5JKV2YAUPM", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ab69ee36-d7c3-11e7-acd2-c3e267de0876", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ab69ee36-d7c3-11e7-acd2-c3e267de0876", 
+                "date": "Sun, 03 Dec 2017 00:48:24 GMT", 
+                "content-length": "40", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_mark/datapipeline.DeletePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_mark/datapipeline.DeletePipeline_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "aca1aa92-d7c3-11e7-9ff9-8d66577a71a4", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "aca1aa92-d7c3-11e7-9ff9-8d66577a71a4", 
+                "date": "Sun, 03 Dec 2017 00:48:26 GMT", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_mark/datapipeline.DescribePipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_mark/datapipeline.DescribePipelines_1.json
@@ -1,0 +1,61 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ac29e2bc-d7c3-11e7-996f-137daf66b280", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ac29e2bc-d7c3-11e7-996f-137daf66b280", 
+                "date": "Sun, 03 Dec 2017 00:48:25 GMT", 
+                "content-length": "1361", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "2017-12-03T00:48:25", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PipelineMarkTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "df-000297435B5JKV2YAUPM", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineMarkTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-000297435B5JKV2YAUPM", 
+                "name": "PipelineMarkTest", 
+                "tags": []
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_mark/datapipeline.DescribePipelines_2.json
+++ b/tests/data/placebo/test_datapipeline_mark/datapipeline.DescribePipelines_2.json
@@ -1,0 +1,70 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ac93a115-d7c3-11e7-996f-137daf66b280", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ac93a115-d7c3-11e7-996f-137daf66b280", 
+                "date": "Sun, 03 Dec 2017 00:48:26 GMT", 
+                "content-length": "759", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "[{\"key\":\"custodian_mark\",\"value\":\"marked for op with no date\"}]", 
+                        "key": "*tags"
+                    }, 
+                    {
+                        "stringValue": "2017-12-03T00:48:25", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "PipelineMarkTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "df-000297435B5JKV2YAUPM", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineMarkTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-000297435B5JKV2YAUPM", 
+                "name": "PipelineMarkTest", 
+                "tags": [
+                    {
+                        "value": "marked for op with no date", 
+                        "key": "custodian_mark"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_mark/datapipeline.ListPipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_mark/datapipeline.ListPipelines_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "hasMoreResults": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "abd5f64c-d7c3-11e7-b06c-83d9042a4324", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "abd5f64c-d7c3-11e7-b06c-83d9042a4324", 
+                "date": "Sun, 03 Dec 2017 00:48:25 GMT", 
+                "content-length": "153", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineIdList": [
+            {
+                "id": "df-000297435B5JKV2YAUPM", 
+                "name": "PipelineMarkTest"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.AddTags_1.json
+++ b/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.AddTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "bab0875b-d7d0-11e7-8006-3f69943873aa", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bab0875b-d7d0-11e7-8006-3f69943873aa", 
+                "date": "Sun, 03 Dec 2017 02:21:53 GMT", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.CreatePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.CreatePipeline_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "pipelineId": "df-021691338N7FFWI4078U", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ba8d47e9-d7d0-11e7-8006-3f69943873aa", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ba8d47e9-d7d0-11e7-8006-3f69943873aa", 
+                "date": "Sun, 03 Dec 2017 02:21:53 GMT", 
+                "content-length": "40", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.DeletePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.DeletePipeline_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "bb5bbb87-d7d0-11e7-8006-3f69943873aa", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bb5bbb87-d7d0-11e7-8006-3f69943873aa", 
+                "date": "Sun, 03 Dec 2017 02:21:55 GMT", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.DescribePipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.DescribePipelines_1.json
@@ -1,0 +1,70 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "bb4b410c-d7d0-11e7-89a6-5f4c00ce13c0", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bb4b410c-d7d0-11e7-89a6-5f4c00ce13c0", 
+                "date": "Sun, 03 Dec 2017 02:21:54 GMT", 
+                "content-length": "1368", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "[{\"key\":\"pipeline_marked_for_op\",\"value\":\"Pipeline marked for op: delete@2017-12-01\"}]", 
+                        "key": "*tags"
+                    }, 
+                    {
+                        "stringValue": "2017-12-03T02:21:54", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "PipelineMarkedForOpTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "df-021691338N7FFWI4078U", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineMarkedForOpTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-021691338N7FFWI4078U", 
+                "name": "PipelineMarkedForOpTest", 
+                "tags": [
+                    {
+                        "value": "Pipeline marked for op: delete@2017-12-01", 
+                        "key": "pipeline_marked_for_op"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.ListPipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_marked_for_op/datapipeline.ListPipelines_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "hasMoreResults": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "bb05d3d0-d7d0-11e7-bbff-377e75ac842e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "bb05d3d0-d7d0-11e7-bbff-377e75ac842e", 
+                "date": "Sun, 03 Dec 2017 02:21:54 GMT", 
+                "content-length": "160", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineIdList": [
+            {
+                "id": "df-021691338N7FFWI4078U", 
+                "name": "PipelineMarkedForOpTest"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.AddTags_1.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.AddTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "617284aa-d7ca-11e7-89a6-5f4c00ce13c0", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "617284aa-d7ca-11e7-89a6-5f4c00ce13c0", 
+                "date": "Sun, 03 Dec 2017 01:36:27 GMT", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.CreatePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.CreatePipeline_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "pipelineId": "df-01485291C0IZAVYM8W6G", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "614c5f70-d7ca-11e7-8ea1-8343288be3db", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "614c5f70-d7ca-11e7-8ea1-8343288be3db", 
+                "date": "Sun, 03 Dec 2017 01:36:26 GMT", 
+                "content-length": "40", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DeletePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DeletePipeline_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "628e06bb-d7ca-11e7-84c6-b3cabb5a47df", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "628e06bb-d7ca-11e7-84c6-b3cabb5a47df", 
+                "date": "Sun, 03 Dec 2017 01:36:29 GMT", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DescribePipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DescribePipelines_1.json
@@ -1,0 +1,70 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6187450e-d7ca-11e7-84c6-b3cabb5a47df", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6187450e-d7ca-11e7-84c6-b3cabb5a47df", 
+                "date": "Sun, 03 Dec 2017 01:36:26 GMT", 
+                "content-length": "764", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "[{\"key\":\"tag_to_remove\",\"value\":\"value of tag to remove\"}]", 
+                        "key": "*tags"
+                    }, 
+                    {
+                        "stringValue": "2017-12-03T01:36:27", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "PipelineRemoveTagTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "df-01485291C0IZAVYM8W6G", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineRemoveTagTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-01485291C0IZAVYM8W6G", 
+                "name": "PipelineRemoveTagTest", 
+                "tags": [
+                    {
+                        "value": "value of tag to remove", 
+                        "key": "tag_to_remove"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DescribePipelines_2.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DescribePipelines_2.json
@@ -1,0 +1,70 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "621bbd6d-d7ca-11e7-8ea1-8343288be3db", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "621bbd6d-d7ca-11e7-8ea1-8343288be3db", 
+                "date": "Sun, 03 Dec 2017 01:36:27 GMT", 
+                "content-length": "1306", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "[{\"key\":\"tag_to_remove\",\"value\":\"value of tag to remove\"}]", 
+                        "key": "*tags"
+                    }, 
+                    {
+                        "stringValue": "2017-12-03T01:36:27", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "PipelineRemoveTagTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "df-01485291C0IZAVYM8W6G", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineRemoveTagTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-01485291C0IZAVYM8W6G", 
+                "name": "PipelineRemoveTagTest", 
+                "tags": [
+                    {
+                        "value": "value of tag to remove", 
+                        "key": "tag_to_remove"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DescribePipelines_3.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.DescribePipelines_3.json
@@ -1,0 +1,61 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "627f12b1-d7ca-11e7-b1a8-c395ccc17e78", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "627f12b1-d7ca-11e7-b1a8-c395ccc17e78", 
+                "date": "Sun, 03 Dec 2017 01:36:29 GMT", 
+                "content-length": "609", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "2017-12-03T01:36:27", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PipelineRemoveTagTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "df-01485291C0IZAVYM8W6G", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineRemoveTagTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-01485291C0IZAVYM8W6G", 
+                "name": "PipelineRemoveTagTest", 
+                "tags": []
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.ListPipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.ListPipelines_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "hasMoreResults": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "61d64ff7-d7ca-11e7-8ea1-8343288be3db", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "61d64ff7-d7ca-11e7-8ea1-8343288be3db", 
+                "date": "Sun, 03 Dec 2017 01:36:27 GMT", 
+                "content-length": "158", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineIdList": [
+            {
+                "id": "df-01485291C0IZAVYM8W6G", 
+                "name": "PipelineRemoveTagTest"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.RemoveTags_1.json
+++ b/tests/data/placebo/test_datapipeline_remove_tag/datapipeline.RemoveTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6265220b-d7ca-11e7-b1a8-c395ccc17e78", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "6265220b-d7ca-11e7-b1a8-c395ccc17e78", 
+                "date": "Sun, 03 Dec 2017 01:36:29 GMT", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_tag/datapipeline.AddTags_1.json
+++ b/tests/data/placebo/test_datapipeline_tag/datapipeline.AddTags_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e5513ee4-d492-11e7-ac2a-c7eaf452e561", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "e5513ee4-d492-11e7-ac2a-c7eaf452e561", 
+                "date": "Tue, 28 Nov 2017 23:21:43 GMT", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_tag/datapipeline.CreatePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_tag/datapipeline.CreatePipeline_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "pipelineId": "df-0881198RSZJ5SK6MJDH", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e38dbce4-d492-11e7-ac2a-c7eaf452e561", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "e38dbce4-d492-11e7-ac2a-c7eaf452e561", 
+                "date": "Tue, 28 Nov 2017 23:21:39 GMT", 
+                "content-length": "39", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_tag/datapipeline.DeletePipeline_1.json
+++ b/tests/data/placebo/test_datapipeline_tag/datapipeline.DeletePipeline_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e57fc874-d492-11e7-af23-613c345b2053", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "e57fc874-d492-11e7-af23-613c345b2053", 
+                "date": "Tue, 28 Nov 2017 23:21:43 GMT", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_datapipeline_tag/datapipeline.DescribePipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_tag/datapipeline.DescribePipelines_1.json
@@ -1,0 +1,61 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e4f0a895-d492-11e7-b1c5-edcc08620081", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "e4f0a895-d492-11e7-b1c5-edcc08620081", 
+                "date": "Tue, 28 Nov 2017 23:21:42 GMT", 
+                "content-length": "1230", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "2017-11-28T23:21:40", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PipelineTagTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "df-0881198RSZJ5SK6MJDH", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineTagTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-0881198RSZJ5SK6MJDH", 
+                "name": "PipelineTagTest", 
+                "tags": []
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_tag/datapipeline.DescribePipelines_2.json
+++ b/tests/data/placebo/test_datapipeline_tag/datapipeline.DescribePipelines_2.json
@@ -1,0 +1,70 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e567ad5a-d492-11e7-b1c5-edcc08620081", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "e567ad5a-d492-11e7-b1c5-edcc08620081", 
+                "date": "Tue, 28 Nov 2017 23:21:43 GMT", 
+                "content-length": "694", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineDescriptionList": [
+            {
+                "fields": [
+                    {
+                        "stringValue": "[{\"key\":\"key1\",\"value\":\"value1\"}]", 
+                        "key": "*tags"
+                    }, 
+                    {
+                        "stringValue": "2017-11-28T23:21:40", 
+                        "key": "@creationTime"
+                    }, 
+                    {
+                        "stringValue": "PIPELINE", 
+                        "key": "@sphere"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "pipelineCreator"
+                    }, 
+                    {
+                        "stringValue": "PipelineTagTest", 
+                        "key": "name"
+                    }, 
+                    {
+                        "stringValue": "df-0881198RSZJ5SK6MJDH", 
+                        "key": "@id"
+                    }, 
+                    {
+                        "stringValue": "PENDING", 
+                        "key": "@pipelineState"
+                    }, 
+                    {
+                        "stringValue": "123456789012", 
+                        "key": "@accountId"
+                    }, 
+                    {
+                        "stringValue": "PipelineTagTest1", 
+                        "key": "uniqueId"
+                    }, 
+                    {
+                        "stringValue": "AIDATHISISTHEAWSUSER1", 
+                        "key": "@userId"
+                    }
+                ], 
+                "pipelineId": "df-0881198RSZJ5SK6MJDH", 
+                "name": "PipelineTagTest", 
+                "tags": [
+                    {
+                        "value": "value1", 
+                        "key": "key1"
+                    }
+                ]
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_datapipeline_tag/datapipeline.ListPipelines_1.json
+++ b/tests/data/placebo/test_datapipeline_tag/datapipeline.ListPipelines_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "hasMoreResults": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e495685d-d492-11e7-b4af-496584dcee7b", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "e495685d-d492-11e7-b4af-496584dcee7b", 
+                "date": "Tue, 28 Nov 2017 23:21:41 GMT", 
+                "content-length": "150", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "pipelineIdList": [
+            {
+                "id": "df-0881198RSZJ5SK6MJDH", 
+                "name": "PipelineTagTest"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
Per [#1671](https://github.com/capitalone/cloud-custodian/issues/1671) AWS now supports tagging of the Data Pipeline resource. Extending functionality to Custodian.

- adding 'tag', 'remove-tag', 'mark-for-op' actions
- adding 'marked-for-op' filter
- adding unittests