### PR TITLE
multi-cloud registry (basic foundations)

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -279,13 +279,6 @@ def schema_completer(prefix):
     load_resources()
     components = prefix.split('.')
 
-    # Completions for resource
-    if len(components) == 1:
-        choices = [r for r in provider.resources().keys() if r.startswith('aws.%s' % prefix)]
-        if len(choices) == 1:
-            choices += ['{}{}'.format(choices[0], '.')]
-        return choices
-
     if components[0] in provider.clouds.keys():
         cloud_provider = components.pop(0)
         provider_resources = provider.resources(cloud_provider)
@@ -293,6 +286,14 @@ def schema_completer(prefix):
         cloud_provider = 'aws'
         provider_resources = provider.resources('aws')
         components[0] = "aws.%s" % components[0]
+
+    # Completions for resource
+    if len(components) == 1:
+        choices = [r for r in provider.resources().keys()
+                   if r.startswith(components[0])]
+        if len(choices) == 1:
+            choices += ['{}{}'.format(choices[0], '.')]
+        return choices
 
     if components[0] not in provider_resources.keys():
         return []

--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -30,7 +30,7 @@ import yaml
 from c7n.policy import Policy, PolicyCollection, load as policy_load
 from c7n.reports import report as do_report
 from c7n.utils import Bag, dumps, load_file
-from c7n.manager import resources
+from c7n import provider
 from c7n.resources import load_resources
 from c7n import schema
 
@@ -281,12 +281,20 @@ def schema_completer(prefix):
 
     # Completions for resource
     if len(components) == 1:
-        choices = [r for r in resources.keys() if r.startswith(prefix)]
+        choices = [r for r in provider.resources().keys() if r.startswith('aws.%s' % prefix)]
         if len(choices) == 1:
             choices += ['{}{}'.format(choices[0], '.')]
         return choices
 
-    if components[0] not in resources.keys():
+    if components[0] in provider.clouds.keys():
+        cloud_provider = components.pop(0)
+        provider_resources = provider.resources(cloud_provider)
+    else:
+        cloud_provider = 'aws'
+        provider_resources = provider.resources('aws')
+        components[0] = "aws.%s" % components[0]
+
+    if components[0] not in provider_resources.keys():
         return []
 
     # Completions for category
@@ -299,7 +307,7 @@ def schema_completer(prefix):
 
     # Completions for item
     elif len(components) == 3:
-        resource_mapping = schema.resource_vocabulary()
+        resource_mapping = schema.resource_vocabulary(cloud_provider)
         return ['{}.{}.{}'.format(components[0], components[1], x)
                 for x in resource_mapping[components[0]][components[1]]]
 
@@ -314,7 +322,6 @@ def schema_cmd(options):
 
     load_resources()
     resource_mapping = schema.resource_vocabulary()
-
     if options.summary:
         schema.summary(resource_mapping)
         return
@@ -334,13 +341,21 @@ def schema_cmd(options):
     #   - Show class doc string and schema for supplied filter
 
     if not options.resource:
-        resource_list = {'resources': sorted(resources.keys())}
+        resource_list = {'resources': sorted(provider.resources().keys())}
         print(yaml.safe_dump(resource_list, default_flow_style=False))
         return
 
-    # Format is RESOURCE.CATEGORY.ITEM
+    # Format is [PROVIDER].RESOURCE.CATEGORY.ITEM
+    # optional provider defaults to aws for compatibility
     components = options.resource.split('.')
-
+    if components[0] in provider.clouds.keys():
+        cloud_provider = components.pop(0)
+        resource_mapping = schema.resource_vocabulary(
+            cloud_provider)
+        components[0] = '%s.%s' % (cloud_provider, components[0])
+    else:
+        resource_mapping = schema.resource_vocabulary('aws')
+        components[0] = 'aws.%s' % components[0]
     #
     # Handle resource
     #

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -17,11 +17,13 @@ import logging
 
 from c7n import cache
 from c7n.executor import ThreadPoolExecutor
