### PR TITLE
validate child resource explicitly supports trail event lambda policies

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -34,6 +34,7 @@ from c7n.manager import resources
 from c7n.output import DEFAULT_NAMESPACE
 from c7n.resources import load_resources
 from c7n import mu
+from c7n import query
 from c7n import utils
 from c7n.logs_support import (
     normalized_log_entries,
@@ -536,6 +537,12 @@ class CloudTrailMode(LambdaMode):
                 assert e in CloudWatchEvents.trail_events, "event shortcut not defined: %s" % e
             if isinstance(e, dict):
                 jmespath.compile(e['ids'])
+        if isinstance(self.policy.resource_manager, query.ChildResourceManager):
+            if not getattr(self.policy.resource_manager.resource_type,
+                           'supports_trailevents', False):
+                raise ValueError(
+                    "resource:%s does not support cloudtrail mode policies" % (
+                        self.policy.resource_type))
 
 
 class EC2InstanceState(LambdaMode):

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -249,6 +249,19 @@ class TestPolicyCollection(BaseTest):
 
 class TestPolicy(BaseTest):
 
+    def test_child_resource_trail_validation(self):
+        self.assertRaises(
+            ValueError,
+            self.load_policy,
+            {'name': 'api-resources',
+             'resource': 'rest-resource',
+             'mode': {
+                 'type': 'cloudtrail',
+                 'events': [
+                     {'source': 'apigateway.amazonaws.com',
+                      'event': 'UpdateResource',
+                      'ids': 'requestParameter.stageName'}]}})
+
     def test_load_policy_validation_error(self):
         invalid_policies = {
             'policies':
@@ -261,7 +274,6 @@ class TestPolicy(BaseTest):
             }]
         }
         self.assertRaises(Exception, self.load_policy_set, invalid_policies)
-
 
     def test_policy_validation(self):
         policy = self.load_policy({


### PR DESCRIPTION

per #1976 we should fail attempts to deploy a lambda cloud trail event policy on child resources at validation time, as its not supported at the moment, rather than getting runtime lambda failures.