### PR TITLE
Fix 'TypeError: expected string or buffer' for S3 'set-statements' action

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,6 +22,5 @@
         "**/*.pyc": true,
         "**/*.pyo": true,
         "**/*.dist-info": true
-    },
-    "python.pythonPath": "${workspaceRoot}/venv/bin/python"
+    }
 }

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -22,5 +22,6 @@
         "**/*.pyc": true,
         "**/*.pyo": true,
         "**/*.dist-info": true
-    }
+    },
+    "python.pythonPath": "${workspaceRoot}/venv/bin/python"
 }

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -970,8 +970,7 @@ class SetPolicyStatement(BucketActionBase):
                     'properties': {
                         'Sid': {'type': 'string'},
                         'Effect': {'type': 'string', 'enum': ['Allow', 'Deny']},
-                        'Principal': {'anyOf': [{'type': 'string'},
-                            {'type': 'object'}, {'type': 'array'}]},
+                        'Principal': {'anyOf': [{'type': 'string'}, {'type': 'object'}, {'type': 'array'}]},
                         'NotPrincipal': {'anyOf': [{'type': 'object'}, {'type': 'array'}]},
                         'Action': {'anyOf': [{'type': 'string'}, {'type': 'array'}]},
                         'NotAction': {'anyOf': [{'type': 'string'}, {'type': 'array'}]},

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -996,7 +996,7 @@ class SetPolicyStatement(BucketActionBase):
     )
 
     def process_bucket(self, bucket):
-        policy = bucket['Policy'] or '{}'
+        policy = bucket.get('Policy') or '{}'
 
         fmtargs = self.get_std_format_args(bucket)
 

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -991,7 +991,7 @@ class SetPolicyStatement(BucketActionBase):
     )
 
     def process_bucket(self, bucket):
-        policy = bucket.get('Policy', '{}')
+        policy = bucket['Policy'] or '{}'
 
         fmtargs = self.get_std_format_args(bucket)
 

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -970,7 +970,7 @@ class SetPolicyStatement(BucketActionBase):
                     'properties': {
                         'Sid': {'type': 'string'},
                         'Effect': {'type': 'string', 'enum': ['Allow', 'Deny']},
-                        'Principal': {'anyOf': [{'type': 'object'}, {'type': 'array'}]},
+                        'Principal': {'anyOf': [{'type': 'string'}, {'type': 'object'}, {'type': 'array'}]},
                         'NotPrincipal': {'anyOf': [{'type': 'object'}, {'type': 'array'}]},
                         'Action': {'anyOf': [{'type': 'string'}, {'type': 'array'}]},
                         'NotAction': {'anyOf': [{'type': 'string'}, {'type': 'array'}]},
@@ -980,10 +980,14 @@ class SetPolicyStatement(BucketActionBase):
                     },
                     'required': ['Sid', 'Effect'],
                     'oneOf': [
-                        {'required': ['Action', 'Resource']},
-                        {'required': ['NotAction', 'Resource']},
-                        {'required': ['Action', 'NotResource']},
-                        {'required': ['NotAction', 'NotResource']}
+                        {'required': ['Principal', 'Action', 'Resource']},
+                        {'required': ['NotPrincipal', 'Action', 'Resource']},
+                        {'required': ['Principal', 'NotAction', 'Resource']},
+                        {'required': ['NotPrincipal', 'NotAction', 'Resource']},
+                        {'required': ['Principal', 'Action', 'NotResource']},
+                        {'required': ['NotPrincipal', 'Action', 'NotResource']},
+                        {'required': ['Principal', 'NotAction', 'NotResource']},
+                        {'required': ['NotPrincipal', 'NotAction', 'NotResource']}
                     ]
                 }
             }

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -970,7 +970,8 @@ class SetPolicyStatement(BucketActionBase):
                     'properties': {
                         'Sid': {'type': 'string'},
                         'Effect': {'type': 'string', 'enum': ['Allow', 'Deny']},
-                        'Principal': {'anyOf': [{'type': 'string'}, {'type': 'object'}, {'type': 'array'}]},
+                        'Principal': {'anyOf': [{'type': 'string'},
+                            {'type': 'object'}, {'type': 'array'}]},
                         'NotPrincipal': {'anyOf': [{'type': 'object'}, {'type': 'array'}]},
                         'Action': {'anyOf': [{'type': 'string'}, {'type': 'array'}]},
                         'NotAction': {'anyOf': [{'type': 'string'}, {'type': 'array'}]},

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -742,7 +742,7 @@ class S3ConfigSource(ConfigTest):
         self.assertEqual(
             resource['Website'],
             {'RedirectAllRequestsTo': {'HostName': 'www.google.com/', 'Protocol': 'https'}})
-        
+
     def test_config_normalize_website(self):
         event = event_data('s3-website.json', 'config')
         p = self.load_policy({'name': 's3cfg', 'resource': 's3'})
@@ -838,7 +838,9 @@ class BucketPolicyStatements(BaseTest):
         sid = 'CustodianTest'
 
         self.patch(s3.S3, 'executor_factory', MainThreadExecutor)
-        self.patch(s3, 'S3_AUGMENT_TABLE', [])
+        self.patch(s3, 'S3_AUGMENT_TABLE', [
+            ('get_bucket_policy',  'Policy', None, 'Policy'),
+        ])
 
         session_factory = self.replay_flight_data('test_s3_policy_statements')
 


### PR DESCRIPTION
Fixes https://github.com/capitalone/cloud-custodian/issues/1867.
Also made corrections to the S3 bucket policy statement schema:
* `Principal` can be a single string (e.g. `*`)
* Either `Principal` or `NotPrincipal` is required