-from c7n.registry import PluginRegistry
+from c7n.provider import AWS
+
 from c7n.utils import dumps
 
 
-resources = PluginRegistry('resources')
+# Compatibility import
+resources = AWS.resources
 
 
 class ResourceManager(object):

--- a/c7n/provider.py
+++ b/c7n/provider.py
@@ -1,0 +1,41 @@
+# Copyright 2015-2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from c7n.registry import PluginRegistry
+
+
+clouds = PluginRegistry('c7n.providers')
+
+
+@clouds.register('aws')
+class AWS(object):
+
+    resource_prefix = 'aws'
+    # legacy path for older plugins
+    resources = PluginRegistry('resources')
+
+
+@clouds.register('gcp')
+class GoogleCloud(object):
+
+    resource_prefix = 'gcp'
+    resources = PluginRegistry('%s.resources' % resource_prefix)
+
+
+@clouds.register('azure')
+class Azure(object):
+
+    resource_prefix = 'azure'
+    resources = PluginRegistry('%s.resources' % resource_prefix)

--- a/c7n/provider.py
+++ b/c7n/provider.py
@@ -39,3 +39,13 @@ class Azure(object):
 
     resource_prefix = 'azure'
     resources = PluginRegistry('%s.resources' % resource_prefix)
+
+
+def resources(cloud_provider=None):
+    results = {}
+    for cname, ctype in clouds.items():
+        if cloud_provider and cname != cloud_provider:
+            continue
+        for rname, rtype in ctype.resources.items():
+            results['%s.%s' % (cname, rname)] = rtype
+    return results

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -95,7 +95,7 @@ def specific_error(error):
     if r is not None:
         found = None
         for idx, v in enumerate(error.validator_value):
-            if r in v['$ref'].rsplit('/', 2):
+            if r in v['$ref'].rsplit('/', 2)[1]:
                 found = idx
         if found is not None:
             # error context is a flat list of all validation

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -34,7 +34,7 @@ import logging
 from jsonschema import Draft4Validator as Validator
 from jsonschema.exceptions import best_match
 
-from c7n.manager import resources
+from c7n.provider import clouds
 from c7n.resources import load_resources
 from c7n.filters import ValueFilter, EventFilter, AgeFilter
 
@@ -225,11 +225,16 @@ def generate(resource_types=()):
     }
 
     resource_refs = []
-    for type_name, resource_type in resources.items():
-        if resource_types and type_name not in resource_types:
-            continue
-        resource_refs.append(
-            process_resource(type_name, resource_type, resource_defs))
+    for cloud_name, cloud_type in clouds.items():
+        for type_name, resource_type in cloud_type.resources.items():
+            if resource_types and type_name not in resource_types:
+                continue
+            alias_name = None
+            r_type_name = "%s.%s" % (cloud_name, type_name)
+            if cloud_name == 'aws':
+                alias_name = type_name
+            resource_refs.append(
+                process_resource(r_type_name, resource_type, resource_defs, alias_name))
 
     schema = {
         '$schema': 'http://json-schema.org/schema#',
@@ -251,7 +256,7 @@ def generate(resource_types=()):
     return schema
 
 
-def process_resource(type_name, resource_type, resource_defs):
+def process_resource(type_name, resource_type, resource_defs, alias_name=None):
     r = resource_defs.setdefault(type_name, {'actions': {}, 'filters': {}})
 
     seen_actions = set()  # Aliases get processed once
@@ -327,6 +332,10 @@ def process_resource(type_name, resource_type, resource_defs):
         ]
     }
 
+    if alias_name:
+        resource_policy['allOf'][1]['properties'][
+            'resource']['enum'].append(alias_name)
+
     if type_name == 'ec2':
         resource_policy['allOf'][1]['properties']['query'] = {}
 
@@ -336,9 +345,13 @@ def process_resource(type_name, resource_type, resource_defs):
 
 def resource_vocabulary():
     vocabulary = {}
