### PR TITLE
deterministic lambda packaging / delta fixes 

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -229,8 +229,8 @@ def checksum(fh, hasher, blocksize=65536):
 def custodian_archive(packages=None):
     """Create a lambda code archive for running custodian.
 
-    Lambda archive currently always includes `c7n` and `pkg_resources`. Add additional
-    packages in the mode block
+    Lambda archive currently always includes `c7n` and
+    `pkg_resources`. Add additional packages in the mode block.
 
     Example policy that includes additional packages
 
@@ -243,13 +243,13 @@ def custodian_archive(packages=None):
             packages:
               - botocore
 
-    Kwargs:
-        packages (set): List of additional packages to include in the lambda archive.
+    packages: List of additional packages to include in the lambda archive.
+
     """
     modules = {'c7n', 'pkg_resources'}
     if packages:
         modules = filter(None, modules.union(packages))
-    return PythonPackageArchive(*modules)
+    return PythonPackageArchive(*sorted(modules))
 
 
 class LambdaManager(object):
@@ -389,7 +389,8 @@ class LambdaManager(object):
         changed = False
         if existing:
             old_config = existing['Configuration']
-            if archive.get_checksum() != old_config['CodeSha256']:
+            if archive.get_checksum() != old_config[
+                    'CodeSha256'].encode('ascii'):
                 log.debug("Updating function %s code", func.name)
                 params = dict(FunctionName=func.name, Publish=True)
                 params.update(code_ref)

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -609,7 +609,7 @@ LAMBDA_EMPTY_VALUES = {
     'TracingConfig': {'Mode': 'PassThrough'},
     'VpcConfig': {'SubnetIds': [], 'SecurityGroupIds': []},
     'KMSKeyArn': '',
-    }
+}
 
 
 class LambdaFunction(AbstractLambdaFunction):

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -537,13 +537,6 @@ class PolicyLambdaProvision(BaseTest):
         self.assertTrue('boto3/utils.py' in pl.archive.get_filenames())
         self.assertTrue('botocore/utils.py' in pl.archive.get_filenames())
 
-    def get_lambda_func(self, **config):
-        m = {'resources': 's3',
-             'name': 'some-lamb',
-             'mode': {'type': 'cloudtrail', 'events': ['CreateBucket']}}
-        m['mode'].update(config)
-        return PolicyLambda(Policy(m, Config.empty()))
-
     def test_delta_config_diff(self):
         delta = LambdaManager.delta_function
         self.assertFalse(

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -58,9 +58,7 @@ class Publish(BaseTest):
             '''def handler(*a, **kw):\n    print("Greetings, program!")''')
         archive.close()
         self.addCleanup(archive.remove)
-
         return LambdaFunction(func_data, archive)
-
 
     def test_publishes_a_lambda(self):
         session_factory = self.replay_flight_data('test_publishes_a_lambda')


### PR DESCRIPTION
better policy lambda update delta calculation prior to change.

code update delta
- mu sort modules added for deterministic zip manifest
- code archive checksum encoded for binary string compare on py 3.6

config update delta
- specify empty value defaults
- correctly detect drift in vpc config
- properly handle deletion of environment, vpc config, dead letter queue, etc

fixes #1978 

