### PR TITLE
sagemaker resources update

### DIFF
--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -51,9 +51,6 @@ class NotebookInstance(QueryResourceManager):
             tags = client.list_tags(
                 ResourceArn=r['NotebookInstanceArn'])['Tags']
             r['Tags'] = tags
-
-            # normalize arn attribute for flat tagging
-            r['ResourceArn'] = r['NotebookInstanceArn']
             return r
 
         # Describe notebook-instance & then list tags
@@ -104,9 +101,6 @@ class SagemakerEndpoint(QueryResourceManager):
             tags = client.list_tags(
                 ResourceArn=e['EndpointArn'])['Tags']
             e['Tags'] = tags
-
-            # normalize arn attribute for flat tagging
-            e['ResourceArn'] = e['EndpointArn']
             return e
 
         # Describe endpoints & then list tags
@@ -141,9 +135,6 @@ class SagemakerEndpointConfig(QueryResourceManager):
             tags = client.list_tags(
                 ResourceArn=e['EndpointConfigArn'])['Tags']
             e['Tags'] = tags
-
-            # normalize arn attribute for flat tagging
-            e['ResourceArn'] = e['EndpointConfigArn']
             return e
 
         endpoints = super(SagemakerEndpointConfig, self).augment(endpoints)
@@ -219,9 +210,8 @@ class TagNotebookInstance(Tag):
         tag_list = []
         for t in tags:
             tag_list.append({'Key': t['Key'], 'Value': t['Value']})
-
         for r in resources:
-            client.add_tags(ResourceArn=r['ResourceArn'], Tags=tag_list)
+            client.add_tags(ResourceArn=r[self.id_key], Tags=tag_list)
 
 
 @SagemakerEndpoint.action_registry.register('remove-tag')
@@ -267,7 +257,7 @@ class RemoveTagNotebookInstance(RemoveTag):
             self.manager.session_factory).client('sagemaker')
 
         for r in resources:
-            client.delete_tags(ResourceArn=r['ResourceArn'], TagKeys=keys)
+            client.delete_tags(ResourceArn=r[self.id_key], TagKeys=keys)
 
 
 @SagemakerEndpoint.action_registry.register('mark-for-op')
@@ -323,7 +313,7 @@ class MarkNotebookInstanceForOp(TagDelayedAction):
             tag_list.append({'Key': t['Key'], 'Value': t['Value']})
 
         for r in resources:
-            client.add_tags(ResourceArn=r['ResourceArn'], Tags=tag_list)
+            client.add_tags(ResourceArn=r[self.id_key], Tags=tag_list)
 
 
 @NotebookInstance.action_registry.register('start')

--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -44,9 +44,9 @@ class NotebookInstance(QueryResourceManager):
     permissions = ('sagemaker:ListTags',)
 
     def augment(self, resources):
-        def _augment(r):
-            client = local_session(self.session_factory).client('sagemaker')
+        client = local_session(self.session_factory).client('sagemaker')
 
+        def _augment(r):
             # List tags for the Notebook-Instance & set as attribute
             tags = client.list_tags(
                 ResourceArn=r['NotebookInstanceArn'])['Tags']
@@ -96,8 +96,9 @@ class SagemakerEndpoint(QueryResourceManager):
     permissions = ('sagemaker:ListTags',)
 
     def augment(self, endpoints):
+        client = local_session(self.session_factory).client('sagemaker')
+
         def _augment(e):
-            client = local_session(self.session_factory).client('sagemaker')
             tags = client.list_tags(
                 ResourceArn=e['EndpointArn'])['Tags']
             e['Tags'] = tags
@@ -130,8 +131,9 @@ class SagemakerEndpointConfig(QueryResourceManager):
     permissions = ('sagemaker:ListTags',)
 
     def augment(self, endpoints):
+        client = local_session(self.session_factory).client('sagemaker')
+
         def _augment(e):
-            client = local_session(self.session_factory).client('sagemaker')
             tags = client.list_tags(
                 ResourceArn=e['EndpointConfigArn'])['Tags']
             e['Tags'] = tags

