### PR TITLE
fix failing test in test_mu.py

### DIFF
--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -175,7 +175,7 @@ class PolicyLambdaProvision(BaseTest):
         # now publish to the topic and look for lambda log output
         client.publish(TopicArn=topic_arn, Message='Greetings, program!')
         #time.sleep(15) -- turn this back on when recording flight data
-        log_events = manager.logs(func, '1970-1-2', '9170-1-1')
+        log_events = manager.logs(func, '1970-1-1 UTC', '9170-1-1')
         messages = [e['message'] for e in log_events
                     if e['message'].startswith('{"Records')]
         self.addCleanup(

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -175,7 +175,7 @@ class PolicyLambdaProvision(BaseTest):
         # now publish to the topic and look for lambda log output
         client.publish(TopicArn=topic_arn, Message='Greetings, program!')
         #time.sleep(15) -- turn this back on when recording flight data
-        log_events = manager.logs(func, '1970-1-1', '9170-1-1')
+        log_events = manager.logs(func, '1970-1-2', '9170-1-1')
         messages = [e['message'] for e in log_events
                     if e['message'].startswith('{"Records')]
         self.addCleanup(


### PR DESCRIPTION
Hi,

While it doesn't appear to fail in your automated tests, there is one test that always fails for me when I run it locally. This very small pull request is to fix that upstream so I don't have to ignore locally failing tests.

I've attached debug output.

It looks like some kind of boundary condition, possibly associated with my timezone and that "1970-01-01" appears to get resolved to a negative number (-3600000) thus causing this test to fail for me.

Thanks,
Andy

[test_sns_subscriber-failure.txt](https://github.com/capitalone/cloud-custodian/files/1555979/test_sns_subscriber-failure.txt)
