### PR TITLE
ability to filter rds/ebs snapshots and volumes with missing kms keys

### DIFF
--- a/c7n/filters/__init__.py
+++ b/c7n/filters/__init__.py
@@ -27,3 +27,4 @@ from .core import (
 from .iamaccess import CrossAccountAccessFilter, PolicyChecker
 from .metrics import MetricsFilter, ShieldMetrics
 from .vpc import DefaultVpcBase
+from .kms import FilterKmsInvalid

--- a/c7n/filters/kms.py
+++ b/c7n/filters/kms.py
@@ -1,0 +1,34 @@
+# Copyright 2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .core import Filter
+
+
+class FilterKmsInvalid(Filter):
+    """Filters out invalid KmsKeyIds
+    """
+    def process(self, resources, event=None):
+        if not self.data.get('value', True):
+            return resources
+        # try using cache first to get a listing of all KMS Keys and compares resources to the list
+        # This will populate the cache.
+        kms_keys = self.manager.get_resource_manager('kms-key').resources()
+        key_ids = [key['KeyArn'] for key in kms_keys]
+
+        matches = []
+        for item in resources:
+            if item['Encrypted'] and item['KmsKeyId'] not in key_ids:
+                matches.append(item)
+        return matches

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -469,7 +469,7 @@ class KmsKeyAlias(ResourceKmsKeyAlias):
 
 
 @Snapshot.filter_registry.register('skip-active-kms')
-class KmsKeyActive(Filter):
+class KmsKeyActiveSnapshot(Filter):
     """
     Filter to ignore snapshots that have an active KMS Key.
 
@@ -514,7 +514,8 @@ class KmsKeyActive(Filter):
         return self
 
     def process(self, snapshots, event=None):
-       return _filter_kms_active(self, snapshots)
+        return _filter_kms_active(self, snapshots)
+
 
 @filters.register('skip-active-kms')
 class KmsKeyActive(Filter):

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -128,6 +128,7 @@ def _filter_ami_snapshots(self, snapshots):
             matches.append(snap)
     return matches
 
+
 @Snapshot.filter_registry.register('cross-account')
 class SnapshotCrossAccountAccess(CrossAccountAccessFilter):
 

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -128,25 +128,6 @@ def _filter_ami_snapshots(self, snapshots):
             matches.append(snap)
     return matches
 
-
-def _filter_kms_active(self, resources):
-    if not self.data.get('value', True):
-        return resources
-    # try using cache first to get a listing of all KMS Keys and compares resources to the list
-    # This will populate the cache.
-    kms_keys = self.manager.get_resource_manager('kms-key').resources()
-
-    key_ids = []
-    for key in kms_keys:
-        key_ids.append(key['KeyArn'])
-
-    matches = []
-    for item in resources:
-        if item['Encrypted'] and item['KmsKeyId'] not in key_ids:
-            matches.append(item)
-    return matches
-
-
 @Snapshot.filter_registry.register('cross-account')
 class SnapshotCrossAccountAccess(CrossAccountAccessFilter):
 

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -468,7 +468,7 @@ class KmsKeyAlias(ResourceKmsKeyAlias):
         return self.get_matching_aliases(resources)
 
 
-@Snapshot.filter_registry.register('skip-active-kms')
+@Snapshot.filter_registry.register('invalid-kms')
 class KmsKeyActiveSnapshot(Filter):
     """
     Filter to ignore snapshots that have an active KMS Key.
@@ -485,7 +485,7 @@ class KmsKeyActiveSnapshot(Filter):
               - name: delete-snapshots-with-missing-keys
                 resource: ebs-snapshot
                 filters:
-                  - skip-active-kms
+                  - invalid-kms
 
     :example:
 
@@ -497,12 +497,12 @@ class KmsKeyActiveSnapshot(Filter):
               - name: delete-snapshots
                 resource: ebs-snapshot
                 filters:
-                  - type: skip-active-kms
+                  - type: invalid-kms
                     value: false
 
     """
 
-    schema = type_schema('skip-active-kms', value={'type': 'boolean'})
+    schema = type_schema('invalid-kms', value={'type': 'boolean'})
 
     def get_permissions(self):
         return self.manager.get_resource_manager('ec2').get_permissions()
@@ -517,7 +517,7 @@ class KmsKeyActiveSnapshot(Filter):
         return _filter_kms_active(self, snapshots)
 
 
-@filters.register('skip-active-kms')
+@filters.register('invalid-kms')
 class KmsKeyActive(Filter):
     """
     Filter to ignore volumes that have an active KMS Key.
@@ -534,7 +534,7 @@ class KmsKeyActive(Filter):
               - name: delete-volumes-with-missing-keys
                 resource: ebs
                 filters:
-                  - skip-active-kms
+                  - invalid-kms
 
     :example:
 
@@ -546,12 +546,12 @@ class KmsKeyActive(Filter):
               - name: delete-volumes
                 resource: ebs
                 filters:
-                  - type: skip-active-kms
+                  - type: invalid-kms
                     value: false
 
     """
 
-    schema = type_schema('skip-active-kms', value={'type': 'boolean'})
+    schema = type_schema('invalid-kms', value={'type': 'boolean'})
 
     def get_permissions(self):
         return self.manager.get_resource_manager('ec2').get_permissions()

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -27,7 +27,7 @@ from c7n.actions import ActionRegistry, BaseAction
 from c7n.exceptions import PolicyValidationError
 from c7n.filters import (
     CrossAccountAccessFilter, Filter, FilterRegistry, AgeFilter, ValueFilter,
-    ANNOTATION_KEY, OPERATORS)
+    ANNOTATION_KEY, FilterValidationError, OPERATORS, FilterKmsInvalid)
 from c7n.filters.health import HealthEventFilter
 
 from c7n.manager import resources
@@ -469,7 +469,7 @@ class KmsKeyAlias(ResourceKmsKeyAlias):
 
 
 @Snapshot.filter_registry.register('invalid-kms')
-class KmsKeyActiveSnapshot(Filter):
+class KmsKeyActiveSnapshot(FilterKmsInvalid):
     """
     Filter to ignore snapshots that have an active KMS Key.
 
@@ -507,18 +507,9 @@ class KmsKeyActiveSnapshot(Filter):
     def get_permissions(self):
         return self.manager.get_resource_manager('ec2').get_permissions()
 
-    def validate(self):
-        if not isinstance(self.data.get('value', True), bool):
-            raise FilterValidationError(
-                "invalid config: expected boolean value")
-        return self
-
-    def process(self, snapshots, event=None):
-        return _filter_kms_active(self, snapshots)
-
 
 @filters.register('invalid-kms')
-class KmsKeyActive(Filter):
+class KmsKeyActive(FilterKmsInvalid):
     """
     Filter to ignore volumes that have an active KMS Key.
 
@@ -555,15 +546,6 @@ class KmsKeyActive(Filter):
 
     def get_permissions(self):
         return self.manager.get_resource_manager('ec2').get_permissions()
-
-    def validate(self):
-        if not isinstance(self.data.get('value', True), bool):
-            raise FilterValidationError(
-                "invalid config: expected boolean value")
-        return self
-
-    def process(self, resources, event=None):
-        return _filter_kms_active(self, resources)
 
 
 @filters.register('fault-tolerant')

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -504,6 +504,9 @@ class KmsKeyActive(Filter):
 
     schema = type_schema('skip-active-kms', value={'type': 'boolean'})
 
+    def get_permissions(self):
+        return self.manager.get_resource_manager('ec2').get_permissions()
+
     def validate(self):
         if not isinstance(self.data.get('value', True), bool):
             raise FilterValidationError(
@@ -548,6 +551,9 @@ class KmsKeyActive(Filter):
     """
 
     schema = type_schema('skip-active-kms', value={'type': 'boolean'})
+
+    def get_permissions(self):
+        return self.manager.get_resource_manager('ec2').get_permissions()
 
     def validate(self):
         if not isinstance(self.data.get('value', True), bool):

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1165,7 +1165,7 @@ class RestoreInstance(BaseAction):
         return params, post_modify
 
 
-@RDSSnapshot.filter_registry.register('skip-active-kms')
+@RDSSnapshot.filter_registry.register('invalid-kms')
 class KmsKeyActive(Filter):
     """
     Filter to ignore snapshots that have an active KMS Key.
@@ -1182,7 +1182,7 @@ class KmsKeyActive(Filter):
               - name: delete-snapshots-with-missing-keys
                 resource: rds-snapshot
                 filters:
-                  - skip-active-kms
+                  - invalid-kms
 
     :example:
 
@@ -1194,12 +1194,12 @@ class KmsKeyActive(Filter):
               - name: delete-snapshots
                 resource: rds-snapshot
                 filters:
-                  - type: skip-active-kms
+                  - type: invalid-kms
                     value: false
 
     """
 
-    schema = type_schema('skip-active-kms', value={'type': 'boolean'})
+    schema = type_schema('invalid-kms', value={'type': 'boolean'})
 
     def get_permissions(self):
         return self.manager.get_resource_manager('rds').get_permissions()

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1213,6 +1213,7 @@ class KmsKeyActive(Filter):
     def process(self, snapshots, event=None):
         return _filter_kms_active(self, snapshots)
 
+
 def _filter_kms_active(self, resources):
     if not self.data.get('value', True):
         return resources

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1201,6 +1201,9 @@ class KmsKeyActive(Filter):
 
     schema = type_schema('skip-active-kms', value={'type': 'boolean'})
 
+    def get_permissions(self):
+        return self.manager.get_resource_manager('rds').get_permissions()
+
     def validate(self):
         if not isinstance(self.data.get('value', True), bool):
             raise FilterValidationError(

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1223,7 +1223,7 @@ def _filter_kms_active(self, resources):
 
     matches = []
     for item in resources:
-        elif item['Encrypted'] and item['KmsKeyId'] not in key_ids:
+        if item['Encrypted'] and item['KmsKeyId'] not in key_ids:
             matches.append(item)
     return matches
 

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1211,7 +1211,7 @@ class KmsKeyActive(Filter):
         return self
 
     def process(self, snapshots, event=None):
-       return _filter_kms_active(self, snapshots)
+        return _filter_kms_active(self, snapshots)
 
 def _filter_kms_active(self, resources):
     if not self.data.get('value', True):
@@ -1229,6 +1229,7 @@ def _filter_kms_active(self, resources):
         if item['Encrypted'] and item['KmsKeyId'] not in key_ids:
             matches.append(item)
     return matches
+
 
 @RDSSnapshot.filter_registry.register('cross-account')
 class CrossAccountAccess(CrossAccountAccessFilter):

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1165,6 +1165,68 @@ class RestoreInstance(BaseAction):
         return params, post_modify
 
 
+@RDSSnapshot.filter_registry.register('skip-active-kms')
+class KmsKeyActive(Filter):
+    """
+    Filter to ignore snapshots that have an active KMS Key.
+
+    This filter is 'true' by default.
+
+    :example:
+
+    implicit with no parameters, 'true' by default
+
+    .. code-block:: yaml
+
+            policies:
+              - name: delete-snapshots-with-missing-keys
+                resource: rds-snapshot
+                filters:
+                  - skip-active-kms
+
+    :example:
+
+    explicit with parameter
+
+    .. code-block:: yaml
+
+            policies:
+              - name: delete-snapshots
+                resource: rds-snapshot
+                filters:
+                  - type: skip-active-kms
+                    value: false
+
+    """
+
+    schema = type_schema('skip-active-kms', value={'type': 'boolean'})
+
+    def validate(self):
+        if not isinstance(self.data.get('value', True), bool):
+            raise FilterValidationError(
+                "invalid config: expected boolean value")
+        return self
+
+    def process(self, snapshots, event=None):
+       return _filter_kms_active(self, snapshots)
+
+def _filter_kms_active(self, resources):
+    if not self.data.get('value', True):
+        return resources
+    # try using cache first to get a listing of all KMS Keys and compares resources to the list
+    # This will populate the cache.
+    kms_keys = self.manager.get_resource_manager('kms-key').resources()
+
+    key_ids = []
+    for key in kms_keys:
+        key_ids.append(key['KeyArn'])
+
+    matches = []
+    for item in resources:
+        elif item['Encrypted'] and item['KmsKeyId'] not in key_ids:
+            matches.append(item)
+    return matches
+
 @RDSSnapshot.filter_registry.register('cross-account')
 class CrossAccountAccess(CrossAccountAccessFilter):
 


### PR DESCRIPTION
…ad the kms key deleted

I put the same logic in both ebs.py and rds.py for the kms active filter.  I can move this to a central location if preferred(if so recommend where it should go).

The idea behind this check is if the kms key has been deleted we have no need to keep the data around as the data can no longer be decrypted.