### PR TITLE
code-block docstring fix

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -679,7 +679,7 @@ class PutMetric(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: track-attached-ebs

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -97,7 +97,7 @@ class CloudTrailEnabled(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: account-cloudtrail-enabled
@@ -165,7 +165,7 @@ class ConfigEnabled(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: account-check-config-services
@@ -262,7 +262,7 @@ class IAMSummary(ValueFilter):
     For example to determine if an account has either not been
     enabled with root mfa or has root api keys.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
       policies:
         - name: root-keys-or-no-mfa
@@ -299,7 +299,7 @@ class AccountPasswordPolicy(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: password-policy-check
@@ -378,7 +378,7 @@ class ServiceLimit(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: account-service-limits
@@ -469,7 +469,7 @@ class RequestLimitIncrease(BaseAction):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: account-service-limits
@@ -609,7 +609,7 @@ class EnableTrail(BaseAction):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: trail-test
@@ -723,7 +723,7 @@ class HasVirtualMFA(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
                 - name: account-with-virtual-mfa
@@ -769,7 +769,7 @@ class EnableDataEvents(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-remove-owner-tag

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -66,7 +66,7 @@ class Deregister(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ami-deregister-old
@@ -100,7 +100,7 @@ class RemoveLaunchPermissions(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ami-remove-launch-permissions
@@ -132,7 +132,7 @@ class ImageAgeFilter(AgeFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ami-remove-launch-permissions
@@ -158,7 +158,7 @@ class ImageUnusedFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ami-unused

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -288,7 +288,7 @@ class SetS3Logging(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elbv2-test
@@ -354,7 +354,7 @@ class AppELBMarkForOpAction(tags.TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-failed-mark-for-op
@@ -386,7 +386,7 @@ class AppELBTagAction(tags.Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-create-required-tag
@@ -415,7 +415,7 @@ class AppELBRemoveTagAction(tags.RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-delete-expired-tag
@@ -446,7 +446,7 @@ class AppELBDeleteAction(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-delete-failed-elb
@@ -542,7 +542,7 @@ class IsLoggingFilter(Filter, AppELBAttributeFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
                 - name: alb-is-logging-test
@@ -585,7 +585,7 @@ class IsNotLoggingFilter(Filter, AppELBAttributeFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
                 - name: alb-is-not-logging-test
@@ -642,7 +642,7 @@ class AppELBListenerFilter(ValueFilter, AppELBListenerFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: app-elb-invalid-ciphers
@@ -703,7 +703,7 @@ class AppELBModifyListenerPolicy(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-modify-listener
@@ -768,7 +768,7 @@ class AppELBHealthCheckProtocolMismatchFilter(Filter,
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-healthcheck-mismatch
@@ -815,7 +815,7 @@ class AppELBDefaultVpcFilter(DefaultVpcBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-in-default-vpc
@@ -938,7 +938,7 @@ class AppELBTargetGroupTagAction(tags.Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-targetgroup-add-required-tag
@@ -967,7 +967,7 @@ class AppELBTargetGroupRemoveTagAction(tags.RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-targetgroup-remove-expired-tag
@@ -995,7 +995,7 @@ class AppELBTargetGroupDefaultVpcFilter(DefaultVpcBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-targetgroups-default-vpc
@@ -1020,7 +1020,7 @@ class AppELBTargetGroupDeleteAction(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: appelb-targetgroups-delete-unused

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -155,7 +155,7 @@ class LaunchConfigFilter(ValueFilter, LaunchConfigFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: launch-config-public-ip
@@ -404,7 +404,7 @@ class NotEncryptedFilter(Filter, LaunchConfigFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-unencrypted
@@ -543,7 +543,7 @@ class ImageAgeFilter(AgeFilter, LaunchConfigFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-older-image
@@ -588,7 +588,7 @@ class ImageFilter(ValueFilter, LaunchConfigFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-image-tag
@@ -645,7 +645,7 @@ class VpcIdFilter(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-vpc-xyz
@@ -695,7 +695,7 @@ class GroupTagTrim(TagTrim):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-tag-trim
@@ -731,7 +731,7 @@ class CapacityDelta(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-capacity-delta
@@ -756,7 +756,7 @@ class Resize(Action):
 
     1. set min/desired to current running instances
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-resize
@@ -770,7 +770,7 @@ class Resize(Action):
     2. apply a fixed resize of min, max or desired, optionally saving the
        previous values to a named tag (for restoring later):
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: offhours-asg-off
@@ -787,7 +787,7 @@ class Resize(Action):
 
     3. restore previous values for min/max/desired from a tag:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: offhours-asg-on
@@ -914,7 +914,7 @@ class RemoveTag(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-remove-unnecessary-tags
@@ -973,7 +973,7 @@ class Tag(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-add-owner-tag
@@ -1049,7 +1049,7 @@ class PropagateTags(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-propagate-required
@@ -1157,7 +1157,7 @@ class RenameTag(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-rename-owner-tag
@@ -1254,7 +1254,7 @@ class MarkForOp(Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-suspend-schedule
@@ -1311,7 +1311,7 @@ class Suspend(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-suspend-processes
@@ -1393,7 +1393,7 @@ class Resume(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-resume-processes
@@ -1470,7 +1470,7 @@ class Delete(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-unencrypted
@@ -1548,7 +1548,7 @@ class LaunchConfigAge(AgeFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-launch-config-old
@@ -1572,7 +1572,7 @@ class UnusedLaunchConfig(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-unused-launch-config
@@ -1603,7 +1603,7 @@ class LaunchConfigDelete(Action):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: asg-unused-launch-config-delete

--- a/c7n/resources/awslambda.py
+++ b/c7n/resources/awslambda.py
@@ -172,7 +172,7 @@ class LambdaCrossAccountAccessFilter(CrossAccountAccessFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: lambda-cross-account
@@ -214,7 +214,7 @@ class RemovePolicyStatement(RemovePolicyBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: lambda-remove-cross-accounts
@@ -279,7 +279,7 @@ class TagDelayedAction(TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: lambda-delete-unused
@@ -306,7 +306,7 @@ class Tag(Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: lambda-add-owner-tag
@@ -331,7 +331,7 @@ class RemoveTag(RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: lambda-remove-old-tag
@@ -358,7 +358,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: lambda-delete-dotnet-functions

--- a/c7n/resources/cfn.py
+++ b/c7n/resources/cfn.py
@@ -47,7 +47,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: cloudformation-delete-failed-stacks

--- a/c7n/resources/cloudfront.py
+++ b/c7n/resources/cloudfront.py
@@ -125,7 +125,7 @@ class DistributionMetrics(MetricsFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: cloudfront-distribution-errors
@@ -223,7 +223,7 @@ class DistributionDisableAction(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: distribution-delete
@@ -269,7 +269,7 @@ class StreamingDistributionDisableAction(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: streaming-distribution-delete
@@ -315,7 +315,7 @@ class DistributionSSLAction(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: distribution-set-ssl

--- a/c7n/resources/code.py
+++ b/c7n/resources/code.py
@@ -48,7 +48,7 @@ class DeleteRepository(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: codecommit-delete
@@ -107,7 +107,7 @@ class DeleteProject(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: codebuild-delete

--- a/c7n/resources/cognito.py
+++ b/c7n/resources/cognito.py
@@ -43,7 +43,7 @@ class DeleteIdentityPool(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: identity-pool-delete
@@ -91,7 +91,7 @@ class DeleteUserPool(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: user-pool-delete

--- a/c7n/resources/cw.py
+++ b/c7n/resources/cw.py
@@ -46,7 +46,7 @@ class AlarmDelete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: cloudwatch-delete-stale-alarms
@@ -110,7 +110,7 @@ class Retention(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: cloudwatch-set-log-group-retention
@@ -138,7 +138,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: cloudwatch-delete-stale-log-group
@@ -165,7 +165,7 @@ class LastWriteDays(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: cloudwatch-stale-groups

--- a/c7n/resources/datapipeline.py
+++ b/c7n/resources/datapipeline.py
@@ -173,6 +173,7 @@ class TagPipeline(Tag):
     :example:
 
     .. code-block:: yaml
+
             policies:
               - name: tag-pipeline
                 resource: datapipeline
@@ -209,6 +210,7 @@ class UntagPipeline(RemoveTag):
     :example:
 
     .. code-block:: yaml
+
             policies:
               - name: pipeline-remove-tag
                 resource: datapipeline

--- a/c7n/resources/datapipeline.py
+++ b/c7n/resources/datapipeline.py
@@ -101,7 +101,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: datapipeline-delete
@@ -133,7 +133,7 @@ class MarkForOpPipeline(TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: pipeline-delete-unused
@@ -172,7 +172,7 @@ class TagPipeline(Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
             policies:
               - name: tag-pipeline
                 resource: datapipeline
@@ -208,7 +208,7 @@ class UntagPipeline(RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
             policies:
               - name: pipeline-remove-tag
                 resource: datapipeline

--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -111,7 +111,7 @@ class TagDelayedAction(TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: dynamo-mark-tag-compliance
@@ -143,7 +143,7 @@ class TagTable(Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: dynamodb-tag-table
@@ -172,7 +172,7 @@ class UntagTable(RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: dynamodb-remove-tag
@@ -203,7 +203,7 @@ class DeleteTable(BaseAction, StatusFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: delete-empty-tables

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -305,7 +305,7 @@ class CopySnapshot(BaseAction):
                 actions:
                   - type: copy
                     target_region: us-west-2
-                    target_key: *target_kms_key*
+                    target_key: target_kms_key
                     encrypted: true
     """
 

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -92,7 +92,7 @@ class SnapshotAge(AgeFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ebs-snapshots-week-old
@@ -177,7 +177,7 @@ class SnapshotSkipAmiSnapshots(Filter):
     :example:
 
         .. implicit with no parameters, 'true' by default
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: delete-stale-snapshots
@@ -191,7 +191,7 @@ class SnapshotSkipAmiSnapshots(Filter):
     :example:
 
         .. explicit with parameter
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: delete-snapshots
@@ -226,7 +226,7 @@ class SnapshotDelete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: delete-stale-snapshots
@@ -290,7 +290,7 @@ class CopySnapshot(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: copy-snapshot-east-west
@@ -403,7 +403,7 @@ class AttachedInstanceFilter(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: instance-ebs-volumes
@@ -553,7 +553,7 @@ class CopyInstanceTags(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ebs-copy-instance-tags
@@ -704,7 +704,7 @@ class EncryptInstanceVolumes(BaseAction):
 
     :example:
 
-        .. code-block:: yaml
+    .. code-block:: yaml
 
             policies:
               - name: encrypt-unencrypted-ebs
@@ -967,7 +967,7 @@ class CreateSnapshot(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: snapshot-volumes
@@ -999,7 +999,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: delete-unattached-volumes
@@ -1145,7 +1145,7 @@ class ModifyVolume(BaseAction):
       Find under utilized provisioned iops volumes older than a week
       and change their type.
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
            policies:
             - name: ebs-remove-piops
@@ -1179,7 +1179,7 @@ class ModifyVolume(BaseAction):
 
       Double storage and quadruple iops for all io1 volumes.
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
            policies:
             - name: ebs-remove-piops

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -176,7 +176,8 @@ class SnapshotSkipAmiSnapshots(Filter):
 
     :example:
 
-        .. implicit with no parameters, 'true' by default
+    implicit with no parameters, 'true' by default
+
     .. code-block:: yaml
 
             policies:
@@ -190,7 +191,8 @@ class SnapshotSkipAmiSnapshots(Filter):
 
     :example:
 
-        .. explicit with parameter
+    explicit with parameter
+
     .. code-block:: yaml
 
             policies:
@@ -202,6 +204,7 @@ class SnapshotSkipAmiSnapshots(Filter):
                     op: ge
                   - type: skip-ami-snapshots
                     value: false
+
     """
 
     schema = type_schema('skip-ami-snapshots', value={'type': 'boolean'})

--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -187,7 +187,7 @@ filters.register('network-location', net_filters.NetworkLocation)
 class StateTransitionAge(AgeFilter):
     """Age an instance has been in the given state.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-state-running-7-days
@@ -386,7 +386,7 @@ class ImageAge(AgeFilter, InstanceImageBase):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-ancient-ami
@@ -454,7 +454,7 @@ class InstanceOffHour(OffHour, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: offhour-evening-stop
@@ -511,7 +511,7 @@ class InstanceOnHour(OnHour, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: onhour-morning-start
@@ -566,7 +566,7 @@ class EphemeralInstanceFilter(Filter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-ephemeral-instances
@@ -609,7 +609,7 @@ class InstanceAgeFilter(AgeFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-30-days-plus
@@ -664,7 +664,7 @@ class SingletonFilter(Filter, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-recover-instances
@@ -729,7 +729,7 @@ class Start(BaseAction, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-start-stopped-instances
@@ -879,7 +879,7 @@ class Stop(BaseAction, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-stop-running-instances
@@ -948,7 +948,7 @@ class Reboot(BaseAction, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-reboot-instances
@@ -1018,7 +1018,7 @@ class Terminate(BaseAction, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-process-termination
@@ -1082,7 +1082,7 @@ class Snapshot(BaseAction):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-snapshots
@@ -1200,7 +1200,7 @@ class AutorecoverAlarm(BaseAction, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: ec2-autorecover-alarm
@@ -1261,7 +1261,7 @@ class SetInstanceProfile(BaseAction, StateTransitionFilter):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: set-default-instance-profile

--- a/c7n/resources/ecr.py
+++ b/c7n/resources/ecr.py
@@ -45,7 +45,7 @@ class ECRCrossAccountAccessFilter(CrossAccountAccessFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ecr-cross-account
@@ -85,7 +85,7 @@ class RemovePolicyStatement(RemovePolicyBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ecr-remove-cross-accounts

--- a/c7n/resources/elasticache.py
+++ b/c7n/resources/elasticache.py
@@ -89,7 +89,7 @@ class SubnetFilter(net_filters.SubnetFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elasticache-in-subnet-x
@@ -130,7 +130,7 @@ class DeleteElastiCacheCluster(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elasticache-delete-stale-clusters
@@ -198,7 +198,7 @@ class SnapshotElastiCacheCluster(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elasticache-cluster-snapshot
@@ -324,7 +324,7 @@ class ElastiCacheSnapshotAge(AgeFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elasticache-stale-snapshots
@@ -365,7 +365,7 @@ class DeleteElastiCacheSnapshot(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elasticache-stale-snapshots
@@ -407,7 +407,7 @@ class CopyClusterTags(BaseAction):
     Copy specified tags from Elasticache cluster to Snapshot
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             - name: elasticache-test
               resource: cache-snapshot

--- a/c7n/resources/elasticbeanstalk.py
+++ b/c7n/resources/elasticbeanstalk.py
@@ -115,7 +115,7 @@ class TagDelayedAction(tags.TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: mark-for-delete
@@ -158,7 +158,7 @@ class Tag(tags.Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: eb-env-tag-owner-tag
@@ -194,7 +194,7 @@ class RemoveTag(tags.RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: eb-env-unmark
@@ -226,7 +226,7 @@ class Terminate(BaseAction):
 
     :Example:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
         policies:
           - name: eb-env-termination

--- a/c7n/resources/elasticsearch.py
+++ b/c7n/resources/elasticsearch.py
@@ -122,9 +122,9 @@ class Delete(Action):
 class ElasticSearchAddTag(Tag):
     """Action to create tag(s) on an existing elasticsearch domain
 
-        :example:
+    :example:
 
-            .. code-block: yaml
+    .. code-block:: yaml
 
                 policies:
                   - name: es-add-tag
@@ -157,18 +157,18 @@ class ElasticSearchAddTag(Tag):
 class ElasticSearchRemoveTag(RemoveTag):
     """Removes tag(s) on an existing elasticsearch domain
 
-            :example:
+    :example:
 
-                .. code-block: yaml
+    .. code-block:: yaml
 
-                    policies:
-                      - name: es-remove-tag
-                        resource: elasticsearch
-                        filters:
-                          - "tag:ExpiredTag": present
-                        actions:
-                          - type: remove-tag
-                            tags: ['ExpiredTag']
+        policies:
+          - name: es-remove-tag
+            resource: elasticsearch
+            filters:
+              - "tag:ExpiredTag": present
+            actions:
+              - type: remove-tag
+                tags: ['ExpiredTag']
         """
     permissions = ('es:RemoveTags',)
 
@@ -188,9 +188,9 @@ class ElasticSearchRemoveTag(RemoveTag):
 class ElasticSearchMarkForOp(TagDelayedAction):
     """Tag an elasticsearch domain for action later
 
-        :example:
+    :example:
 
-            .. code-block: yaml
+    .. code-block:: yaml
 
                 policies:
                   - name: es-delete-missing

--- a/c7n/resources/elb.py
+++ b/c7n/resources/elb.py
@@ -139,7 +139,7 @@ class TagDelayedAction(tags.TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-delete-unused
@@ -171,7 +171,7 @@ class Tag(tags.Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-add-owner-tag
@@ -201,7 +201,7 @@ class RemoveTag(tags.RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-remove-old-tag
@@ -233,7 +233,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-delete-unused
@@ -264,7 +264,7 @@ class SetSslListenerPolicy(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-set-listener-policy
@@ -362,7 +362,7 @@ class EnableS3Logging(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-test
@@ -407,7 +407,7 @@ class DisableS3Logging(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: turn-off-elb-logs
@@ -463,7 +463,7 @@ class Instance(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-image-filter
@@ -508,7 +508,7 @@ class IsSSLFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-using-ssl
@@ -540,7 +540,7 @@ class SSLPolicyFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-ssl-policies
@@ -727,7 +727,7 @@ class HealthCheckProtocolMismatch(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-healthcheck-mismatch
@@ -761,7 +761,7 @@ class DefaultVpc(DefaultVpcBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: elb-default-vpc
@@ -800,7 +800,7 @@ class IsLoggingFilter(Filter, ELBAttributeFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
             - name: elb-is-logging-test
@@ -843,7 +843,7 @@ class IsNotLoggingFilter(Filter, ELBAttributeFilterBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
                 - name: elb-is-not-logging-test

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -125,7 +125,7 @@ class TagDelayedAction(TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: emr-mark-for-op
@@ -157,7 +157,7 @@ class TagTable(Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: emr-tag-table
@@ -186,7 +186,7 @@ class UntagTable(RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: emr-remove-tag
@@ -219,7 +219,7 @@ class Terminate(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: emr-terminate

--- a/c7n/resources/glacier.py
+++ b/c7n/resources/glacier.py
@@ -104,7 +104,7 @@ class RemovePolicyStatement(RemovePolicyBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: glacier-cross-account

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -290,7 +290,7 @@ class SpecificIamRoleManagedPolicy(Filter):
 
     For example, if the user wants to check all roles with 'admin-policy':
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
      - name: iam-roles-have-admin
        resource: iam-role
@@ -320,7 +320,7 @@ class NoSpecificIamRoleManagedPolicy(Filter):
 
     For example, if the user wants to check all roles without 'ip-restriction':
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
      - name: iam-roles-no-ip-restriction
        resource: iam-role
@@ -398,7 +398,7 @@ class AllowAllIamPolicies(Filter):
     For example, if the user wants to check all used policies and filter on
     allow all:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
      - name: iam-no-used-all-all-policy
        resource: iam-policy
@@ -496,7 +496,7 @@ class CredentialReport(Filter):
     never used their password but have active access keys from the
     last month
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
      - name: iam-mfa-active-keys-no-login
        resource: iam-user
@@ -691,7 +691,7 @@ class UserPolicy(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: iam-users-with-admin-access
@@ -737,7 +737,7 @@ class GroupMembership(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: iam-users-with-admin-access
@@ -781,7 +781,7 @@ class UserAccessKey(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: iam-users-with-active-keys
@@ -865,7 +865,7 @@ class UserDelete(BaseAction):
 
     :example:
 
-      .. code-block: yaml
+      .. code-block:: yaml
 
         # using a 'credential' filter'
         - name: iam-only-whitelisted-users
@@ -992,7 +992,7 @@ class UserRemoveAccessKey(BaseAction):
     For example if we wanted to disable keys after 90 days of non-use and
     delete them after 180 days of nonuse:
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
      - name: iam-mfa-active-keys-no-login
        resource: iam-user

--- a/c7n/resources/kms.py
+++ b/c7n/resources/kms.py
@@ -90,7 +90,7 @@ class KeyRotationStatus(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: kms-key-disabled-rotation
@@ -128,7 +128,7 @@ class KMSCrossAccountAccessFilter(CrossAccountAccessFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: kms-key-cross-account
@@ -164,7 +164,7 @@ class GrantCount(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: kms-grants
@@ -230,7 +230,7 @@ class RemovePolicyStatement(RemovePolicyBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
            policies:
               - name: kms-key-cross-account
@@ -294,19 +294,19 @@ class RemovePolicyStatement(RemovePolicyBase):
 class TagKmsKey(Tag):
     """Action to create tag(s) on KMS keys
 
-        :example:
+    :example:
 
-            .. code-block: yaml
+    .. code-block:: yaml
 
-                policies:
-                  - name: tag-kms-keys
-                    resource: kms-key
-                    filters:
-                      - "tag:RequiredTag": absent
-                    actions:
-                      - type: tag
-                        key: RequiredTag
-                        value: tag-value
+        policies:
+          - name: tag-kms-keys
+            resource: kms-key
+            filters:
+              - "tag:RequiredTag": absent
+            actions:
+              - type: tag
+                key: RequiredTag
+                value: tag-value
         """
 
     permissions = ('kms:TagResource',)
@@ -328,18 +328,18 @@ class TagKmsKey(Tag):
 class RemoveTagKmsKey(RemoveTag):
     """Action to remove tag(s) on KMS keys
 
-        :example:
+    :example:
 
-            .. code-block: yaml
+    .. code-block:: yaml
 
-                policies:
-                  - name: kms-key-remove-tag
-                    resource: kms-key
-                    filters:
-                      - "tag:ExpiredTag": present
-                    actions:
-                      - type: remove-tag
-                        tags: ["ExpiredTag"]
+        policies:
+          - name: kms-key-remove-tag
+            resource: kms-key
+            filters:
+              - "tag:ExpiredTag": present
+            actions:
+              - type: remove-tag
+                tags: ["ExpiredTag"]
         """
 
     permissions = ('kms:UntagResource',)

--- a/c7n/resources/ml.py
+++ b/c7n/resources/ml.py
@@ -43,7 +43,7 @@ class DeleteMLModel(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: ml-model-delete

--- a/c7n/resources/opsworks.py
+++ b/c7n/resources/opsworks.py
@@ -66,7 +66,7 @@ class DeleteStack(BaseAction, StateTransitionFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: opswork-delete
@@ -129,7 +129,7 @@ class StopStack(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: opswork-stop
@@ -177,7 +177,7 @@ class CMDelete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: opsworks-cm-delete

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -277,7 +277,7 @@ class DefaultVpc(net_filters.DefaultVpcBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: default-vpc-rds
@@ -324,7 +324,7 @@ class AutoPatch(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: enable-rds-autopatch
@@ -368,7 +368,7 @@ class UpgradeAvailable(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-upgrade-available
@@ -413,7 +413,7 @@ class UpgradeMinor(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: upgrade-rds-minor
@@ -547,7 +547,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-delete
@@ -643,7 +643,7 @@ class Snapshot(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-snapshot
@@ -691,7 +691,7 @@ class ResizeInstance(BaseAction):
        storage, and resize them to have an additional 30% storage
        the resize here is async during the next maintenance.
 
-       .. code-block: yaml
+    .. code-block:: yaml
             policies:
               - name: rds-snapshot-retention
                 resource: rds
@@ -711,7 +711,7 @@ class ResizeInstance(BaseAction):
        storage, and resize them to be 30% smaller, the resize here
        is configured to be immediate.
 
-       .. code-block: yaml
+    .. code-block:: yaml
             policies:
               - name: rds-snapshot-retention
                 resource: rds
@@ -754,7 +754,7 @@ class RetentionWindow(BaseAction):
     enforce (min, max, exact) sets retention days occordingly.
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-snapshot-retention
@@ -840,7 +840,7 @@ class RDSSetPublicAvailability(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: disable-rds-public-accessibility
@@ -988,7 +988,7 @@ class RDSSnapshotAge(AgeFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-snapshot-expired
@@ -1269,7 +1269,7 @@ class RDSSnapshotDelete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-snapshot-delete-stale
@@ -1387,7 +1387,7 @@ class RDSSubnetGroupDeleteAction(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-subnet-group-delete-unused
@@ -1416,7 +1416,7 @@ class UnusedRDSSubnetGroup(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-subnet-group-delete-unused
@@ -1447,7 +1447,7 @@ class ParameterFilter(ValueFilter):
     Applies value type filter on set db parameter values.
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-pg

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -687,11 +687,12 @@ class ResizeInstance(BaseAction):
 
     :example:
 
-       This will find databases using over 85% of their allocated
-       storage, and resize them to have an additional 30% storage
-       the resize here is async during the next maintenance.
+    This will find databases using over 85% of their allocated
+    storage, and resize them to have an additional 30% storage
+    the resize here is async during the next maintenance.
 
     .. code-block:: yaml
+
             policies:
               - name: rds-snapshot-retention
                 resource: rds
@@ -707,11 +708,12 @@ class ResizeInstance(BaseAction):
                     percent: 30
 
 
-       This will find databases using under 20% of their allocated
-       storage, and resize them to be 30% smaller, the resize here
-       is configured to be immediate.
+    This will find databases using under 20% of their allocated
+    storage, and resize them to be 30% smaller, the resize here
+    is configured to be immediate.
 
     .. code-block:: yaml
+
             policies:
               - name: rds-snapshot-retention
                 resource: rds

--- a/c7n/resources/rdscluster.py
+++ b/c7n/resources/rdscluster.py
@@ -102,7 +102,7 @@ class TagDelayedAction(tags.TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: mark-for-delete
@@ -137,7 +137,7 @@ class Tag(tags.Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-owner-tag
@@ -169,7 +169,7 @@ class RemoveTag(tags.RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-unmark-cluster
@@ -236,7 +236,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-delete-unused
@@ -303,7 +303,7 @@ class RetentionWindow(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-backup-retention
@@ -377,7 +377,7 @@ class Snapshot(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-snapshot
@@ -439,7 +439,7 @@ class RDSSnapshotAge(AgeFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-snapshots-expired
@@ -466,7 +466,7 @@ class RDSClusterSnapshotDelete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-snapshots-expired-delete

--- a/c7n/resources/rdsparamgroup.py
+++ b/c7n/resources/rdsparamgroup.py
@@ -113,7 +113,7 @@ class PGCopy(PGMixin, Copy):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-param-group-copy
@@ -141,7 +141,7 @@ class PGClusterCopy(PGClusterMixin, Copy):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-param-group-copy
@@ -188,7 +188,7 @@ class PGDelete(PGMixin, Delete):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-param-group-delete
@@ -211,7 +211,7 @@ class PGClusterDelete(PGClusterMixin, Delete):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-param-group-delete
@@ -286,7 +286,7 @@ class PGModify(PGMixin, Modify):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-param-group-modify
@@ -321,7 +321,7 @@ class PGClusterModify(PGClusterMixin, Modify):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: rds-cluster-param-group-modify

--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -78,7 +78,7 @@ class DefaultVpc(DefaultVpcBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-default-vpc
@@ -131,7 +131,7 @@ class Parameter(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-no-ssl
@@ -191,7 +191,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-no-ssl
@@ -249,7 +249,7 @@ class RetentionWindow(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-snapshot-retention
@@ -306,7 +306,7 @@ class Snapshot(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-snapshot
@@ -355,7 +355,7 @@ class EnhancedVpcRoutine(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-enable-enhanced-routing
@@ -407,7 +407,7 @@ class RedshiftSetPublicAccess(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
                 - name: redshift-set-public-access
@@ -447,7 +447,7 @@ class TagDelayedAction(tags.TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-terminate-unencrypted
@@ -482,7 +482,7 @@ class Tag(tags.Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-tag
@@ -513,7 +513,7 @@ class RemoveTag(tags.RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-remove-tag
@@ -545,7 +545,7 @@ class TagTrim(tags.TagTrim):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-tag-trim
@@ -642,7 +642,7 @@ class RedshiftSnapshotAge(AgeFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-old-snapshots
@@ -666,7 +666,7 @@ class RedshiftSnapshotDelete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-delete-old-snapshots
@@ -710,7 +710,7 @@ class RedshiftSnapshotTagDelayedAction(tags.TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-snapshot-expiring
@@ -745,7 +745,7 @@ class RedshiftSnapshotTag(tags.Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-required-tags
@@ -777,7 +777,7 @@ class RedshiftSnapshotRemoveTag(tags.RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: redshift-remove-tags

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -534,7 +534,7 @@ class S3CrossAccountFilter(CrossAccountAccessFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-acl
@@ -616,7 +616,7 @@ class GlobalGrantsFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-delete-global-grants
@@ -702,7 +702,7 @@ class HasStatementFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-bucket-has-statement
@@ -749,7 +749,7 @@ class EncryptionEnabledFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-bucket-not-encrypted
@@ -797,7 +797,7 @@ class MissingPolicyStatementFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-bucket-missing-statement
@@ -836,7 +836,7 @@ class BucketNotificationFilter(ValueFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: delete-incorrect-notification
@@ -938,7 +938,7 @@ class SetPolicyStatement(BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: force-s3-https
@@ -1024,7 +1024,7 @@ class RemovePolicyStatement(RemovePolicyBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-remove-encrypt-put
@@ -1085,7 +1085,7 @@ class ToggleVersioning(BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-enable-versioning
@@ -1140,7 +1140,7 @@ class ToggleLogging(BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-enable-logging
@@ -1195,7 +1195,7 @@ class AttachLambdaEncrypt(BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-logging-buckets
@@ -1296,7 +1296,7 @@ class EncryptionRequiredPolicy(BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-enforce-encryption
@@ -1586,7 +1586,7 @@ class EncryptExtantKeys(ScanBucket):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-encrypt-objects
@@ -1840,7 +1840,7 @@ class LogTarget(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-log-bucket
@@ -1972,7 +1972,7 @@ class DeleteGlobalGrants(BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-delete-global-grants
@@ -2041,7 +2041,7 @@ class BucketTag(Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-tag-region
@@ -2065,7 +2065,7 @@ class MarkBucketForOp(TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-encrypt
@@ -2093,7 +2093,7 @@ class RemoveBucketTag(RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-remove-owner-tag
@@ -2316,7 +2316,7 @@ class DeleteBucket(ScanBucket):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: delete-unencrypted-buckets
@@ -2447,7 +2447,7 @@ class Lifecycle(BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-apply-lifecycle
@@ -2661,7 +2661,7 @@ class BucketEncryption(KMSKeyResolverMixin, Filter):
 
     :example
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-bucket-encryption-AES256
@@ -2742,7 +2742,7 @@ class SetBucketEncryption(KMSKeyResolverMixin, BucketActionBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-enable-default-encryption-kms

--- a/c7n/resources/sns.py
+++ b/c7n/resources/sns.py
@@ -74,7 +74,7 @@ class RemovePolicyStatement(RemovePolicyBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
            policies:
               - name: sns-cross-account

--- a/c7n/resources/sqs.py
+++ b/c7n/resources/sqs.py
@@ -103,7 +103,7 @@ class SQSCrossAccount(CrossAccountAccessFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: sqs-cross-account
@@ -120,7 +120,7 @@ class RemovePolicyStatement(RemovePolicyBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
            policies:
               - name: sqs-cross-account
@@ -173,7 +173,7 @@ class MarkForOpQueue(TagDelayedAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: sqs-delete-unused
@@ -213,7 +213,7 @@ class TagQueue(Tag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: tag-sqs
@@ -251,7 +251,7 @@ class UntagQueue(RemoveTag):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: sqs-remove-tag
@@ -288,7 +288,7 @@ class DeleteSqsQueue(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: sqs-delete
@@ -321,7 +321,7 @@ class SetEncryption(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: sqs-set-encrypt

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -56,7 +56,7 @@ class FlowLogFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: flow-logs-enabled
@@ -69,7 +69,7 @@ class FlowLogFilter(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: flow-mis-configured
@@ -163,7 +163,7 @@ class SecurityGroupFilter(RelatedResourceFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: gray-vpcs
@@ -530,7 +530,7 @@ class UnusedSecurityGroup(SGUsage):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: security-groups-unused
@@ -557,7 +557,7 @@ class UsedSecurityGroup(SGUsage):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: security-groups-in-use
@@ -587,7 +587,7 @@ class Stale(Filter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: stale-security-groups
@@ -629,7 +629,7 @@ class SGDefaultVpc(DefaultVpcBase):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: security-group-default-vpc
@@ -666,7 +666,7 @@ class SGPermission(Filter):
     permission From/To range. The following example matches on ingress
     rules which allow for a range that includes all of the given ports.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
       - type: ingress
         Ports: [22, 443, 80]
@@ -677,7 +677,7 @@ class SGPermission(Filter):
     then the rule will match. ie. OnlyPorts is a negative assertion match,
     it matches when a permission includes ports outside of the specified set.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
       - type: ingress
         OnlyPorts: [22]
@@ -687,7 +687,7 @@ class SGPermission(Filter):
     against each of the rules. If any iprange cidr match then the permission
     matches.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
       - type: ingress
         IpProtocol: -1
@@ -697,7 +697,7 @@ class SGPermission(Filter):
     ingress/egress permissions. The following example matches on ingress
     rules which allow traffic its own same security group.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
       - type: ingress
         SelfReference: True
@@ -705,7 +705,7 @@ class SGPermission(Filter):
     As well for assertions that a ingress/egress permission only matches
     a given set of ports, *note* OnlyPorts is an inverse match.
 
-    .. code-block: yaml
+    .. code-block:: yaml
 
       - type: egress
         OnlyPorts: [22, 443, 80]
@@ -888,7 +888,7 @@ class Delete(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: security-groups-unused-delete
@@ -914,7 +914,7 @@ class RemovePermissions(BaseAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: security-group-revoke-8080
@@ -1004,7 +1004,7 @@ class InterfaceSubnetFilter(net_filters.SubnetFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: network-interface-in-subnet
@@ -1024,7 +1024,7 @@ class InterfaceSecurityGroupFilter(net_filters.SecurityGroupFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: network-interface-ssh
@@ -1054,7 +1054,7 @@ class InterfaceModifyVpcSecurityGroups(ModifyVpcSecurityGroupsAction):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: network-interface-remove-group
@@ -1229,7 +1229,7 @@ class AclSubnetFilter(net_filters.SubnetFilter):
 
     :example:
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: subnet-acl
@@ -1253,7 +1253,7 @@ class AclAwsS3Cidrs(Filter):
 
         Find all nacls that do not allow communication with s3.
 
-        .. code-block: yaml
+    .. code-block:: yaml
 
             policies:
               - name: s3-not-allowed-nacl


### PR DESCRIPTION
Related to issue #1888.

code-block needs to have 2 colons after it and has to be on the same dent as the `"""`

This should add a lot of example policies to our api documentation