### PR TITLE
Make the cache aware of profiles (#1925)

### DIFF
--- a/c7n/query.py
+++ b/c7n/query.py
@@ -386,9 +386,12 @@ class QueryResourceManager(ResourceManager):
         return perms
 
     def get_cache_key(self, query):
-        return {'region': self.config.region,
-                'resource': str(self.__class__.__name__),
-                'q': query}
+        return {
+            'profile': self.config.profile,
+            'region': self.config.region,
+            'resource': str(self.__class__.__name__),
+            'q': query
+        }
 
     def resources(self, query=None):
         key = self.get_cache_key(query)

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -387,7 +387,7 @@ class QueryResourceManager(ResourceManager):
 
     def get_cache_key(self, query):
         return {
-            'profile': self.config.profile,
+            'account': self.account_id,
             'region': self.config.region,
             'resource': str(self.__class__.__name__),
             'q': query

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -57,10 +57,10 @@ class FileCacheManagerTest(TestCase):
         self.addCleanup(t.close)
         c = cache.FileCacheManager(Namespace(cache_period=60, cache=t.name))
         self.assertFalse(c.load())
-        k1 = {'region': 'us-west-2', 'resource': 'ec2'}
+        k1 = {'profile': 'us-prod', 'region': 'us-west-2', 'resource': 'ec2'}
         c.save(k1, range(5))
         self.assertEqual(c.get(k1), range(5))
-        k2 = {'region': 'eu-west-1', 'resource': 'asg'}
+        k2 = {'profile': 'eu-prod', 'region': 'eu-west-1', 'resource': 'asg'}
         c.save(k2, range(2))
         self.assertEqual(c.get(k1), range(5))
         self.assertEqual(c.get(k2), range(2))

--- a/tests/test_cache.py
+++ b/tests/test_cache.py
@@ -57,10 +57,10 @@ class FileCacheManagerTest(TestCase):
         self.addCleanup(t.close)
         c = cache.FileCacheManager(Namespace(cache_period=60, cache=t.name))
         self.assertFalse(c.load())
-        k1 = {'profile': 'us-prod', 'region': 'us-west-2', 'resource': 'ec2'}
+        k1 = {'account': '12345678901234', 'region': 'us-west-2', 'resource': 'ec2'}
         c.save(k1, range(5))
         self.assertEqual(c.get(k1), range(5))
-        k2 = {'profile': 'eu-prod', 'region': 'eu-west-1', 'resource': 'asg'}
+        k2 = {'account': '98765432101234', 'region': 'eu-west-1', 'resource': 'asg'}
         c.save(k2, range(2))
         self.assertEqual(c.get(k1), range(5))
         self.assertEqual(c.get(k2), range(2))

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -28,7 +28,9 @@ class CliTest(BaseTest):
     """ A subclass of BaseTest with some handy functions for CLI related tests. """
 
     def patch_account_id(self):
-        test_account_id = lambda x: self.account_id
+        def test_account_id(options):
+            options.account_id = self.account_id
+
         self.patch(cli, '_default_account_id', test_account_id)
 
     def get_output(self, argv):


### PR DESCRIPTION
#1925 

The cache was storing by region, resource, and query, but it ignored profiles.  I added that in to the cache key.

@kapilt - I tested on my end and it seems to work fine.  I can see the profile is stored in the cache file and when I test with profile that link to the same region in different accounts (skunkworks vs. my own personal account) the results are as expected.  It was a tiny change though - so are there any considerations I may have missed?