### PR TITLE
WIP - Fix datapipeline functional tests

### DIFF
--- a/tests/test_datapipeline.py
+++ b/tests/test_datapipeline.py
@@ -15,6 +15,10 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from .common import BaseTest, functional
 
+# datapipeline is not available in us-east-2 where we run our functional tests
+# so we do a forced override here.
+REGION = 'us-west-2'
+
 
 class DataPipelineTest(BaseTest):
 
@@ -57,7 +61,7 @@ class DataPipelineTest(BaseTest):
             'filters': [
                 {'tag:foo': 'bar'}],
             },
-            config={'region': 'us-west-2'},
+            config={'region': REGION},
             session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -93,7 +97,7 @@ class DataPipelineTest(BaseTest):
 
     @functional
     def test_tag_datapipeline(self):
-        factory = self.replay_flight_data('test_datapipeline_tag')
+        factory = self.replay_flight_data('test_datapipeline_tag', region=REGION)
 
         session = factory()
         client = session.client('datapipeline')
@@ -120,7 +124,7 @@ class DataPipelineTest(BaseTest):
 
     @functional
     def test_mark_datapipeline(self):
-        factory = self.replay_flight_data('test_datapipeline_mark')
+        factory = self.replay_flight_data('test_datapipeline_mark', region=REGION)
 
         session = factory()
         client = session.client('datapipeline')
@@ -150,7 +154,7 @@ class DataPipelineTest(BaseTest):
 
     @functional
     def test_remove_tag_datapipeline(self):
-        factory = self.replay_flight_data('test_datapipeline_remove_tag')
+        factory = self.replay_flight_data('test_datapipeline_remove_tag', region=REGION)
 
         session = factory()
         client = session.client('datapipeline')
@@ -183,7 +187,7 @@ class DataPipelineTest(BaseTest):
 
     @functional
     def test_marked_for_op_datapipeline(self):
-        factory = self.replay_flight_data('test_datapipeline_marked_for_op')
+        factory = self.replay_flight_data('test_datapipeline_marked_for_op', region=REGION)
 
         session = factory()
         client = session.client('datapipeline')

--- a/tests/zpill.py
+++ b/tests/zpill.py
@@ -271,10 +271,15 @@ class PillTest(unittest.TestCase):
 
         return factory
 
-    def replay_flight_data(self, test_case, zdata=False):
+    def replay_flight_data(self, test_case, zdata=False, region=None):
+        """
+        The `region` argument is to allow functional tests to override the
+        default region. It is unused when replaying stored data.
+        """
+
         if os.environ.get('C7N_FUNCTIONAL') == 'yes':
             self.recording = True
-            return lambda region=None, assume=None: boto3.Session(
+            return lambda region=region, assume=None: boto3.Session(
                 region_name=region)
 
         if not zdata:


### PR DESCRIPTION
datapipeline is unavailable in many regions which was causing these tests to fail when run against us-east-2

@whit537 - this is a small PR.  I marked it WIP to see if I could get any other test fixes in it before Kapil looks at it, but I created it so that you would be aware of it and you can pull it into yours if desired.