### PR TITLE
add retry logic for ami deregistration

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -21,7 +21,7 @@ from c7n.filters import FilterRegistry, AgeFilter, Filter, OPERATORS
 
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
-from c7n.utils import local_session, type_schema
+from c7n.utils import local_session, type_schema, get_retry
 
 
 log = logging.getLogger('custodian.ami')
@@ -86,8 +86,11 @@ class Deregister(BaseAction):
             list(w.map(self.process_image, images))
 
     def process_image(self, image):
+        retry = get_retry((
+            'RequestLimitExceeded', 'Client.RequestLimitExceeded'))
+
         client = local_session(self.manager.session_factory).client('ec2')
-        client.deregister_image(ImageId=image['ImageId'])
+        retry(client.deregister_image, ImageId=image['ImageId'])
 
 
 @actions.register('remove-launch-permissions')


### PR DESCRIPTION
If we have several hundred amis to deregister it will fail due to rate limiting.  This fixes the issue.