### PR TITLE
adding sagemaker support | notebook-instance

### DIFF
--- a/c7n/resources/__init__.py
+++ b/c7n/resources/__init__.py
@@ -74,6 +74,7 @@ def load_resources():
     import c7n.resources.redshift
     import c7n.resources.route53
     import c7n.resources.s3
+    import c7n.resources.sagemaker
     import c7n.resources.sfn
     import c7n.resources.shield
     import c7n.resources.simpledb

--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -1,0 +1,240 @@
+# Copyright 2016-2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from botocore.exceptions import ClientError
+
+from c7n.manager import resources
+from c7n.filters import FilterRegistry
+from c7n.query import QueryResourceManager
+from c7n.utils import local_session, type_schema
+from c7n.actions import BaseAction
+from c7n.tags import RemoveTag, Tag, TagActionFilter, TagDelayedAction
+
+filters = FilterRegistry('sagemaker.filters')
+filters.register('marked-for-op', TagActionFilter)
+
+
+@resources.register('notebook-instance')
+class NotebookInstance(QueryResourceManager):
+
+    class resource_type(object):
+        service = 'sagemaker'
+        enum_spec = ('list_notebook_instances', 'NotebookInstances', None)
+        detail_spec = (
+            'describe_notebook_instance', 'NotebookInstanceName',
+            'NotebookInstanceName', None)
+        id = 'NotebookInstanceArn'
+        name = 'NotebookInstanceName'
+        date = 'CreationTime'
+        dimension = None
+        filter_name = None
+
+    filter_registry = filters
+    permissions = ('sagemaker:ListTags',)
+
+    def augment(self, resources):
+        def _tags(r):
+            client = local_session(self.session_factory).client('sagemaker')
+            tags = client.list_tags(
+                ResourceArn=r['NotebookInstanceArn'])['Tags']
+            r.setdefault('Tags', []).extend(tags)
+            return r
+
+        with self.executor_factory(max_workers=2) as w:
+            return list(filter(None, w.map(_tags, resources)))
+
+
+@NotebookInstance.action_registry.register('tag')
+class TagNotebookInstance(Tag):
+    """Action to create tag(s) on a notebook-instance
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: tag-notebook-instance
+                resource: notebook-instance
+                filters:
+                  - "tag:target-tag": absent
+                actions:
+                  - type: tag
+                    key: target-tag
+                    value: target-value
+    """
+    permissions = ('sagemaker:AddTags',)
+
+    def process_resource_set(self, resources, tags):
+        client = local_session(
+            self.manager.session_factory).client('sagemaker')
+
+        tag_list = []
+        for t in tags:
+            tag_list.append({'Key': t['Key'], 'Value': t['Value']})
+
+        for r in resources:
+            try:
+                client.add_tags(
+                    ResourceArn=r['NotebookInstanceArn'],
+                    Tags=tag_list)
+            except ClientError as e:
+                self.log.exception(
+                    'Exception tagging notebook instance %s: %s',
+                    r['NotebookInstanceName'], e)
+
+
+@NotebookInstance.action_registry.register('remove-tag')
+class RemoveTagNotebookInstance(RemoveTag):
+    """Remove tag(s) from notebook-instance(s)
+    
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: notebook-instance-remove-tag
+                resource: notebook-instabce
+                filters:
+                  - "tag:BadTag": present
+                actions:
+                  - type: remove-tag
+                    tags: ["BadTag"]
+    """
+    permissions = ('sagemaker:DeleteTags',)
+
+    def process_resource_set(self, resources, keys):
+        client = local_session(
+            self.manager.session_factory).client('sagemaker')
+
+        for r in resources:
+            try:
+                client.delete_tags(
+                    ResourceArn=r['NotebookInstanceArn'],
+                    TagKeys=keys)
+            except ClientError as e:
+                self.log.exception(
+                    'Exception tagging notebook instance %s: %s',
+                    r['NotebookInstanceName'], e)
+
+
+@NotebookInstance.action_registry.register('mark-for-op')
+class MarkNotebookInstanceForOp(TagDelayedAction):
+    """Mark notebook instance for deferred action
+    
+    :example:
+    
+    .. code-block:: yaml
+
+        policies:
+          - name: notebook-instance-invalid-tag-delete
+            resource: notebook-instance
+            filters:
+              - "tag:InvalidTag": present
+            actions:
+              - type: mark-for-op
+                op: stop
+                days: 7
+    """
+    permissions = ('sagemaker:AddTags',)
+
+    def process_resource_set(self, resources, tags):
+        client = local_session(
+            self.manager.session_factory).client('sagemaker')
+
+        tag_list = []
+        for t in tags:
+            tag_list.append({'Key': t['Key'], 'Value': t['Value']})
+
+        for r in resources:
+            try:
+                client.add_tags(
+                    ResourceArn=r['NotebookInstanceArn'],
+                    Tags=tag_list)
+            except ClientError as e:
+                self.log.exception(
+                    'Exception tagging notebook instance %s: %s',
+                    r['NotebookInstanceName'], e)
+
+
+@NotebookInstance.action_registry.register('stop')
+class StopNotebookInstance(BaseAction):
+    """Stop notebook-instance(s)
+    
+    :example:
+    
+    .. code-block: yaml
+    
+        policies:
+          - name: stop-notebook-instance
+            resource: notebook-instance
+            filters:
+              - "tag:DeleteMe": present
+              - NotebookInstanceStatus: InService
+            actions:
+              - stop
+    """
+    schema = type_schema('stop')
+    permissions = ('sagemaker:StopNotebookInstance',)
+
+    def process_instance(self, resource):
+        client = local_session(
+            self.manager.session_factory).client('sagemaker')
+        try:
+            client.stop_notebook_instance(
+                NotebookInstanceName=resource['NotebookInstanceName'])
+        except ClientError as e:
+            self.log.exception(
+                "Exception stopping notebook instance %s:\n %s" % (
+                    resource['NotebookInstanceName'], e))
+
+    def process(self, resources):
+        with self.executor_factory(max_workers=2) as w:
+            list(w.map(self.process_instance, resources))
+
+
+@NotebookInstance.action_registry.register('delete')
+class DeleteNotebookInstance(BaseAction):
+    """Deletes notebook-instance(s)
+
+    :example:
+
+    .. code-block: yaml
+    
+        policies:
+          - name: delete-notebook-instance
+            resource: notebook-instance
+            filters:
+              - "tag:DeleteMe": present
+              - NotebookInstanceStatus: Stopped
+            actions:
+              - delete
+    """
+    schema = type_schema('delete')
+    permissions = ('sagemaker:DeleteNotebookInstance',)
+
+    def process_instance(self, resource):
+        client = local_session(
+            self.manager.session_factory).client('sagemaker')
+        try:
+            client.delete_notebook_instance(
+                NotebookInstanceName=resource['NotebookInstanceName'])
+        except ClientError as e:
+            self.log.exception(
+                "Exception deleting notebook instance %s:\n %s" % (
+                    resource['NotebookInstanceName'], e))
+
+    def process(self, resources):
+        with self.executor_factory(max_workers=2) as w:
+            list(w.map(self.process_instance, resources))

