### PR TITLE
sg ingress/egress filters support match-operator [backwards-incompatible]

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -773,6 +773,7 @@ class SGPermission(Filter):
         'IpRanges', 'PrefixListIds'))
     filter_attrs = set(('Cidr', 'Ports', 'OnlyPorts', 'SelfReference'))
     attrs = perm_attrs.union(filter_attrs)
+    attrs.add('match-operator')
 
     def validate(self):
         delta = set(self.data.keys()).difference(self.attrs)
@@ -835,10 +836,16 @@ class SGPermission(Filter):
 
     def process_self_reference(self, perm, sg_id):
         found = None
+        ref_match = self.data.get('SelfReference')
+        if ref_match is not None:
+            found = False
         if 'UserIdGroupPairs' in perm and 'SelfReference' in self.data:
             self_reference = sg_id in [p['GroupId']
                                        for p in perm['UserIdGroupPairs']]
-            found = self_reference & self.data['SelfReference']
+            if ref_match is False and not self_reference:
+                found = True
+            if ref_match is True and self_reference:
+                found = True
         return found
 
     def expand_permissions(self, permissions):
@@ -866,34 +873,20 @@ class SGPermission(Filter):
                     yield ep
 
     def __call__(self, resource):
-        def _accumulate(f, x):
-            '''
-            Accumulate an intermediate found value into the overall result.
-            '''
-            if x is not None:
-                f = (f is not None and x & f or x)
-            return f
-
         matched = []
         sg_id = resource['GroupId']
+        match_op = self.data.get('match-operator', 'or') == 'or' and any or all
 
         for perm in self.expand_permissions(resource[self.ip_permissions_key]):
-            found = None
-            for f in self.vfilters:
-                if f(perm):
-                    found = True
-                else:
-                    found = False
-                    break
-            if found is None or found:
-                found = _accumulate(found, self.process_ports(perm))
-            if found is None or found:
-                found = _accumulate(found, self.process_cidrs(perm))
-            if found is None or found:
-                found = _accumulate(found, self.process_self_reference(perm, sg_id))
-            if not found:
-                continue
-            matched.append(perm)
+            perm_matches = {}
+            for idx, f in enumerate(self.vfilters):
+                perm_matches[idx] = bool(f(perm))
+            perm_matches['ports'] = self.process_ports(perm)
+            perm_matches['cidrs'] = self.process_cidrs(perm)
+            perm_matches['self-refs'] = self.process_self_reference(perm, sg_id)
+            match = match_op(filter(lambda x: x is not None, perm_matches.values()))
+            if match:
+                matched.append(perm)
 
         if matched:
             resource['Matched%s' % self.ip_permissions_key] = matched
@@ -909,6 +902,7 @@ class IPPermission(SGPermission):
         # 'additionalProperties': True,
         'properties': {
             'type': {'enum': ['ingress']},
+            'match-operator': {'type': 'string', 'enum': ['or', 'and']},
             'Ports': {'type': 'array', 'items': {'type': 'integer'}},
             'SelfReference': {'type': 'boolean'}
         },
@@ -924,6 +918,7 @@ class IPPermissionEgress(SGPermission):
         # 'additionalProperties': True,
         'properties': {
             'type': {'enum': ['egress']},
+            'match-operator': {'type': 'string', 'enum': ['or', 'and']},
             'SelfReference': {'type': 'boolean'}
         },
         'required': ['type']}

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -671,7 +671,7 @@ class SecurityGroupTest(BaseTest):
               u'UserIdGroupPairs': []}])
 
     @functional
-    def test_self_reference(self):
+    def test_self_reference_once(self):
         factory = self.replay_flight_data(
             'test_security_group_self_reference')
         client = factory().client('ec2')
@@ -737,12 +737,14 @@ class SecurityGroupTest(BaseTest):
             'name': 'sg-find0',
             'resource': 'security-group',
             'filters': [
+                {'GroupName': 'sg1'},
                 {'type': 'ingress',
-                 'SelfReference': False},
-                {'GroupName': 'sg1'}]
+                 'match-operator': 'and',
+                 'Ports': [80],
+                 'SelfReference': False}]
             }, session_factory=factory)
         resources = p.run()
-        self.assertEqual(len(resources), 0)
+        self.assertEqual(len(resources), 1)
 
         p = self.load_policy({
             'name': 'sg-find1',
@@ -1061,6 +1063,7 @@ class SecurityGroupTest(BaseTest):
             'filters': [
                 {'type': 'ingress',
                  'Ports': [22],
+                 'match-operator': 'and',
                  'SelfReference': True}
                 ]})
         manager = p.get_resource_manager()
@@ -1072,6 +1075,7 @@ class SecurityGroupTest(BaseTest):
             'filters': [
                 {'type': 'ingress',
                  'Ports': [22],
+                 'match-operator': 'and',
                  'SelfReference': False}
                 ]})
         manager = p.get_resource_manager()
@@ -1083,6 +1087,7 @@ class SecurityGroupTest(BaseTest):
             'filters': [
                 {'type': 'ingress',
                  'Ports': [22],
+                 'match-operator': 'and',
                  'Cidr': {
                     'value': '0.0.0.0/0',
                     'op': 'eq',
@@ -1135,6 +1140,7 @@ class SecurityGroupTest(BaseTest):
             'filters': [
                 {'type': 'ingress',
                  'Ports': [22],
+                 'match-operator': 'and',
                  'Cidr': {
                     'value': '10.42.3.0/24',
                     'op': 'eq',


### PR DESCRIPTION
This implements configurable operator when specifying multiple keys on an ingress/egress permission. 

After some reflection it seems that the default `or` operator is probably causing some confusion for users, and that it would be better to switch the default to `and`. I've got a poll out to the user community (mailing list and gitter), as this may have some compatibility impact.

**[Backwards** **Incompatibility]**. To date the security group ingress/egress permission filters would allow for specifying multiple key conditions to check a permission against, previously the results of those conditions would always be `or`d when evaluating the permission. In implementing the `and` operator and making that configurable, and reviewing extant tests and usage, it became clear that this is a source of lots of confusion for users, and bad policies, and that all would be better off switching the default to `and`. This causes more restrictive filtering by default when specifying multiple conditions, its also backwards incompatible. The simple solution to maintain the extant behavior is to explicitly specify the `match-operator: or` on the ingress fitler. This will be in the new 0.8.28.0 release. Pull request here https://github.com/capitalone/cloud-custodian/pull/1954 issue discussion here https://github.com/capitalone/cloud-custodian/issues/1943


closes #1943
