### PR TITLE
Fixed the typo caught by @ephil in CustomerGateways

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1322,7 +1322,7 @@ class CustomerGateway(query.QueryResourceManager):
     class resource_type(object):
         service = 'ec2'
         type = 'customer-gateway'
-        enum_spec = ('describe_customer_gateways', 'CustomerGateway', None)
+        enum_spec = ('describe_customer_gateways', 'CustomerGateways', None)
         detail_spec = None
         id = 'CustomerGatewayId'
         filter_name = 'CustomerGatewayIds'


### PR DESCRIPTION
just needed an 's' at the end per the response element in the docs: https://boto3.readthedocs.io/en/latest/reference/services/ec2.html#EC2.Client.describe_customer_gateways