+    resources = {}
+    for cname, ctype in clouds.items():
+        for rname, rtype in resources.items():
+            resources['%s.%s' % (cname, rname)] = rtype
+
     for type_name, resource_type in resources.items():
         classes = {'actions': {}, 'filters': {}}
-
         actions = []
         for action_name, cls in resource_type.action_registry.items():
             actions.append(action_name)

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -343,12 +343,18 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None):
     return {'$ref': '#/definitions/resources/%s/policy' % type_name}
 
 
-def resource_vocabulary():
+def resource_vocabulary(cloud_name=None, qualify_name=True):
     vocabulary = {}
     resources = {}
+
     for cname, ctype in clouds.items():
-        for rname, rtype in resources.items():
-            resources['%s.%s' % (cname, rname)] = rtype
+        if cloud_name is not None and cloud_name != cname:
+            continue
+        for rname, rtype in ctype.resources.items():
+            if qualify_name:
+                resources['%s.%s' % (cname, rname)] = rtype
+            else:
+                resources[rname] = rtype
 
     for type_name, resource_type in resources.items():
         classes = {'actions': {}, 'filters': {}}

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -340,12 +340,12 @@ class TabCompletionTest(CliTest):
     """ Tests for argcomplete tab completion. """
 
     def test_schema_completer(self):
-        self.assertIn('rds', cli.schema_completer('rd'))
-        self.assertIn('s3.', cli.schema_completer('s3'))
+        self.assertIn('aws.rds', cli.schema_completer('rd'))
+        self.assertIn('aws.s3.', cli.schema_completer('s3'))
         self.assertListEqual([], cli.schema_completer('invalidResource.'))
-        self.assertIn('rds.actions', cli.schema_completer('rds.'))
-        self.assertIn('s3.filters.', cli.schema_completer('s3.filters'))
-        self.assertIn('s3.filters.event', cli.schema_completer('s3.filters.eve'))
+        self.assertIn('aws.rds.actions', cli.schema_completer('rds.'))
+        self.assertIn('aws.s3.filters.', cli.schema_completer('s3.filters'))
+        self.assertIn('aws.s3.filters.event', cli.schema_completer('s3.filters.eve'))
         self.assertListEqual([], cli.schema_completer('rds.actions.foo.bar'))
 
     def test_schema_completer_wrapper(self):
@@ -353,7 +353,7 @@ class TabCompletionTest(CliTest):
             summary = False
 
         args = MockArgs()
-        self.assertIn('rds', cli._schema_tab_completer('rd', args))
+        self.assertIn('aws.rds', cli._schema_tab_completer('rd', args))
 
         args.summary = True
         self.assertListEqual([], cli._schema_tab_completer('rd', args))

--- a/tests/test_provider.py
+++ b/tests/test_provider.py
@@ -1,0 +1,26 @@
+# Copyright 2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+from .common import BaseTest
+
+from c7n.provider import clouds
+
+
+class ProviderTest(BaseTest):
+
+    def test_available_clouds(self):
+        self.assertEqual(
+            sorted(clouds.keys()),
+            ['aws', 'azure', 'gcp'])

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -105,7 +105,7 @@ class SchemaTest(BaseTest):
         from jsonschema.exceptions import ValidationError
         data = {
                 'policies': [{'name': 'test',
-                 'resource': 'ec2',
+                 'resource': 'aws.ec2',
                  'filters': {
                      'type': 'ebs',
                      'invalid': []}
@@ -117,7 +117,6 @@ class SchemaTest(BaseTest):
         self.assertEqual(len(resp), 2)
         self.assertIsInstance(resp[0], ValidationError)
         self.assertIsInstance(resp[1], ValidationError)
-
 
     def test_vars_and_tags(self):
         data = {


### PR DESCRIPTION
when referencing from policy resources get a provider prefix ('aws', 'azure', 'gcp'), aws gets legacy treatment to support extant unqualified resource policies.