### PR TITLE
(c7n-org) giving precedence to accounts config region

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -284,7 +284,7 @@ def run_account_script(account, region, output_dir, debug, script_args):
 @click.option('-s', '--output-dir', required=True, type=click.Path())
 @click.option('-a', '--accounts', multiple=True, default=None)
 @click.option('-t', '--tags', multiple=True, default=None)
-@click.option('-r', '--region', default=['us-east-1', 'us-west-2'], multiple=True)
+@click.option('-r', '--region', default=None, multiple=True)
 @click.option('--echo', default=False, is_flag=True)
 @click.option('--serial', default=False, is_flag=True)
 @click.argument('script_args', nargs=-1, type=click.UNPROCESSED)
@@ -301,7 +301,7 @@ def run_script(config, output_dir, accounts, tags, region, echo, serial, script_
     with executor(max_workers=WORKER_COUNT) as w:
         futures = {}
         for a in accounts_config.get('accounts', ()):
-            account_regions = region or a['regions']
+            account_regions = region or a['regions'] or ('us-east-1', 'us-west-2')
             for r in account_regions:
                 futures[w.submit(
                     run_account_script, a, r, output_dir, serial, script_args)
@@ -384,7 +384,7 @@ def run_account(account, region, policies_config, output_path, cache_period, met
 @click.option('-s', '--output-dir', required=True, type=click.Path())
 @click.option('-a', '--accounts', multiple=True, default=None)
 @click.option('-t', '--tags', multiple=True, default=None)
-@click.option('-r', '--region', default=['us-east-1', 'us-west-2'], multiple=True)
+@click.option('-r', '--region', default=None, multiple=True)
 @click.option('-p', '--policy', multiple=True)
 @click.option('--cache-period', default=15, type=int)
 @click.option("--metrics", default=False, is_flag=True)
@@ -400,7 +400,7 @@ def run(config, use, output_dir, accounts, tags,
     with executor(max_workers=WORKER_COUNT) as w:
         futures = {}
         for a in accounts_config.get('accounts', ()):
-            account_regions = region or a['regions']
+            account_regions = region or a['regions'] or ('us-east-1', 'us-west-2')
             for r in account_regions:
                 futures[w.submit(
                     run_account,

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -179,7 +179,7 @@ def report_account(account, region, policies_config, output_path, debug):
 @click.option('--field', multiple=True)
 @click.option('--no-default-fields', default=False, is_flag=True)
 @click.option('-t', '--tags', multiple=True, default=None)
-@click.option('-r', '--region', default=['us-east-1', 'us-west-2'], multiple=True)
+@click.option('-r', '--region', default=None, multiple=True)
 @click.option('--debug', default=False, is_flag=True)
 @click.option('-v', '--verbose', default=False, help="Verbose", is_flag=True)
 @click.option('-p', '--policy', multiple=True)
@@ -200,8 +200,7 @@ def report(config, output, use, output_dir, accounts, field, no_default_fields, 
     with executor(max_workers=WORKER_COUNT) as w:
         futures = {}
         for a in accounts_config.get('accounts', ()):
-            account_regions = region or a['regions']
-            for r in account_regions:
+            for r in region or a['regions'] or ('us-east-1', 'us-west-2'):
                 futures[w.submit(
                     report_account,
                     a, r,


### PR DESCRIPTION
- removing `default=('us-east-1', 'us-west-2')` from `--region` parameter (replaced with `None`)
- adding additional `or` to `accounts_region` var to default to east/west if no region specified