### PR TITLE
Network location filter supports ignores subnet/security group attribute

### DIFF
--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -153,9 +153,9 @@ class NetworkLocation(Filter):
                 for k, v in i.items():
                     if jmespath.search(k, r) == v:
                         found = True
-                if found == True:
+                if found is True:
                     break
-            if found == True:
+            if found is True:
                 continue
             results.append(r)
         return results

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -18,6 +18,8 @@ from c7n.utils import local_session, type_schema
 from .core import Filter, ValueFilter, FilterValidationError
 from .related import RelatedResourceFilter
 
+import jmespath
+
 
 class SecurityGroupFilter(RelatedResourceFilter):
     """Filter a resource by its associated security groups."""
@@ -75,9 +77,9 @@ class NetworkLocation(Filter):
             'type': 'boolean',
             'default': False,
             'description': (
-                "How to handle missing keys on elements, by default this causes "
+                "How to handle missing keys on elements, by default this causes"
                 "resources to be considered not-equal")},
-           'match': {'type': 'string', 'enum': ['equal', 'non-equal'],
+           'match': {'type': 'string', 'enum': ['equal', 'not-equal'],
                      'default': 'non-equal'},
            'compare': {
             'type': 'array',
@@ -93,7 +95,9 @@ class NetworkLocation(Filter):
            'max-cardinality': {
                'type': 'integer', 'default': 1,
                'title': ''},
-           'required': ['key']
+           'ignore': {'type': 'array', 'items': {'type': 'object'}},
+           'required': ['key'],
+
            })
 
     permissions = ('ec2:DescribeSecurityGroups', 'ec2:DescribeSubnets')
@@ -129,13 +133,31 @@ class NetworkLocation(Filter):
         results = []
 
         for r in resources:
-            resource_sgs = [related_sg[sid] for sid in self.sg.get_related_ids([r])]
-            resource_subnets = [
-                related_subnet[sid] for sid in self.subnet.get_related_ids([r])]
+            resource_sgs = self.filter_ignored(
+                [related_sg[sid] for sid in self.sg.get_related_ids([r])])
+            resource_subnets = self.filter_ignored([
+                related_subnet[sid] for sid in self.subnet.get_related_ids([r])])
             found = self.process_resource(r, resource_sgs, resource_subnets, key)
             if found:
                 results.append(found)
 
+        return results
+
+    def filter_ignored(self, resources):
+        ignores = self.data.get('ignore', ())
+        results = []
+
+        for r in resources:
+            found = False
+            for i in ignores:
+                for k, v in i.items():
+                    if jmespath.search(k, r) == v:
+                        found = True
+                if found == True:
+                    break
+            if found == True:
+                continue
+            results.append(r)
         return results
 
     def process_resource(self, r, resource_sgs, resource_subnets, key):

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -221,6 +221,61 @@ class NetworkLocationTest(BaseTest):
             }])
 
     @functional
+    def test_network_location_ignore(self):
+        # if we use network-location-with ignore we won't find any resources.
+
+        # Note we're reusing another tests data set, with the exact same
+        # resource creation, just altering our policy filter to examine
+        # a different parameter on results.
+        self.factory = self.replay_flight_data(
+            'test_network_location_sg_cardinality')
+        client = self.factory().client('ec2')
+        vpc_id = client.create_vpc(CidrBlock="10.4.0.0/16")['Vpc']['VpcId']
+        self.addCleanup(client.delete_vpc, VpcId=vpc_id)
+
+        web_sub_id = client.create_subnet(
+            VpcId=vpc_id, CidrBlock="10.4.9.0/24")[
+                'Subnet']['SubnetId']
+        self.addCleanup(client.delete_subnet, SubnetId=web_sub_id)
+
+        web_sg_id = client.create_security_group(
+            GroupName="web-tier",
+            VpcId=vpc_id,
+            Description="for apps")['GroupId']
+        self.addCleanup(client.delete_security_group, GroupId=web_sg_id)
+
+        db_sg_id = client.create_security_group(
+            GroupName="db-tier",
+            VpcId=vpc_id,
+            Description="for dbs")['GroupId']
+        self.addCleanup(client.delete_security_group, GroupId=db_sg_id)
+
+        nic = client.create_network_interface(
+            SubnetId=web_sub_id,
+            Groups=[web_sg_id, db_sg_id])['NetworkInterface']['NetworkInterfaceId']
+        self.addCleanup(client.delete_network_interface, NetworkInterfaceId=nic)
+
+        client.create_tags(
+            Resources=[web_sg_id, web_sub_id, nic],
+            Tags=[{'Key': 'Location', 'Value': 'web'}])
+        client.create_tags(
+            Resources=[db_sg_id],
+            Tags=[{'Key': 'Location', 'Value': 'db'}])
+
+        p = self.load_policy({
+            'name': 'netloc',
+            'resource': 'eni',
+            'filters': [
+                {'NetworkInterfaceId': nic},
+                {'type': 'network-location',
+                 'ignore': [
+                     {'GroupName': 'db-tier'}],
+                 'key': 'tag:Location'}]
+            }, session_factory=self.factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    @functional
     def test_network_location_sg_cardinality(self):
         self.factory = self.replay_flight_data(
             'test_network_location_sg_cardinality')


### PR DESCRIPTION
its a common use case to use network-location to find resources using a security groups or subnets that don't map to a particular logical design pattern, web servers using a different app's database security group, but its also common to have various shared security groups (bastion, loggagg, etc), for those its useful to have network-location filter ignore particular groups by attribute (name i suspect most commonly), this adds jmespath filtering against the subnets and security groups being matched on to address ignoring these shared resources.