### PR TITLE
Adding subnets and security_groups to the schema

### DIFF
--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -218,6 +218,8 @@ def generate(resource_types=()):
                 'tracing_config': {'type': 'object'},
                 'tags': {'type': 'object'},
                 'packages': {'type': 'array'},
+                'subnets': {'type': 'array'},
+                'security_groups': {'type': 'array'},
             },
         },
     }


### PR DESCRIPTION
When creating lambda functions the schema was missing the parameters for subnets and security_groups to create a VPC enabled lambda function.