### PR TITLE
c7n_mailer - add optional owner_absent_contact option to notify action

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -390,6 +390,8 @@ class Notify(EventAction):
               - event-user
               - resource-creator
               - email@address
+             owner_absent_contact:
+              - other_email@address
              # which template for the email should we use
              template: policy-template
              transport:
@@ -408,6 +410,7 @@ class Notify(EventAction):
         'properties': {
             'type': {'enum': ['notify']},
             'to': {'type': 'array', 'items': {'type': 'string'}},
+            'owner_absent_contact': {'type': 'array', 'items': {'type': 'string'}},
             'to_from': ValuesFrom.schema,
             'cc': {'type': 'array', 'items': {'type': 'string'}},
             'cc_from': ValuesFrom.schema,

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -182,6 +182,8 @@ policies:
         subject: fix your tags
         to:
           - resource-owner
+        owner_absent_contact:
+          - foo@example.com
         transport:
           type: sqs
           queue: https://sqs.us-east-1.amazonaws.com/80101010101/cloud-custodian-message-relay
@@ -205,6 +207,10 @@ Both of these special values are best effort, i.e., if no `OwnerContact` tag is
 specified then `resource-owner` email will not be delivered, and in the case of
 `event-owner` an instance role or system account will not result in an email.
 
+The optional `owner_absent_contact` list specifies email addresses to notify only if
+the `resource-owner` special option was unable to find any matching owner contact
+tags.
+
 For reference purposes, the JSON Schema of the `notify` action:
 
 ```json
@@ -214,6 +220,7 @@ For reference purposes, the JSON Schema of the `notify` action:
   "properties": {
     "type": {"enum": ["notify"]},
     "to": {"type": "array", "items": {"type": "string"}},
+    "owner_absent_contact": {"type": "array", "items": {"type": "string"}},
     "subject": {"type": "string"},
     "priority_header": {"type": "string"},
     "template": {"type": "string"},

--- a/tools/c7n_mailer/tests/test_email.py
+++ b/tools/c7n_mailer/tests/test_email.py
@@ -195,6 +195,32 @@ class EmailTest(unittest.TestCase):
         self.assertEqual(emails_to_resources_map[email_1_to_addrs], [RESOURCE_1])
         self.assertEqual(emails_to_resources_map[email_2_to_addrs], [RESOURCE_2])
 
+    def test_emails_resource_mapping_no_owner(self):
+        SQS_MESSAGE = copy.deepcopy(SQS_MESSAGE_1)
+        SQS_MESSAGE['action'].pop('priority_header', None)
+        SQS_MESSAGE['action']['owner_absent_contact'] = ['foo@example.com']
+        RESOURCE_2 = {
+            'AvailabilityZone': 'us-east-1a',
+            'Attachments': [],
+            'Tags': [
+                {
+                    'Value': 'peter',
+                    'Key': 'CreatorName'
+                }
+            ],
+            'VolumeId': 'vol-01a0e6ea6b89f0099'
+        }
+        SQS_MESSAGE['resources'] = [RESOURCE_2]
+        emails_to_resources_map = self.email_delivery.get_email_to_addrs_to_resources_map(
+            SQS_MESSAGE
+        )
+        email_1_to_addrs = (
+            'bill_lumberg@initech.com', 'foo@example.com', 'peter@initech.com'
+        )
+        self.assertEqual(
+            emails_to_resources_map[email_1_to_addrs], [RESOURCE_2]
+        )
+
     def test_no_mapping_if_no_valid_emails(self):
         SQS_MESSAGE = copy.deepcopy(SQS_MESSAGE_1)
         SQS_MESSAGE['action']['to'].remove('ldap_uid_tags')


### PR DESCRIPTION
This adds a new ``owner_absent_contact`` option to the notify action schema, and implementation of this in mailer. This allows specifying a list of email addresses to receive the notifications if and only if ``get_resource_owner_emails_from_resource()`` returns an empty list (i.e. no valid email addresses can be found from the resource owner tag(s)).

This is something we've wanted for our implementation for a while, so that notifications can go to the owner if specified, or a distribution list if no owner tag is present.