### PR TITLE
Correcting EC2 Encrypted EBS Policy Example

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -254,7 +254,7 @@ class AttachedVolume(ValueFilter):
             resource: ec2
             filters:
               - type: ebs
-                key: encrypted
+                key: Encrypted
                 value: true
     """
 


### PR DESCRIPTION
Example policy doesn't work as the e in encrypted was lower case.  Changing to uppercase to fix it.