### PR TITLE
Always call 'unquote_plus' on the S3 object key value supplied by Inventory

### DIFF
--- a/tools/c7n_salactus/c7n_salactus/inventory.py
+++ b/tools/c7n_salactus/c7n_salactus/inventory.py
@@ -50,8 +50,7 @@ def load_manifest_file(client, bucket, schema, versioned, ifilters, key_info):
                 k = kr[1]
                 if inventory_filter(ifilters, schema, kr):
                     continue
-                if '%' in k:
-                    k = unquote_plus(k)
+                k = unquote_plus(k)
                 if versioned:
                     if kr[3] == 'true':
                         keys.append((k, kr[2], True))


### PR DESCRIPTION
Fixes https://github.com/capitalone/cloud-custodian/issues/1997.
Since the decoding is occurring after filtering it seems acceptable to call `unquote_plus` on all S3 object key values.