### PR TITLE
Delete lifecycle when only one exists

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -2612,8 +2612,11 @@ class Lifecycle(BucketActionBase):
         config = list(filter(None, config))
 
         try:
-            s3.put_bucket_lifecycle_configuration(
-                Bucket=bucket['Name'], LifecycleConfiguration={'Rules': config})
+            if not config:
+                s3.delete_bucket_lifecycle(Bucket=bucket['Name'])
+            else:
+                s3.put_bucket_lifecycle_configuration(
+                    Bucket=bucket['Name'], LifecycleConfiguration={'Rules': config})
         except ClientError as e:
             if e.response['Error']['Code'] == 'AccessDenied':
                 log.warning("Access Denied Bucket:%s while applying lifecycle" % bucket['Name'])


### PR DESCRIPTION
`put_bucket_lifecycle_configuration` api can only remove a lifecycle configuration if multiple exist.  If you are trying to remove a lifecycle configuration and the bucket only has 1, you have to call `delete_bucket_lifecycle`.