--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -27,7 +27,7 @@ filters = FilterRegistry('sagemaker.filters')
 filters.register('marked-for-op', TagActionFilter)
 
 
-@resources.register('notebook-instance')
+@resources.register('sagemaker-notebook')
 class NotebookInstance(QueryResourceManager):
 
     class resource_type(object):
@@ -79,15 +79,15 @@ class StateTransitionFilter(object):
 
 @NotebookInstance.action_registry.register('tag')
 class TagNotebookInstance(Tag):
-    """Action to create tag(s) on a notebook-instance
+    """Action to create tag(s) on a sagemaker-notebook
 
     :example:
 
     .. code-block:: yaml
 
             policies:
-              - name: tag-notebook-instance
-                resource: notebook-instance
+              - name: tag-sagemaker-notebook
+                resource: sagemaker-notebook
                 filters:
                   - "tag:target-tag": absent
                 actions:
@@ -118,14 +118,14 @@ class TagNotebookInstance(Tag):
 
 @NotebookInstance.action_registry.register('remove-tag')
 class RemoveTagNotebookInstance(RemoveTag):
-    """Remove tag(s) from notebook-instance(s)
+    """Remove tag(s) from sagemaker-notebook(s)
 
     :example:
 
     .. code-block:: yaml
 
             policies:
-              - name: notebook-instance-remove-tag
+              - name: sagemaker-notebook-remove-tag
                 resource: notebook-instabce
                 filters:
                   - "tag:BadTag": present
@@ -159,8 +159,8 @@ class MarkNotebookInstanceForOp(TagDelayedAction):
     .. code-block:: yaml
 
         policies:
-          - name: notebook-instance-invalid-tag-stop
-            resource: notebook-instance
+          - name: sagemaker-notebook-invalid-tag-stop
+            resource: sagemaker-notebook
             filters:
               - "tag:InvalidTag": present
             actions:
@@ -191,15 +191,15 @@ class MarkNotebookInstanceForOp(TagDelayedAction):
 
 @NotebookInstance.action_registry.register('start')
 class StartNotebookInstance(BaseAction, StateTransitionFilter):
-    """Start notebook-instance(s)
+    """Start sagemaker-notebook(s)
 
     :example:
 
     .. code-block: yaml
 
         policies:
-          - name: start-notebook-instance
-            resource: notebook-instance
+          - name: start-sagemaker-notebook
+            resource: sagemaker-notebook
             actions:
               - start
     """
@@ -229,15 +229,15 @@ class StartNotebookInstance(BaseAction, StateTransitionFilter):
 
 @NotebookInstance.action_registry.register('stop')
 class StopNotebookInstance(BaseAction, StateTransitionFilter):
-    """Stop notebook-instance(s)
+    """Stop sagemaker-notebook(s)
 
     :example:
 
     .. code-block: yaml
 
         policies:
-          - name: stop-notebook-instance
-            resource: notebook-instance
+          - name: stop-sagemaker-notebook
+            resource: sagemaker-notebook
             filters:
               - "tag:DeleteMe": present
             actions:
@@ -269,15 +269,15 @@ class StopNotebookInstance(BaseAction, StateTransitionFilter):
 
 @NotebookInstance.action_registry.register('delete')
 class DeleteNotebookInstance(BaseAction, StateTransitionFilter):
-    """Deletes notebook-instance(s)
+    """Deletes sagemaker-notebook(s)
 
     :example:
 
     .. code-block: yaml
 
         policies:
-          - name: delete-notebook-instance
-            resource: notebook-instance
+          - name: delete-sagemaker-notebook
+            resource: sagemaker-notebook
             filters:
               - "tag:DeleteMe": present
             actions:

--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -58,6 +58,13 @@ class NotebookInstance(QueryResourceManager):
 
 
 class StateTransitionFilter(object):
+    """Filter instances by state.
+
+    Try to simplify construction for policy authors by automatically
+    filtering elements (filters or actions) to the instances states
+    they are valid for.
+
+    """
     valid_origin_states = ()
 
     def filter_instance_state(self, instances, states=None):

--- a/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.DeleteNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.DeleteNotebookInstance_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3018c5ef-d5ce-49d9-8675-f954c434288a", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:05:55 GMT", 
+                "x-amzn-requestid": "3018c5ef-d5ce-49d9-8675-f954c434288a", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.DeleteNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.DeleteNotebookInstance_1.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "3018c5ef-d5ce-49d9-8675-f954c434288a", 
+            "RequestId": "ebb39108-5698-4d69-adaf-057bbd278137", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 19:05:55 GMT", 
-                "x-amzn-requestid": "3018c5ef-d5ce-49d9-8675-f954c434288a", 
+                "date": "Mon, 08 Jan 2018 21:16:40 GMT", 
+                "x-amzn-requestid": "ebb39108-5698-4d69-adaf-057bbd278137", 
                 "content-length": "0", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NetworkInterfaceId": "eni-95be8a5e", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "1f0dbb44-8ac9-4f33-ab7b-07a26eb235d0", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:05:56 GMT", 
+                "x-amzn-requestid": "1f0dbb44-8ac9-4f33-ab7b-07a26eb235d0", 
+                "content-length": "511", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "NotebookInstanceStatus": "Deleting", 
+        "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+        "RoleArn": "arn:aws:iam::644160558196:role/service-role/AmazonSageMaker-ExecutionRole-20180108T122369", 
+        "NotebookInstanceName": "c7n-test", 
+        "CreationTime": {
+            "hour": 12, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 28, 
+            "microsecond": 363000, 
+            "year": 2018, 
+            "day": 8, 
+            "minute": 24
+        }, 
+        "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+        "SecurityGroups": [
+            "sg-6c7fa917"
+        ], 
+        "SubnetId": "subnet-3a334610", 
+        "LastModifiedTime": {
+            "hour": 14, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 55, 
+            "microsecond": 626000, 
+            "year": 2018, 
+            "day": 8, 
+            "minute": 5
+        }, 
+        "InstanceType": "ml.t2.medium"
+    }
+}

--- a/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NotebookInstances": [
+            {
+                "NotebookInstanceStatus": "Stopped", 
+                "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test", 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 363000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 24
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+                "LastModifiedTime": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 30, 
+                    "microsecond": 453000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 5
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "5ec6c33e-6f2c-4dde-8543-cc82528c749d", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:05:53 GMT", 
+                "x-amzn-requestid": "5ec6c33e-6f2c-4dde-8543-cc82528c749d", 
+                "content-length": "334", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "9002a320-6aca-417a-a0c5-37efce43d0f5", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:05:54 GMT", 
+                "x-amzn-requestid": "9002a320-6aca-417a-a0c5-37efce43d0f5", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListTags_1.json
@@ -4,18 +4,22 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "9002a320-6aca-417a-a0c5-37efce43d0f5", 
+            "RequestId": "4490cb35-cdea-491b-99d5-8c3b9b59147d", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 19:05:54 GMT", 
-                "x-amzn-requestid": "9002a320-6aca-417a-a0c5-37efce43d0f5", 
-                "content-length": "97", 
+                "date": "Mon, 08 Jan 2018 21:16:40 GMT", 
+                "x-amzn-requestid": "4490cb35-cdea-491b-99d5-8c3b9b59147d", 
+                "content-length": "133", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
         }, 
         "Tags": [
             {
-                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Value": "DeleteMe", 
+                "Key": "DeleteMe"
+            }, 
+            {
+                "Value": "Resource does not meet policy: stop@2018/01/09", 
                 "Key": "custodian_cleanup"
             }
         ]

--- a/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_delete_notebook_instance/sagemaker.ListTags_2.json
@@ -4,19 +4,19 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "181dc35b-261e-4f7f-870a-490f8e85ceeb", 
+            "RequestId": "d2a7e696-56cd-4ecc-9c94-856c4e30cfcc", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:14:52 GMT", 
-                "x-amzn-requestid": "181dc35b-261e-4f7f-870a-490f8e85ceeb", 
-                "content-length": "95", 
+                "date": "Mon, 08 Jan 2018 21:16:39 GMT", 
+                "x-amzn-requestid": "d2a7e696-56cd-4ecc-9c94-856c4e30cfcc", 
+                "content-length": "48", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
         }, 
         "Tags": [
             {
-                "Value": "Resource does not meet policy: stop@2018/01/09", 
-                "Key": "custodian_cleanup"
+                "Value": "DeleteMe", 
+                "Key": "DeleteMe"
             }
         ]
     }

--- a/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.AddTags_1.json
+++ b/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.AddTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "41a3c3b3-ea35-4779-af84-a008c03d3cb5", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:46:19 GMT", 
+                "x-amzn-requestid": "41a3c3b3-ea35-4779-af84-a008c03d3cb5", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NotebookInstances": [
+            {
+                "NotebookInstanceStatus": "InService", 
+                "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test", 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 363000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 24
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+                "LastModifiedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 30, 
+                    "microsecond": 578000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 29
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "7dff03d4-c1f6-4af8-a56b-41b9dc625536", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:46:18 GMT", 
+                "x-amzn-requestid": "7dff03d4-c1f6-4af8-a56b-41b9dc625536", 
+                "content-length": "336", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -3,29 +3,56 @@
     "data": {
         "NotebookInstances": [
             {
+                "NotebookInstanceStatus": "Stopped", 
+                "Url": "c7n-test-2.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test-2", 
+                "CreationTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 26, 
+                    "microsecond": 151000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 46
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test-2", 
+                "LastModifiedTime": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 18, 
+                    "microsecond": 395000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 7
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }, 
+            {
                 "NotebookInstanceStatus": "InService", 
                 "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
                 "NotebookInstanceName": "c7n-test", 
                 "CreationTime": {
-                    "hour": 12, 
+                    "hour": 15, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 28, 
-                    "microsecond": 363000, 
+                    "second": 35, 
+                    "microsecond": 498000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 24
+                    "minute": 25
                 }, 
                 "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
                 "LastModifiedTime": {
-                    "hour": 12, 
+                    "hour": 16, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 30, 
-                    "microsecond": 578000, 
+                    "second": 47, 
+                    "microsecond": 81000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 29
+                    "minute": 10
                 }, 
                 "InstanceType": "ml.t2.medium"
             }
@@ -33,11 +60,11 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "7dff03d4-c1f6-4af8-a56b-41b9dc625536", 
+            "RequestId": "b8e62457-a27a-4fde-9f20-b5ca2cd5a3eb", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 18:46:18 GMT", 
-                "x-amzn-requestid": "7dff03d4-c1f6-4af8-a56b-41b9dc625536", 
-                "content-length": "336", 
+                "date": "Mon, 08 Jan 2018 21:14:51 GMT", 
+                "x-amzn-requestid": "b8e62457-a27a-4fde-9f20-b5ca2cd5a3eb", 
+                "content-length": "653", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }

--- a/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "0eb74c28-47ae-4b48-b0c7-00fd395a5e81", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:46:18 GMT", 
+                "x-amzn-requestid": "0eb74c28-47ae-4b48-b0c7-00fd395a5e81", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_1.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "0eb74c28-47ae-4b48-b0c7-00fd395a5e81", 
+            "RequestId": "df780678-d111-40ea-a929-a72b2c879b9b", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 18:46:18 GMT", 
-                "x-amzn-requestid": "0eb74c28-47ae-4b48-b0c7-00fd395a5e81", 
+                "date": "Mon, 08 Jan 2018 21:14:51 GMT", 
+                "x-amzn-requestid": "df780678-d111-40ea-a929-a72b2c879b9b", 
                 "content-length": "11", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "56027e7d-18de-401e-8ae4-1021a2f3b82c", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:46:19 GMT", 
+                "x-amzn-requestid": "56027e7d-18de-401e-8ae4-1021a2f3b82c", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_3.json
+++ b/tests/data/placebo/test_sagemaker_mark_for_op_notebook_instance/sagemaker.ListTags_3.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "181dc35b-261e-4f7f-870a-490f8e85ceeb", 
+            "RequestId": "d3457261-755b-469f-b84b-b7238fac27c3", 
             "HTTPHeaders": {
                 "date": "Mon, 08 Jan 2018 21:14:52 GMT", 
-                "x-amzn-requestid": "181dc35b-261e-4f7f-870a-490f8e85ceeb", 
+                "x-amzn-requestid": "d3457261-755b-469f-b84b-b7238fac27c3", 
                 "content-length": "95", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -3,29 +3,56 @@
     "data": {
         "NotebookInstances": [
             {
+                "NotebookInstanceStatus": "Stopped", 
+                "Url": "c7n-test-2.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test-2", 
+                "CreationTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 26, 
+                    "microsecond": 151000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 46
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test-2", 
+                "LastModifiedTime": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 18, 
+                    "microsecond": 395000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 7
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }, 
+            {
                 "NotebookInstanceStatus": "InService", 
                 "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
                 "NotebookInstanceName": "c7n-test", 
                 "CreationTime": {
-                    "hour": 12, 
+                    "hour": 15, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 28, 
-                    "microsecond": 363000, 
+                    "second": 35, 
+                    "microsecond": 498000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 24
+                    "minute": 25
                 }, 
                 "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
                 "LastModifiedTime": {
-                    "hour": 12, 
+                    "hour": 16, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 30, 
-                    "microsecond": 578000, 
+                    "second": 47, 
+                    "microsecond": 81000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 29
+                    "minute": 10
                 }, 
                 "InstanceType": "ml.t2.medium"
             }
@@ -33,11 +60,11 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "add7e746-04bb-42af-b6b4-e990e6eca975", 
+            "RequestId": "86b3f78f-d20a-4437-bbe4-91408c61fb10", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 18:50:07 GMT", 
-                "x-amzn-requestid": "add7e746-04bb-42af-b6b4-e990e6eca975", 
-                "content-length": "336", 
+                "date": "Mon, 08 Jan 2018 21:14:53 GMT", 
+                "x-amzn-requestid": "86b3f78f-d20a-4437-bbe4-91408c61fb10", 
+                "content-length": "653", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }

--- a/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NotebookInstances": [
+            {
+                "NotebookInstanceStatus": "InService", 
+                "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test", 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 363000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 24
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+                "LastModifiedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 30, 
+                    "microsecond": 578000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 29
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "add7e746-04bb-42af-b6b4-e990e6eca975", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:50:07 GMT", 
+                "x-amzn-requestid": "add7e746-04bb-42af-b6b4-e990e6eca975", 
+                "content-length": "336", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "69d0e865-2595-4929-b920-972aec33b98b", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:50:08 GMT", 
+                "x-amzn-requestid": "69d0e865-2595-4929-b920-972aec33b98b", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListTags_1.json
@@ -4,18 +4,18 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "69d0e865-2595-4929-b920-972aec33b98b", 
+            "RequestId": "e1444d1b-3cdd-4c65-9c94-3c80b7a290ea", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 18:50:08 GMT", 
-                "x-amzn-requestid": "69d0e865-2595-4929-b920-972aec33b98b", 
-                "content-length": "97", 
+                "date": "Mon, 08 Jan 2018 21:14:53 GMT", 
+                "x-amzn-requestid": "e1444d1b-3cdd-4c65-9c94-3c80b7a290ea", 
+                "content-length": "95", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
         }, 
         "Tags": [
             {
-                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Value": "Resource does not meet policy: stop@2018/01/09", 
                 "Key": "custodian_cleanup"
             }
         ]

--- a/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_marked_for_op_notebook_instance/sagemaker.ListTags_2.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "dbee6571-6c83-41db-a7e1-5df294d24530", 
+            "RequestId": "603713cb-6914-4705-aac1-ee76cdc726d5", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:14:51 GMT", 
-                "x-amzn-requestid": "dbee6571-6c83-41db-a7e1-5df294d24530", 
+                "date": "Mon, 08 Jan 2018 21:14:54 GMT", 
+                "x-amzn-requestid": "603713cb-6914-4705-aac1-ee76cdc726d5", 
                 "content-length": "11", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListNotebookInstances_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NotebookInstances": [
+            {
+                "NotebookInstanceStatus": "InService", 
+                "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test", 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 363000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 24
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+                "LastModifiedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 30, 
+                    "microsecond": 578000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 29
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d2ac2383-80c1-4cf8-95a0-b68eb6022b71", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 17:59:58 GMT", 
+                "x-amzn-requestid": "d2ac2383-80c1-4cf8-95a0-b68eb6022b71", 
+                "content-length": "336", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListNotebookInstances_1.json
@@ -7,25 +7,25 @@
                 "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
                 "NotebookInstanceName": "c7n-test", 
                 "CreationTime": {
-                    "hour": 12, 
+                    "hour": 15, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 28, 
-                    "microsecond": 363000, 
+                    "second": 35, 
+                    "microsecond": 498000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 24
+                    "minute": 25
                 }, 
                 "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
                 "LastModifiedTime": {
-                    "hour": 12, 
+                    "hour": 15, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 30, 
-                    "microsecond": 578000, 
+                    "second": 23, 
+                    "microsecond": 173000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 29
+                    "minute": 30
                 }, 
                 "InstanceType": "ml.t2.medium"
             }
@@ -33,10 +33,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "d2ac2383-80c1-4cf8-95a0-b68eb6022b71", 
+            "RequestId": "cc1e679c-144d-4194-b2c2-b666ba95dbac", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 17:59:58 GMT", 
-                "x-amzn-requestid": "d2ac2383-80c1-4cf8-95a0-b68eb6022b71", 
+                "date": "Mon, 08 Jan 2018 20:30:58 GMT", 
+                "x-amzn-requestid": "cc1e679c-144d-4194-b2c2-b666ba95dbac", 
                 "content-length": "336", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "8fc4d933-b63c-459d-84a3-74f037a7b9dd", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 17:59:58 GMT", 
+                "x-amzn-requestid": "8fc4d933-b63c-459d-84a3-74f037a7b9dd", 
+                "content-length": "44", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "c7n-test", 
+                "Key": "Name"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_notebook_instances/sagemaker.ListTags_1.json
@@ -4,19 +4,19 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "8fc4d933-b63c-459d-84a3-74f037a7b9dd", 
+            "RequestId": "4c2abed8-ab62-40a3-9835-32dd58418f8a", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 17:59:58 GMT", 
-                "x-amzn-requestid": "8fc4d933-b63c-459d-84a3-74f037a7b9dd", 
-                "content-length": "44", 
+                "date": "Mon, 08 Jan 2018 20:31:00 GMT", 
+                "x-amzn-requestid": "4c2abed8-ab62-40a3-9835-32dd58418f8a", 
+                "content-length": "97", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
         }, 
         "Tags": [
             {
-                "Value": "c7n-test", 
-                "Key": "Name"
+                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Key": "custodian_cleanup"
             }
         ]
     }

--- a/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.DeleteTags_1.json
+++ b/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.DeleteTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f040240d-24ac-4414-b742-f9270ea3a047", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:35:55 GMT", 
+                "x-amzn-requestid": "f040240d-24ac-4414-b742-f9270ea3a047", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.ListNotebookInstances_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NotebookInstances": [
+            {
+                "NotebookInstanceStatus": "InService", 
+                "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test", 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 363000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 24
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+                "LastModifiedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 30, 
+                    "microsecond": 578000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 29
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ddcb6f92-a5a0-4ab8-a8ed-84ffd5487281", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:35:54 GMT", 
+                "x-amzn-requestid": "ddcb6f92-a5a0-4ab8-a8ed-84ffd5487281", 
+                "content-length": "336", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "821c8410-7ce8-4102-9dc1-a0434564f1ce", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:35:54 GMT", 
+                "x-amzn-requestid": "821c8410-7ce8-4102-9dc1-a0434564f1ce", 
+                "content-length": "49", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "TestValue", 
+                "Key": "Category"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_remove_tag_notebook_instances/sagemaker.ListTags_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4678e717-6943-4c48-a678-a65bbdec59a8", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:35:56 GMT", 
+                "x-amzn-requestid": "4678e717-6943-4c48-a678-a65bbdec59a8", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
@@ -5,16 +5,16 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "b89eb0cf-2947-4ade-bbe6-0db2f9b186dd", 
+            "RequestId": "af1ccaf1-8aab-4098-aece-38b31f777a6e", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:16:40 GMT", 
-                "x-amzn-requestid": "b89eb0cf-2947-4ade-bbe6-0db2f9b186dd", 
+                "date": "Mon, 08 Jan 2018 21:05:55 GMT", 
+                "x-amzn-requestid": "af1ccaf1-8aab-4098-aece-38b31f777a6e", 
                 "content-length": "517", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
         }, 
-        "NotebookInstanceStatus": "Deleting", 
+        "NotebookInstanceStatus": "Stopping", 
         "Url": "c7n-test-2.notebook.us-east-1.sagemaker.aws", 
         "RoleArn": "arn:aws:iam::644160558196:role/service-role/AmazonSageMaker-ExecutionRole-20180108T122369", 
         "NotebookInstanceName": "c7n-test-2", 
@@ -37,11 +37,11 @@
             "hour": 16, 
             "__class__": "datetime", 
             "month": 1, 
-            "second": 40, 
-            "microsecond": 683000, 
+            "second": 28, 
+            "microsecond": 892000, 
             "year": 2018, 
             "day": 8, 
-            "minute": 16
+            "minute": 5
         }, 
         "InstanceType": "ml.t2.medium"
     }

--- a/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -3,7 +3,7 @@
     "data": {
         "NotebookInstances": [
             {
-                "NotebookInstanceStatus": "Stopped", 
+                "NotebookInstanceStatus": "Stopping", 
                 "Url": "c7n-test-2.notebook.us-east-1.sagemaker.aws", 
                 "NotebookInstanceName": "c7n-test-2", 
                 "CreationTime": {
@@ -21,16 +21,16 @@
                     "hour": 16, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 18, 
-                    "microsecond": 395000, 
+                    "second": 28, 
+                    "microsecond": 892000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 7
+                    "minute": 5
                 }, 
                 "InstanceType": "ml.t2.medium"
             }, 
             {
-                "NotebookInstanceStatus": "InService", 
+                "NotebookInstanceStatus": "Stopped", 
                 "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
                 "NotebookInstanceName": "c7n-test", 
                 "CreationTime": {
@@ -45,14 +45,14 @@
                 }, 
                 "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
                 "LastModifiedTime": {
-                    "hour": 16, 
+                    "hour": 15, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 47, 
-                    "microsecond": 81000, 
+                    "second": 14, 
+                    "microsecond": 913000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 10
+                    "minute": 56
                 }, 
                 "InstanceType": "ml.t2.medium"
             }
@@ -60,11 +60,11 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "909ca178-0ab2-42ad-ac09-d33c730e935a", 
+            "RequestId": "00cd6aa3-bebb-42ad-8b9c-f4750feae7e4", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:16:39 GMT", 
-                "x-amzn-requestid": "909ca178-0ab2-42ad-ac09-d33c730e935a", 
-                "content-length": "653", 
+                "date": "Mon, 08 Jan 2018 21:05:53 GMT", 
+                "x-amzn-requestid": "00cd6aa3-bebb-42ad-8b9c-f4750feae7e4", 
+                "content-length": "652", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }

--- a/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.ListTags_1.json
@@ -4,18 +4,18 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "181dc35b-261e-4f7f-870a-490f8e85ceeb", 
+            "RequestId": "ee58f784-565d-46c1-bd6c-0c5d4aa97203", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:14:52 GMT", 
-                "x-amzn-requestid": "181dc35b-261e-4f7f-870a-490f8e85ceeb", 
-                "content-length": "95", 
+                "date": "Mon, 08 Jan 2018 21:05:53 GMT", 
+                "x-amzn-requestid": "ee58f784-565d-46c1-bd6c-0c5d4aa97203", 
+                "content-length": "97", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
         }, 
         "Tags": [
             {
-                "Value": "Resource does not meet policy: stop@2018/01/09", 
+                "Value": "Resource does not meet policy: delete@2018/01/15", 
                 "Key": "custodian_cleanup"
             }
         ]

--- a/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.ListTags_2.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "dbee6571-6c83-41db-a7e1-5df294d24530", 
+            "RequestId": "f0cdb1a2-0049-4bef-91f1-5a7ee6ce8e34", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:14:51 GMT", 
-                "x-amzn-requestid": "dbee6571-6c83-41db-a7e1-5df294d24530", 
+                "date": "Mon, 08 Jan 2018 21:05:53 GMT", 
+                "x-amzn-requestid": "f0cdb1a2-0049-4bef-91f1-5a7ee6ce8e34", 
                 "content-length": "11", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.StartNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_start_notebook_instance/sagemaker.StartNotebookInstance_1.json
@@ -4,15 +4,14 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "dbee6571-6c83-41db-a7e1-5df294d24530", 
+            "RequestId": "d66cb873-f183-4749-8915-2a514bdf6f75", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:14:51 GMT", 
-                "x-amzn-requestid": "dbee6571-6c83-41db-a7e1-5df294d24530", 
-                "content-length": "11", 
+                "date": "Mon, 08 Jan 2018 21:05:54 GMT", 
+                "x-amzn-requestid": "d66cb873-f183-4749-8915-2a514bdf6f75", 
+                "content-length": "0", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
-        }, 
-        "Tags": []
+        }
     }
 }

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
@@ -1,47 +1,47 @@
 {
     "status_code": 200, 
     "data": {
-        "NetworkInterfaceId": "eni-95be8a5e", 
+        "NetworkInterfaceId": "eni-708207fb", 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "87d8bd71-d0a6-4c3a-a33d-e1d1bbc0482f", 
+            "RequestId": "7c391ce3-083e-45e3-a0fc-e090b9aee1ae", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 19:02:56 GMT", 
-                "x-amzn-requestid": "87d8bd71-d0a6-4c3a-a33d-e1d1bbc0482f", 
-                "content-length": "511", 
+                "date": "Mon, 08 Jan 2018 21:05:29 GMT", 
+                "x-amzn-requestid": "7c391ce3-083e-45e3-a0fc-e090b9aee1ae", 
+                "content-length": "517", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }
         }, 
         "NotebookInstanceStatus": "Stopping", 
-        "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+        "Url": "c7n-test-2.notebook.us-east-1.sagemaker.aws", 
         "RoleArn": "arn:aws:iam::644160558196:role/service-role/AmazonSageMaker-ExecutionRole-20180108T122369", 
-        "NotebookInstanceName": "c7n-test", 
+        "NotebookInstanceName": "c7n-test-2", 
         "CreationTime": {
-            "hour": 12, 
+            "hour": 15, 
             "__class__": "datetime", 
             "month": 1, 
-            "second": 28, 
-            "microsecond": 363000, 
+            "second": 26, 
+            "microsecond": 151000, 
             "year": 2018, 
             "day": 8, 
-            "minute": 24
+            "minute": 46
         }, 
-        "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+        "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test-2", 
         "SecurityGroups": [
             "sg-6c7fa917"
         ], 
-        "SubnetId": "subnet-3a334610", 
+        "SubnetId": "subnet-efbcccb7", 
         "LastModifiedTime": {
-            "hour": 14, 
+            "hour": 16, 
             "__class__": "datetime", 
             "month": 1, 
-            "second": 55, 
-            "microsecond": 975000, 
+            "second": 28, 
+            "microsecond": 892000, 
             "year": 2018, 
             "day": 8, 
-            "minute": 2
+            "minute": 5
         }, 
         "InstanceType": "ml.t2.medium"
     }

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.DescribeNotebookInstance_1.json
@@ -1,0 +1,48 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NetworkInterfaceId": "eni-95be8a5e", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "87d8bd71-d0a6-4c3a-a33d-e1d1bbc0482f", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:02:56 GMT", 
+                "x-amzn-requestid": "87d8bd71-d0a6-4c3a-a33d-e1d1bbc0482f", 
+                "content-length": "511", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "NotebookInstanceStatus": "Stopping", 
+        "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+        "RoleArn": "arn:aws:iam::644160558196:role/service-role/AmazonSageMaker-ExecutionRole-20180108T122369", 
+        "NotebookInstanceName": "c7n-test", 
+        "CreationTime": {
+            "hour": 12, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 28, 
+            "microsecond": 363000, 
+            "year": 2018, 
+            "day": 8, 
+            "minute": 24
+        }, 
+        "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+        "SecurityGroups": [
+            "sg-6c7fa917"
+        ], 
+        "SubnetId": "subnet-3a334610", 
+        "LastModifiedTime": {
+            "hour": 14, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 55, 
+            "microsecond": 975000, 
+            "year": 2018, 
+            "day": 8, 
+            "minute": 2
+        }, 
+        "InstanceType": "ml.t2.medium"
+    }
+}

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NotebookInstances": [
+            {
+                "NotebookInstanceStatus": "InService", 
+                "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test", 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 363000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 24
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+                "LastModifiedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 30, 
+                    "microsecond": 578000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 29
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "906d0427-3507-4e1c-9b0c-2ae6c0d5e7f5", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:02:54 GMT", 
+                "x-amzn-requestid": "906d0427-3507-4e1c-9b0c-2ae6c0d5e7f5", 
+                "content-length": "336", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListNotebookInstances_1.json
@@ -4,28 +4,55 @@
         "NotebookInstances": [
             {
                 "NotebookInstanceStatus": "InService", 
+                "Url": "c7n-test-2.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test-2", 
+                "CreationTime": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 26, 
+                    "microsecond": 151000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 46
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test-2", 
+                "LastModifiedTime": {
+                    "hour": 16, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 19, 
+                    "microsecond": 533000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 2
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }, 
+            {
+                "NotebookInstanceStatus": "Stopped", 
                 "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
                 "NotebookInstanceName": "c7n-test", 
                 "CreationTime": {
-                    "hour": 12, 
+                    "hour": 15, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 28, 
-                    "microsecond": 363000, 
+                    "second": 35, 
+                    "microsecond": 498000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 24
+                    "minute": 25
                 }, 
                 "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
                 "LastModifiedTime": {
-                    "hour": 12, 
+                    "hour": 15, 
                     "__class__": "datetime", 
                     "month": 1, 
-                    "second": 30, 
-                    "microsecond": 578000, 
+                    "second": 14, 
+                    "microsecond": 913000, 
                     "year": 2018, 
                     "day": 8, 
-                    "minute": 29
+                    "minute": 56
                 }, 
                 "InstanceType": "ml.t2.medium"
             }
@@ -33,11 +60,11 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "906d0427-3507-4e1c-9b0c-2ae6c0d5e7f5", 
+            "RequestId": "e35bb08a-dddb-4da2-98e0-7dbece2722ec", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 19:02:54 GMT", 
-                "x-amzn-requestid": "906d0427-3507-4e1c-9b0c-2ae6c0d5e7f5", 
-                "content-length": "336", 
+                "date": "Mon, 08 Jan 2018 21:05:27 GMT", 
+                "x-amzn-requestid": "e35bb08a-dddb-4da2-98e0-7dbece2722ec", 
+                "content-length": "653", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"
             }

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "25b39195-166c-4dc2-a8c8-6e2ee4fbe798", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:02:54 GMT", 
+                "x-amzn-requestid": "25b39195-166c-4dc2-a8c8-6e2ee4fbe798", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/15", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListTags_1.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "25b39195-166c-4dc2-a8c8-6e2ee4fbe798", 
+            "RequestId": "e9c25fd9-5e36-4939-9d3e-72372bae1299", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 19:02:54 GMT", 
-                "x-amzn-requestid": "25b39195-166c-4dc2-a8c8-6e2ee4fbe798", 
+                "date": "Mon, 08 Jan 2018 21:05:28 GMT", 
+                "x-amzn-requestid": "e9c25fd9-5e36-4939-9d3e-72372bae1299", 
                 "content-length": "97", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.ListTags_2.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "dbee6571-6c83-41db-a7e1-5df294d24530", 
+            "RequestId": "6405eeae-6c18-4797-91eb-9e8a74cb90bb", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 21:14:51 GMT", 
-                "x-amzn-requestid": "dbee6571-6c83-41db-a7e1-5df294d24530", 
+                "date": "Mon, 08 Jan 2018 21:05:28 GMT", 
+                "x-amzn-requestid": "6405eeae-6c18-4797-91eb-9e8a74cb90bb", 
                 "content-length": "11", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.StopNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.StopNotebookInstance_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "1ed583b2-50c0-49dc-abfd-36818d4db1d0", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 19:02:55 GMT", 
+                "x-amzn-requestid": "1ed583b2-50c0-49dc-abfd-36818d4db1d0", 
+                "content-length": "0", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.StopNotebookInstance_1.json
+++ b/tests/data/placebo/test_sagemaker_stop_notebook_instance/sagemaker.StopNotebookInstance_1.json
@@ -4,10 +4,10 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "1ed583b2-50c0-49dc-abfd-36818d4db1d0", 
+            "RequestId": "86710acc-802c-4801-885b-717f6ad5fd53", 
             "HTTPHeaders": {
-                "date": "Mon, 08 Jan 2018 19:02:55 GMT", 
-                "x-amzn-requestid": "1ed583b2-50c0-49dc-abfd-36818d4db1d0", 
+                "date": "Mon, 08 Jan 2018 21:05:28 GMT", 
+                "x-amzn-requestid": "86710acc-802c-4801-885b-717f6ad5fd53", 
                 "content-length": "0", 
                 "content-type": "application/x-amz-json-1.1", 
                 "connection": "keep-alive"

--- a/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.AddTags_1.json
+++ b/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.AddTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "fa6d8d97-5831-4d75-a292-0ccace01e7bd", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:33:05 GMT", 
+                "x-amzn-requestid": "fa6d8d97-5831-4d75-a292-0ccace01e7bd", 
+                "content-length": "49", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "TestValue", 
+                "Key": "Category"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.ListNotebookInstances_1.json
+++ b/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.ListNotebookInstances_1.json
@@ -1,0 +1,46 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NotebookInstances": [
+            {
+                "NotebookInstanceStatus": "InService", 
+                "Url": "c7n-test.notebook.us-east-1.sagemaker.aws", 
+                "NotebookInstanceName": "c7n-test", 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 28, 
+                    "microsecond": 363000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 24
+                }, 
+                "NotebookInstanceArn": "arn:aws:sagemaker:us-east-1:644160558196:notebook-instance/c7n-test", 
+                "LastModifiedTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 30, 
+                    "microsecond": 578000, 
+                    "year": 2018, 
+                    "day": 8, 
+                    "minute": 29
+                }, 
+                "InstanceType": "ml.t2.medium"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "06ef96b5-6c50-45f3-a63a-a1bf434ff48d", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:33:04 GMT", 
+                "x-amzn-requestid": "06ef96b5-6c50-45f3-a63a-a1bf434ff48d", 
+                "content-length": "336", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b36096a9-fe53-4aa5-91ea-6e482036e90a", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:33:05 GMT", 
+                "x-amzn-requestid": "b36096a9-fe53-4aa5-91ea-6e482036e90a", 
+                "content-length": "44", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "c7n-test", 
+                "Key": "Name"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_tag_notebook_instances/sagemaker.ListTags_2.json
@@ -1,0 +1,27 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "df6eeb4d-0730-404d-9bf3-4f7ff571284b", 
+            "HTTPHeaders": {
+                "date": "Mon, 08 Jan 2018 18:33:06 GMT", 
+                "x-amzn-requestid": "df6eeb4d-0730-404d-9bf3-4f7ff571284b", 
+                "content-length": "83", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "TestValue", 
+                "Key": "Category"
+            }, 
+            {
+                "Value": "c7n-test", 
+                "Key": "Name"
+            }
+        ]
+    }
+}

--- a/tests/test_sagemaker.py
+++ b/tests/test_sagemaker.py
@@ -21,8 +21,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_notebook_instances')
         p = self.load_policy({
-            'name': 'list-notebook-instances',
-            'resource': 'notebook-instance'
+            'name': 'list-sagemaker-notebooks',
+            'resource': 'sagemaker-notebook'
         }, session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
@@ -31,8 +31,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_tag_notebook_instances')
         p = self.load_policy({
-            'name': 'tag-notebook-instances',
-            'resource': 'notebook-instance',
+            'name': 'tag-sagemaker-notebooks',
+            'resource': 'sagemaker-notebook',
             'filters': [{
                 'tag:Category': 'absent'}],
             'actions': [{
@@ -52,8 +52,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_remove_tag_notebook_instances')
         p = self.load_policy({
-            'name': 'untag-notebook-instances',
-            'resource': 'notebook-instance',
+            'name': 'untag-sagemaker-notebooks',
+            'resource': 'sagemaker-notebook',
             'filters': [{
                 'tag:Category': 'TestValue'}],
             'actions': [{
@@ -72,8 +72,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_mark_for_op_notebook_instance')
         p = self.load_policy({
-            'name': 'notebook-instances-untagged-delete',
-            'resource': 'notebook-instance',
+            'name': 'sagemaker-notebooks-untagged-delete',
+            'resource': 'sagemaker-notebook',
             'filters': [
                 {'tag:Category': 'absent'},
                 {'tag:custodian_cleanup': 'absent'},
@@ -94,8 +94,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_marked_for_op_notebook_instance')
         p = self.load_policy({
-            'name': 'notebook-instances-untagged-delete',
-            'resource': 'notebook-instance',
+            'name': 'sagemaker-notebooks-untagged-delete',
+            'resource': 'sagemaker-notebook',
             'filters': [{
                 'type': 'marked-for-op',
                 'tag': 'custodian_cleanup',
@@ -108,8 +108,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_start_notebook_instance')
         p = self.load_policy({
-            'name': 'start-notebook-instance',
-            'resource': 'notebook-instance',
+            'name': 'start-sagemaker-notebook',
+            'resource': 'sagemaker-notebook',
             'actions': [{'type': 'start'}]}, session_factory=session_factory)
         resources = p.run()
         self.assertTrue(len(resources), 1)
@@ -123,8 +123,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_stop_notebook_instance')
         p = self.load_policy({
-            'name': 'stop-invalid-notebook-instance',
-            'resource': 'notebook-instance',
+            'name': 'stop-invalid-sagemaker-notebook',
+            'resource': 'sagemaker-notebook',
             'filters': [
                 {'tag:Category': 'absent'}],
             'actions': [{'type': 'stop'}]}, session_factory=session_factory)
@@ -140,8 +140,8 @@ class TestNotebookInstance(BaseTest):
         session_factory = self.replay_flight_data(
             'test_sagemaker_delete_notebook_instance')
         p = self.load_policy({
-            'name': 'delete-invalid-notebook-instance',
-            'resource': 'notebook-instance',
+            'name': 'delete-invalid-sagemaker-notebook',
+            'resource': 'sagemaker-notebook',
             'filters': [
                 {'tag:DeleteMe': 'present'}],
             'actions': [{'type': 'delete'}]}, session_factory=session_factory)

--- a/tests/test_sagemaker.py
+++ b/tests/test_sagemaker.py
@@ -1,0 +1,143 @@
+# Copyright 2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from datetime import datetime
+from dateutil import tz, zoneinfo
+
+from .common import BaseTest, functional
+
+
+class TestNotebookInstance(BaseTest):
+    def test_list_notebook_instances(self):
+        session_factory = self.replay_flight_data(
+            'test_sagemaker_notebook_instances')
+        p = self.load_policy({
+            'name': 'list-notebook-instances',
+            'resource': 'notebook-instance'
+        }, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_tag_notebook_instances(self):
+        session_factory = self.replay_flight_data(
+            'test_sagemaker_tag_notebook_instances')
+        p = self.load_policy({
+            'name': 'tag-notebook-instances',
+            'resource': 'notebook-instance',
+            'filters': [{
+                'tag:Category': 'absent'}],
+            'actions': [{
+                'type': 'tag',
+                'key': 'Category',
+                'value': 'TestValue'}]
+        }, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        client = session_factory().client('sagemaker')
+        tags = client.list_tags(
+            ResourceArn=resources[0]['NotebookInstanceArn'])['Tags']
+        self.assertEqual(tags[0]['Value'], 'TestValue')
+
+    def test_remove_tag_notebook_instance(self):
+        session_factory = self.replay_flight_data(
+            'test_sagemaker_remove_tag_notebook_instances')
+        p = self.load_policy({
+            'name': 'untag-notebook-instances',
+            'resource': 'notebook-instance',
+            'filters': [{
+                'tag:Category': 'TestValue'}],
+            'actions': [{
+                'type': 'remove-tag',
+                'tags': ['Category']}]
+        }, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+        client = session_factory().client('sagemaker')
+        tags = client.list_tags(
+            ResourceArn=resources[0]['NotebookInstanceArn'])['Tags']
+        self.assertEqual(len(tags), 0)
+
+    def test_mark_for_op_notebook_instance(self):
+        session_factory = self.replay_flight_data(
+            'test_sagemaker_mark_for_op_notebook_instance')
+        p = self.load_policy({
+            'name': 'notebook-instances-untagged-delete',
+            'resource': 'notebook-instance',
+            'filters': [
+                {'tag:Category': 'absent'},
+                {'tag:custodian_cleanup': 'absent'}],
+            'actions': [{
+                'type': 'mark-for-op',
+                'tag': 'custodian_cleanup',
+                'op': 'delete',
+                'days': 7}]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = session_factory().client('sagemaker')
+        tags = client.list_tags(
+            ResourceArn=resources[0]['NotebookInstanceArn'])['Tags']
+        self.assertTrue(tags[0]['Key'], 'custodian_cleanup')
+
+    def test_marked_for_op_notebook_instance(self):
+        session_factory = self.replay_flight_data(
+            'test_sagemaker_marked_for_op_notebook_instance')
+        p = self.load_policy({
+            'name': 'notebook-instances-untagged-delete',
+            'resource': 'notebook-instance',
+            'filters': [{
+                'type': 'marked-for-op',
+                'tag': 'custodian_cleanup',
+                'op': 'delete',
+                'skew': 7}]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_stop_notebook_instance(self):
+        session_factory = self.replay_flight_data(
+            'test_sagemaker_stop_notebook_instance')
+        p = self.load_policy({
+            'name': 'delete-invalid-notebook-instance',
+            'resource': 'notebook-instance',
+            'filters': [
+                {'tag:Category': 'absent'},
+                {'NotebookInstanceStatus': 'InService'}],
+            'actions': [{'type': 'stop'}]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertTrue(len(resources), 1)
+
+        client = session_factory().client('sagemaker')
+        notebook = client.describe_notebook_instance(
+            NotebookInstanceName=resources[0]['NotebookInstanceName'])
+        self.assertTrue(notebook['NotebookInstanceStatus'], 'Stopping')
+
+    def test_delete_notebook_instance(self):
+        session_factory = self.replay_flight_data(
+            'test_sagemaker_delete_notebook_instance')
+        p = self.load_policy({
+            'name': 'delete-invalid-notebook-instance',
+            'resource': 'notebook-instance',
+            'filters': [
+                {'tag:Category': 'absent'},
+                {'NotebookInstanceStatus': 'Stopped'}],
+            'actions': [{'type': 'delete'}]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertTrue(len(resources), 1)
+
+        client = session_factory().client('sagemaker')
+        notebook = client.describe_notebook_instance(
+            NotebookInstanceName=resources[0]['NotebookInstanceName'])
+        self.assertTrue(notebook['NotebookInstanceStatus'], 'Deleting')


### PR DESCRIPTION
newly released service 'SageMaker' has no support in custodian. 
adding support for the 'notebook-instance'
- start, stop, delete actions
  - adding state transition filter (from ec2)
- tag actions & filters