### PR TITLE
Add ECS Task Definition filter_name/filter_value

### DIFF
--- a/c7n/resources/ecs.py
+++ b/c7n/resources/ecs.py
@@ -256,6 +256,8 @@ class TaskDefinition(query.QueryResourceManager):
             'describe_task_definition', 'taskDefinition', None,
             'taskDefinition')
         dimension = None
+        filter_name = None
+        filter_type = None
 
 
 @TaskDefinition.action_registry.register('delete')


### PR DESCRIPTION
Fixes error when running custodian in cloudwatch event mode:

```
type object 'resource_type' has no attribute 'filter_name': AttributeError
Traceback (most recent call last):
File "/var/task/custodian_policy.py", line 4, in run
return handler.dispatch_event(event, context)
File "/var/task/c7n/handler.py", line 109, in dispatch_event
p.push(event, context)
File "/var/task/c7n/policy.py", line 712, in push
return mode.run(event, lambda_ctx)
File "/var/task/c7n/policy.py", line 436, in run
resources = self.resolve_resources(event)
File "/var/task/c7n/policy.py", line 413, in resolve_resources
resources = self.policy.resource_manager.get_resources(resource_ids)
File "/var/task/c7n/query.py", line 416, in get_resources
resources = self.augment(self.source.get_resources(ids))
File "/var/task/c7n/query.py", line 210, in get_resources
return self.query.get(self.manager, ids)
File "/var/task/c7n/query.py", line 91, in get
if m.filter_name:
AttributeError: type object 'resource_type' has no attribute 'filter_name'
```