--- a/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.AddTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.AddTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "2f9837d2-b2ef-45ee-8cd3-96f82c8bcc8d", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:40:36 GMT", 
+                "x-amzn-requestid": "2f9837d2-b2ef-45ee-8cd3-96f82c8bcc8d", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/30", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.DescribeEndpointConfig_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.DescribeEndpointConfig_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 46, 
+            "microsecond": 215000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 44
+        }, 
+        "ProductionVariants": [
+            {
+                "InitialVariantWeight": 1.0, 
+                "ModelName": "tmp-for-test-a", 
+                "VariantName": "variant-name-1", 
+                "InitialInstanceCount": 1, 
+                "InstanceType": "ml.m4.xlarge"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3e4ff1a6-4a47-45df-9d57-eb89c2a67cdf", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:40:33 GMT", 
+                "x-amzn-requestid": "3e4ff1a6-4a47-45df-9d57-eb89c2a67cdf", 
+                "content-length": "342", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.ListEndpointConfigs_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.ListEndpointConfigs_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "a4894098-7a60-4da3-853e-05d21c10c4cc", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:40:33 GMT", 
+                "x-amzn-requestid": "a4894098-7a60-4da3-853e-05d21c10c4cc", 
+                "content-length": "197", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigs": [
+            {
+                "EndpointConfigName": "c7n-endpoint-config", 
+                "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 46, 
+                    "microsecond": 215000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 44
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.ListTags_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "645d195e-42fb-4de6-a975-51f85c1ca8a9", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:40:35 GMT", 
+                "x-amzn-requestid": "645d195e-42fb-4de6-a975-51f85c1ca8a9", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_mark_for_op/sagemaker.ListTags_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e9221a22-47b1-4092-a1f0-60cb1b71257d", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:40:37 GMT", 
+                "x-amzn-requestid": "e9221a22-47b1-4092-a1f0-60cb1b71257d", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/30", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_marked_for_op/sagemaker.DescribeEndpointConfig_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_marked_for_op/sagemaker.DescribeEndpointConfig_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 46, 
+            "microsecond": 215000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 44
+        }, 
+        "ProductionVariants": [
+            {
+                "InitialVariantWeight": 1.0, 
+                "ModelName": "tmp-for-test-a", 
+                "VariantName": "variant-name-1", 
+                "InitialInstanceCount": 1, 
+                "InstanceType": "ml.m4.xlarge"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "fdf3703a-c1e6-47d0-849a-3e4a869fa7ce", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:41:24 GMT", 
+                "x-amzn-requestid": "fdf3703a-c1e6-47d0-849a-3e4a869fa7ce", 
+                "content-length": "342", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_marked_for_op/sagemaker.ListEndpointConfigs_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_marked_for_op/sagemaker.ListEndpointConfigs_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "7f00df2a-1415-4d8e-bd89-a5123176c2e4", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:41:23 GMT", 
+                "x-amzn-requestid": "7f00df2a-1415-4d8e-bd89-a5123176c2e4", 
+                "content-length": "197", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigs": [
+            {
+                "EndpointConfigName": "c7n-endpoint-config", 
+                "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 46, 
+                    "microsecond": 215000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 44
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_marked_for_op/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_marked_for_op/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6fb3ba70-95db-4ad4-8db5-e065a8650b66", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:41:24 GMT", 
+                "x-amzn-requestid": "6fb3ba70-95db-4ad4-8db5-e065a8650b66", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/30", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.DeleteTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.DeleteTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "2419f10d-16ef-479a-bc63-e5c845aa7d7f", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:33:33 GMT", 
+                "x-amzn-requestid": "2419f10d-16ef-479a-bc63-e5c845aa7d7f", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.DescribeEndpointConfig_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.DescribeEndpointConfig_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 46, 
+            "microsecond": 215000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 44
+        }, 
+        "ProductionVariants": [
+            {
+                "InitialVariantWeight": 1.0, 
+                "ModelName": "tmp-for-test-a", 
+                "VariantName": "variant-name-1", 
+                "InitialInstanceCount": 1, 
+                "InstanceType": "ml.m4.xlarge"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "41b8ad0b-c5c8-4055-a9db-e71ebfc29d23", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:33:32 GMT", 
+                "x-amzn-requestid": "41b8ad0b-c5c8-4055-a9db-e71ebfc29d23", 
+                "content-length": "342", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.ListEndpointConfigs_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.ListEndpointConfigs_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "2363b954-07d7-4709-95ce-1f7d99d3323e", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:33:32 GMT", 
+                "x-amzn-requestid": "2363b954-07d7-4709-95ce-1f7d99d3323e", 
+                "content-length": "197", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigs": [
+            {
+                "EndpointConfigName": "c7n-endpoint-config", 
+                "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 46, 
+                    "microsecond": 215000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 44
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c60ecce5-9bdc-44e3-ad4c-9ff429549fae", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:33:32 GMT", 
+                "x-amzn-requestid": "c60ecce5-9bdc-44e3-ad4c-9ff429549fae", 
+                "content-length": "56", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "expired-value", 
+                "Key": "expired-tag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_remove_tag/sagemaker.ListTags_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "4f51f1b5-4b8e-4e5c-8fcc-24cea53fe635", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:33:33 GMT", 
+                "x-amzn-requestid": "4f51f1b5-4b8e-4e5c-8fcc-24cea53fe635", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.AddTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.AddTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "a3376931-067e-442a-b8e3-79e2331ad999", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:31:43 GMT", 
+                "x-amzn-requestid": "a3376931-067e-442a-b8e3-79e2331ad999", 
+                "content-length": "58", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "required-value", 
+                "Key": "required-tag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.DescribeEndpointConfig_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.DescribeEndpointConfig_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200, 
+    "data": {
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 46, 
+            "microsecond": 215000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 44
+        }, 
+        "ProductionVariants": [
+            {
+                "InitialVariantWeight": 1.0, 
+                "ModelName": "tmp-for-test-a", 
+                "VariantName": "variant-name-1", 
+                "InitialInstanceCount": 1, 
+                "InstanceType": "ml.m4.xlarge"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "40da71a1-8e74-4075-8553-9bea229e69fd", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:31:42 GMT", 
+                "x-amzn-requestid": "40da71a1-8e74-4075-8553-9bea229e69fd", 
+                "content-length": "342", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.ListEndpointConfigs_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.ListEndpointConfigs_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "8b1a9f09-25f6-4bce-a61c-cbb574a10f7a", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:31:42 GMT", 
+                "x-amzn-requestid": "8b1a9f09-25f6-4bce-a61c-cbb574a10f7a", 
+                "content-length": "197", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigs": [
+            {
+                "EndpointConfigName": "c7n-endpoint-config", 
+                "EndpointConfigArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint-config/c7n-endpoint-config", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 46, 
+                    "microsecond": 215000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 44
+                }
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.ListTags_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "dc40f2e4-fa5f-45f0-a79f-1d950f484502", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:31:43 GMT", 
+                "x-amzn-requestid": "dc40f2e4-fa5f-45f0-a79f-1d950f484502", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_config_tag/sagemaker.ListTags_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "be8d4824-ae53-483f-9036-6ce0b46f884f", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:31:44 GMT", 
+                "x-amzn-requestid": "be8d4824-ae53-483f-9036-6ce0b46f884f", 
+                "content-length": "58", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "required-value", 
+                "Key": "required-tag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.AddTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.AddTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6cd83b75-7694-4aca-ad5e-ec358b745565", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:22:29 GMT", 
+                "x-amzn-requestid": "6cd83b75-7694-4aca-ad5e-ec358b745565", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/30", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.DescribeEndpoint_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.DescribeEndpoint_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "0bf94229-6439-489e-91df-174897daa64a", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:22:27 GMT", 
+                "x-amzn-requestid": "0bf94229-6439-489e-91df-174897daa64a", 
+                "content-length": "362", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 23, 
+            "microsecond": 717000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 45
+        }, 
+        "EndpointName": "c7n-endpoint", 
+        "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+        "LastModifiedTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 40, 
+            "microsecond": 81000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 56
+        }, 
+        "EndpointStatus": "Failed", 
+        "FailureReason": " The primary container for production variant variant-name-1 did not pass the ping health check."
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.ListEndpoints_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.ListEndpoints_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Endpoints": [
+            {
+                "EndpointName": "c7n-endpoint", 
+                "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 23, 
+                    "microsecond": 717000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 45
+                }, 
+                "LastModifiedTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 40, 
+                    "microsecond": 81000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 56
+                }, 
+                "EndpointStatus": "Failed"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "deb7f4fa-b992-45b2-aedc-f24154c33413", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:22:26 GMT", 
+                "x-amzn-requestid": "deb7f4fa-b992-45b2-aedc-f24154c33413", 
+                "content-length": "220", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.ListTags_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "668071fa-db83-4ddc-a86a-b02ddd4851a8", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:22:28 GMT", 
+                "x-amzn-requestid": "668071fa-db83-4ddc-a86a-b02ddd4851a8", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_mark_for_op/sagemaker.ListTags_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "15f070c1-0ac5-47ed-a9b3-0c3358d266b8", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:22:29 GMT", 
+                "x-amzn-requestid": "15f070c1-0ac5-47ed-a9b3-0c3358d266b8", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/30", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_marked_for_op/sagemaker.DescribeEndpoint_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_marked_for_op/sagemaker.DescribeEndpoint_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "8563d71c-6e39-413a-8be7-823b78557499", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:24:39 GMT", 
+                "x-amzn-requestid": "8563d71c-6e39-413a-8be7-823b78557499", 
+                "content-length": "362", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 23, 
+            "microsecond": 717000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 45
+        }, 
+        "EndpointName": "c7n-endpoint", 
+        "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+        "LastModifiedTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 40, 
+            "microsecond": 81000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 56
+        }, 
+        "EndpointStatus": "Failed", 
+        "FailureReason": " The primary container for production variant variant-name-1 did not pass the ping health check."
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_marked_for_op/sagemaker.ListEndpoints_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_marked_for_op/sagemaker.ListEndpoints_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Endpoints": [
+            {
+                "EndpointName": "c7n-endpoint", 
+                "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 23, 
+                    "microsecond": 717000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 45
+                }, 
+                "LastModifiedTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 40, 
+                    "microsecond": 81000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 56
+                }, 
+                "EndpointStatus": "Failed"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ac7b8945-0e55-4087-ba36-7c581e79e17f", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:24:38 GMT", 
+                "x-amzn-requestid": "ac7b8945-0e55-4087-ba36-7c581e79e17f", 
+                "content-length": "220", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_marked_for_op/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_marked_for_op/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d6e293e1-f72c-4821-82d4-2eaa06e247f6", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:24:39 GMT", 
+                "x-amzn-requestid": "d6e293e1-f72c-4821-82d4-2eaa06e247f6", 
+                "content-length": "97", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/01/30", 
+                "Key": "custodian_cleanup"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.DeleteTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.DeleteTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d4d95c65-3a8c-4530-ab17-8ce7717aa251", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:19:08 GMT", 
+                "x-amzn-requestid": "d4d95c65-3a8c-4530-ab17-8ce7717aa251", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.DescribeEndpoint_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.DescribeEndpoint_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "b1553c19-89de-4ccc-8355-cbd7b09a4619", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:19:08 GMT", 
+                "x-amzn-requestid": "b1553c19-89de-4ccc-8355-cbd7b09a4619", 
+                "content-length": "362", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 23, 
+            "microsecond": 717000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 45
+        }, 
+        "EndpointName": "c7n-endpoint", 
+        "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+        "LastModifiedTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 40, 
+            "microsecond": 81000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 56
+        }, 
+        "EndpointStatus": "Failed", 
+        "FailureReason": " The primary container for production variant variant-name-1 did not pass the ping health check."
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.ListEndpoints_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.ListEndpoints_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Endpoints": [
+            {
+                "EndpointName": "c7n-endpoint", 
+                "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 23, 
+                    "microsecond": 717000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 45
+                }, 
+                "LastModifiedTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 40, 
+                    "microsecond": 81000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 56
+                }, 
+                "EndpointStatus": "Failed"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ed3b0dbf-db75-4d6a-a22c-7ab0b1d1653d", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:19:06 GMT", 
+                "x-amzn-requestid": "ed3b0dbf-db75-4d6a-a22c-7ab0b1d1653d", 
+                "content-length": "220", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "71e07cc5-4072-48cc-9848-64ca676c8579", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:19:08 GMT", 
+                "x-amzn-requestid": "71e07cc5-4072-48cc-9848-64ca676c8579", 
+                "content-length": "56", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "expired-value", 
+                "Key": "expired-tag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_remove_tag/sagemaker.ListTags_2.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6e0992e9-a684-49e0-98e2-23e8dae5cc67", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:19:10 GMT", 
+                "x-amzn-requestid": "6e0992e9-a684-49e0-98e2-23e8dae5cc67", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.AddTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.AddTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "11f77152-8f89-4f36-8b58-48adc0dc91c2", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:30:25 GMT", 
+                "x-amzn-requestid": "11f77152-8f89-4f36-8b58-48adc0dc91c2", 
+                "content-length": "58", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "required-value", 
+                "Key": "required-tag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.DescribeEndpoint_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.DescribeEndpoint_1.json
@@ -1,0 +1,42 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "a48e6f07-1def-4ac7-af8c-92896a1ba027", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:30:23 GMT", 
+                "x-amzn-requestid": "a48e6f07-1def-4ac7-af8c-92896a1ba027", 
+                "content-length": "362", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "EndpointConfigName": "c7n-endpoint-config", 
+        "CreationTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 23, 
+            "microsecond": 717000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 45
+        }, 
+        "EndpointName": "c7n-endpoint", 
+        "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+        "LastModifiedTime": {
+            "hour": 9, 
+            "__class__": "datetime", 
+            "month": 1, 
+            "second": 40, 
+            "microsecond": 81000, 
+            "year": 2018, 
+            "day": 29, 
+            "minute": 56
+        }, 
+        "EndpointStatus": "Failed", 
+        "FailureReason": " The primary container for production variant variant-name-1 did not pass the ping health check."
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.ListEndpoints_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.ListEndpoints_1.json
@@ -1,0 +1,44 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Endpoints": [
+            {
+                "EndpointName": "c7n-endpoint", 
+                "EndpointArn": "arn:aws:sagemaker:us-east-1:644160558196:endpoint/c7n-endpoint", 
+                "CreationTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 23, 
+                    "microsecond": 717000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 45
+                }, 
+                "LastModifiedTime": {
+                    "hour": 9, 
+                    "__class__": "datetime", 
+                    "month": 1, 
+                    "second": 40, 
+                    "microsecond": 81000, 
+                    "year": 2018, 
+                    "day": 29, 
+                    "minute": 56
+                }, 
+                "EndpointStatus": "Failed"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c7a32f57-e4b6-4fd4-9fdc-7e9f5822751f", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:30:23 GMT", 
+                "x-amzn-requestid": "c7a32f57-e4b6-4fd4-9fdc-7e9f5822751f", 
+                "content-length": "220", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.ListTags_1.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.ListTags_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "612224c3-e5d3-494a-84e5-c7a4a01f3490", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:30:24 GMT", 
+                "x-amzn-requestid": "612224c3-e5d3-494a-84e5-c7a4a01f3490", 
+                "content-length": "11", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": []
+    }
+}

--- a/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.ListTags_2.json
+++ b/tests/data/placebo/test_sagemaker_endpoint_tag/sagemaker.ListTags_2.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f381adad-6160-487c-a876-f5d60bcf6178", 
+            "HTTPHeaders": {
+                "date": "Mon, 29 Jan 2018 15:30:25 GMT", 
+                "x-amzn-requestid": "f381adad-6160-487c-a876-f5d60bcf6178", 
+                "content-length": "58", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "required-value", 
+                "Key": "required-tag"
+            }
+        ]
+    }
+}


### PR DESCRIPTION
- moving filters definition to inside class for each resource
- removing try/except for most resource actions
  - excepting ResourceNotFound for sagemaker training-job stop action
- adding 'ResourceArn' attribute augment to notebook-instance, endpoint, endpoint-config to allow for single tag/remove-tag/mark-for-op functions
  - adding endpoint & endpoint-config action decorators for tagging actions