### PR TITLE
Update empty DeadLetterConfig values for Lambda policies

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -605,7 +605,7 @@ class AbstractLambdaFunction:
 
 LAMBDA_EMPTY_VALUES = {
     'Environment': {'Variables': {}},
-    'DeadLetterConfig': {'TargetArn': ''},
+    'DeadLetterConfig': {},
     'TracingConfig': {'Mode': 'PassThrough'},
     'VpcConfig': {'SubnetIds': [], 'SecurityGroupIds': []},
     'KMSKeyArn': '',

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -552,7 +552,7 @@ class PolicyLambdaProvision(BaseTest):
                                  'SecurityGroupIds': ['sg-3', 'sg-1']}})
             )
         self.assertFalse(
-            delta({}, {'DeadLetterConfig': {'TargetArn': ''}}))
+            delta({}, {'DeadLetterConfig': {}}))
 
         self.assertTrue(
             delta({}, {'DeadLetterConfig': {'TargetArn': 'arn'}}))
@@ -574,7 +574,7 @@ class PolicyLambdaProvision(BaseTest):
         self.maxDiff = None
         self.assertEqual(
             p.get_config(),
-            {'DeadLetterConfig': {'TargetArn': ''},
+            {'DeadLetterConfig': {},
              'Description': 'cloud-custodian lambda policy',
              'Environment': {'Variables': {}},
              'FunctionName': 'custodian-hello',


### PR DESCRIPTION
Update the empty DeadLetterConfig to address "Invalid dead letter queue ARN" errors when provisioning Lambda policies (#1990).

I'm happy to tweak this PR if the maintainers prefer another approach. This is more of a conversation starter :).