### PR TITLE
add elasticbeanstalk-environment terminate action

### DIFF
--- a/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.DescribeEnvironments_1.json
+++ b/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.DescribeEnvironments_1.json
@@ -1,0 +1,60 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "07c2492b-d925-11e7-b53c-d9b731bbe892", 
+            "HTTPHeaders": {
+                "date": "Mon, 04 Dec 2017 18:57:52 GMT", 
+                "x-amzn-requestid": "07c2492b-d925-11e7-b53c-d9b731bbe892", 
+                "content-length": "1675", 
+                "content-type": "text/xml", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Environments": [
+            {
+                "ApplicationName": "re-jenkins", 
+                "EnvironmentName": "c7n-eb-term-test", 
+                "VersionLabel": "app-477e-170601_115505", 
+                "Status": "Ready", 
+                "Description": "test for c7n EB termination", 
+                "EnvironmentLinks": [], 
+                "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux/2.8.0", 
+                "EndpointURL": "awseb-e-c-AWSEBLoa-VDPIGTI558U-1484559782.us-east-1.elb.amazonaws.com", 
+                "SolutionStackName": "64bit Amazon Linux 2017.09 v2.8.0 running Docker 17.06.2-ce", 
+                "EnvironmentId": "e-cpvmgjjyip", 
+                "CNAME": "c7n-eb-term-test.us-east-1.elasticbeanstalk.com", 
+                "AbortableOperationInProgress": false, 
+                "Tier": {
+                    "Version": " ", 
+                    "Type": "Standard", 
+                    "Name": "WebServer"
+                }, 
+                "Health": "Green", 
+                "DateUpdated": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 40, 
+                    "microsecond": 242000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 57
+                }, 
+                "DateCreated": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 38, 
+                    "microsecond": 330000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 52
+                }, 
+                "EnvironmentArn": "arn:aws:elasticbeanstalk:us-east-1:012345678901:environment/re-jenkins/c7n-eb-term-test"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.DescribeEnvironments_2.json
+++ b/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.DescribeEnvironments_2.json
@@ -1,0 +1,102 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "0814af7f-d925-11e7-9d29-e15fb5867d66", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "0814af7f-d925-11e7-9d29-e15fb5867d66", 
+                "content-length": "3023", 
+                "vary": "Accept-Encoding", 
+                "connection": "keep-alive", 
+                "date": "Mon, 04 Dec 2017 18:57:53 GMT", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "Environments": [
+            {
+                "ApplicationName": "re-jenkins", 
+                "EnvironmentName": "c7n-eb-term-test", 
+                "VersionLabel": "app-477e-170601_115505", 
+                "Status": "Ready", 
+                "Description": "test for c7n EB termination", 
+                "EnvironmentLinks": [], 
+                "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux/2.8.0", 
+                "EndpointURL": "awseb-e-c-AWSEBLoa-VDPIGTI558U-1484559782.us-east-1.elb.amazonaws.com", 
+                "SolutionStackName": "64bit Amazon Linux 2017.09 v2.8.0 running Docker 17.06.2-ce", 
+                "EnvironmentId": "e-cpvmgjjyip", 
+                "CNAME": "c7n-eb-term-test.us-east-1.elasticbeanstalk.com", 
+                "AbortableOperationInProgress": false, 
+                "Tier": {
+                    "Version": " ", 
+                    "Type": "Standard", 
+                    "Name": "WebServer"
+                }, 
+                "Health": "Green", 
+                "DateUpdated": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 40, 
+                    "microsecond": 242000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 57
+                }, 
+                "DateCreated": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 38, 
+                    "microsecond": 330000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 52
+                }, 
+                "EnvironmentArn": "arn:aws:elasticbeanstalk:us-east-1:012345678901:environment/re-jenkins/c7n-eb-term-test"
+            }, 
+            {
+                "ApplicationName": "re-jenkins", 
+                "EnvironmentName": "reJenkins-test-env", 
+                "VersionLabel": "app-477e-170601_115505", 
+                "Status": "Terminated", 
+                "Description": "testing c7n EB terminate", 
+                "EnvironmentLinks": [], 
+                "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux/2.8.0", 
+                "EndpointURL": "awseb-e-b-AWSEBLoa-1LO26A6KPT4XJ-255408782.us-east-1.elb.amazonaws.com", 
+                "SolutionStackName": "64bit Amazon Linux 2017.09 v2.8.0 running Docker 17.06.2-ce", 
+                "EnvironmentId": "e-bu6pphkixi", 
+                "CNAME": "rejenkins-test-env.us-east-1.elasticbeanstalk.com", 
+                "AbortableOperationInProgress": false, 
+                "Tier": {
+                    "Version": " ", 
+                    "Type": "Standard", 
+                    "Name": "WebServer"
+                }, 
+                "Health": "Grey", 
+                "DateUpdated": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 53, 
+                    "microsecond": 29000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 55
+                }, 
+                "DateCreated": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 40, 
+                    "microsecond": 168000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 59
+                }, 
+                "EnvironmentArn": "arn:aws:elasticbeanstalk:us-east-1:012345678901:environment/re-jenkins/reJenkins-test-env"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.DescribeEnvironments_3.json
+++ b/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.DescribeEnvironments_3.json
@@ -1,0 +1,60 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "0883ec25-d925-11e7-9b02-1325c16678ca", 
+            "HTTPHeaders": {
+                "date": "Mon, 04 Dec 2017 18:57:53 GMT", 
+                "x-amzn-requestid": "0883ec25-d925-11e7-9b02-1325c16678ca", 
+                "content-length": "1680", 
+                "content-type": "text/xml", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Environments": [
+            {
+                "ApplicationName": "re-jenkins", 
+                "EnvironmentName": "c7n-eb-term-test", 
+                "VersionLabel": "app-477e-170601_115505", 
+                "Status": "Terminating", 
+                "Description": "test for c7n EB termination", 
+                "EnvironmentLinks": [], 
+                "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux/2.8.0", 
+                "EndpointURL": "awseb-e-c-AWSEBLoa-VDPIGTI558U-1484559782.us-east-1.elb.amazonaws.com", 
+                "SolutionStackName": "64bit Amazon Linux 2017.09 v2.8.0 running Docker 17.06.2-ce", 
+                "EnvironmentId": "e-cpvmgjjyip", 
+                "CNAME": "c7n-eb-term-test.us-east-1.elasticbeanstalk.com", 
+                "AbortableOperationInProgress": false, 
+                "Tier": {
+                    "Version": " ", 
+                    "Type": "Standard", 
+                    "Name": "WebServer"
+                }, 
+                "Health": "Grey", 
+                "DateUpdated": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 53, 
+                    "microsecond": 569000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 57
+                }, 
+                "DateCreated": {
+                    "hour": 18, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 38, 
+                    "microsecond": 330000, 
+                    "year": 2017, 
+                    "day": 4, 
+                    "minute": 52
+                }, 
+                "EnvironmentArn": "arn:aws:elasticbeanstalk:us-east-1:012345678901:environment/re-jenkins/c7n-eb-term-test"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.TerminateEnvironment_1.json
+++ b/tests/data/placebo/test_eb_env_terminate/elasticbeanstalk.TerminateEnvironment_1.json
@@ -1,0 +1,54 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ApplicationName": "re-jenkins", 
+        "EnvironmentName": "c7n-eb-term-test", 
+        "Status": "Terminating", 
+        "Description": "test for c7n EB termination", 
+        "EnvironmentArn": "arn:aws:elasticbeanstalk:us-east-1:012345678901:environment/re-jenkins/c7n-eb-term-test", 
+        "PlatformArn": "arn:aws:elasticbeanstalk:us-east-1::platform/Docker running on 64bit Amazon Linux/2.8.0", 
+        "EndpointURL": "awseb-e-c-AWSEBLoa-VDPIGTI558U-1484559782.us-east-1.elb.amazonaws.com", 
+        "SolutionStackName": "64bit Amazon Linux 2017.09 v2.8.0 running Docker 17.06.2-ce", 
+        "EnvironmentId": "e-cpvmgjjyip", 
+        "CNAME": "c7n-eb-term-test.us-east-1.elasticbeanstalk.com", 
+        "AbortableOperationInProgress": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "083c0d61-d925-11e7-bfa4-d11ccdba1b03", 
+            "HTTPHeaders": {
+                "date": "Mon, 04 Dec 2017 18:57:52 GMT", 
+                "x-amzn-requestid": "083c0d61-d925-11e7-bfa4-d11ccdba1b03", 
+                "content-length": "1387", 
+                "content-type": "text/xml", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tier": {
+            "Version": " ", 
+            "Type": "Standard", 
+            "Name": "WebServer"
+        }, 
+        "Health": "Grey", 
+        "DateUpdated": {
+            "hour": 18, 
+            "__class__": "datetime", 
+            "month": 12, 
+            "second": 53, 
+            "microsecond": 569000, 
+            "year": 2017, 
+            "day": 4, 
+            "minute": 57
+        }, 
+        "DateCreated": {
+            "hour": 18, 
+            "__class__": "datetime", 
+            "month": 12, 
+            "second": 38, 
+            "microsecond": 330000, 
+            "year": 2017, 
+            "day": 4, 
+            "minute": 52
+        }
+    }
+}


### PR DESCRIPTION
This adds an action to the elasticbeanstalk-environment resource to terminate the environment. It exposes all (well, both) of the parameters on the API call (TerminateResources and ForceTerminate) and gives them the same defaults as the API. I also remembered to scrub the account ID from the placebo data.