### PR TITLE
adding hourly functionality to mark-for-op

### DIFF
--- a/tests/data/placebo/test_ec2_mark_hours/ec2.CreateTags_1.json
+++ b/tests/data/placebo/test_ec2_mark_hours/ec2.CreateTags_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "595bba7a-c9ea-4198-ae3e-67d6b87995ed", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Mon, 12 Feb 2018 20:09:20 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_mark_hours/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_mark_hours/ec2.DescribeInstances_1.json
@@ -1,0 +1,161 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 18, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 56, 
+                            "microsecond": 0, 
+                            "year": 2018, 
+                            "day": 12, 
+                            "minute": 5
+                        }, 
+                        "PublicIpAddress": "54.210.46.230", 
+                        "PrivateIpAddress": "172.31.63.102", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-0981bd7350d22dbcd", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-97785bed", 
+                        "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-6", 
+                                "GroupId": "sg-52245925"
+                            }
+                        ], 
+                        "ClientToken": "", 
+                        "SubnetId": "subnet-3a334610", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "12:0b:ed:9f:e6:94", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "NetworkInterfaceId": "eni-126062df", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                                        "PrivateIpAddress": "172.31.63.102", 
+                                        "Primary": true, 
+                                        "Association": {
+                                            "PublicIp": "54.210.46.230", 
+                                            "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-b7e7f47a", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 56, 
+                                        "microsecond": 0, 
+                                        "year": 2018, 
+                                        "day": 12, 
+                                        "minute": 5
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-6", 
+                                        "GroupId": "sg-52245925"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.63.102", 
+                                "SubnetId": "subnet-3a334610", 
+                                "Association": {
+                                    "PublicIp": "54.210.46.230", 
+                                    "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1d"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-067ab83921fe0cf08", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 57, 
+                                        "microsecond": 0, 
+                                        "year": 2018, 
+                                        "day": 12, 
+                                        "minute": 5
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "Tags": [
+                            {
+                                "Value": "MarkForOpTest", 
+                                "Key": "Name"
+                            }, 
+                            {
+                                "Value": "joshuaroot", 
+                                "Key": "CreatorName"
+                            }
+                        ], 
+                        "AmiLaunchIndex": 0
+                    }
+                ], 
+                "ReservationId": "r-02d3311df84ec7fd4", 
+                "Groups": [], 
+                "OwnerId": "644160558196"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6662646d-816e-48fa-9936-a9fc7dde8083", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Mon, 12 Feb 2018 20:09:20 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_mark_hours/ec2.DescribeInstances_2.json
+++ b/tests/data/placebo/test_ec2_mark_hours/ec2.DescribeInstances_2.json
@@ -1,0 +1,165 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 18, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 56, 
+                            "microsecond": 0, 
+                            "year": 2018, 
+                            "day": 12, 
+                            "minute": 5
+                        }, 
+                        "PublicIpAddress": "54.210.46.230", 
+                        "PrivateIpAddress": "172.31.63.102", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-0981bd7350d22dbcd", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-97785bed", 
+                        "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-6", 
+                                "GroupId": "sg-52245925"
+                            }
+                        ], 
+                        "ClientToken": "", 
+                        "SubnetId": "subnet-3a334610", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "12:0b:ed:9f:e6:94", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "NetworkInterfaceId": "eni-126062df", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                                        "PrivateIpAddress": "172.31.63.102", 
+                                        "Primary": true, 
+                                        "Association": {
+                                            "PublicIp": "54.210.46.230", 
+                                            "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-b7e7f47a", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 56, 
+                                        "microsecond": 0, 
+                                        "year": 2018, 
+                                        "day": 12, 
+                                        "minute": 5
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-6", 
+                                        "GroupId": "sg-52245925"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.63.102", 
+                                "SubnetId": "subnet-3a334610", 
+                                "Association": {
+                                    "PublicIp": "54.210.46.230", 
+                                    "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1d"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-067ab83921fe0cf08", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 57, 
+                                        "microsecond": 0, 
+                                        "year": 2018, 
+                                        "day": 12, 
+                                        "minute": 5
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "Tags": [
+                            {
+                                "Value": "MarkForOpTest", 
+                                "Key": "Name"
+                            }, 
+                            {
+                                "Value": "Resource does not meet policy: stop@2018/02/12 23:00", 
+                                "Key": "hourly-mark"
+                            }, 
+                            {
+                                "Value": "joshuaroot", 
+                                "Key": "CreatorName"
+                            }
+                        ], 
+                        "AmiLaunchIndex": 0
+                    }
+                ], 
+                "ReservationId": "r-02d3311df84ec7fd4", 
+                "Groups": [], 
+                "OwnerId": "644160558196"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "6d952c68-37f1-4966-b35a-c88e614a9af5", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Mon, 12 Feb 2018 20:09:20 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_ec2_marked_hours/ec2.DescribeInstances_1.json
+++ b/tests/data/placebo/test_ec2_marked_hours/ec2.DescribeInstances_1.json
@@ -1,0 +1,165 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Reservations": [
+            {
+                "Instances": [
+                    {
+                        "Monitoring": {
+                            "State": "disabled"
+                        }, 
+                        "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                        "State": {
+                            "Code": 16, 
+                            "Name": "running"
+                        }, 
+                        "EbsOptimized": false, 
+                        "LaunchTime": {
+                            "hour": 18, 
+                            "__class__": "datetime", 
+                            "month": 2, 
+                            "second": 56, 
+                            "microsecond": 0, 
+                            "year": 2018, 
+                            "day": 12, 
+                            "minute": 5
+                        }, 
+                        "PublicIpAddress": "54.210.46.230", 
+                        "PrivateIpAddress": "172.31.63.102", 
+                        "ProductCodes": [], 
+                        "VpcId": "vpc-d2d616b5", 
+                        "StateTransitionReason": "", 
+                        "InstanceId": "i-0981bd7350d22dbcd", 
+                        "EnaSupport": true, 
+                        "ImageId": "ami-97785bed", 
+                        "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                        "SecurityGroups": [
+                            {
+                                "GroupName": "launch-wizard-6", 
+                                "GroupId": "sg-52245925"
+                            }
+                        ], 
+                        "ClientToken": "", 
+                        "SubnetId": "subnet-3a334610", 
+                        "InstanceType": "t2.micro", 
+                        "NetworkInterfaces": [
+                            {
+                                "Status": "in-use", 
+                                "MacAddress": "12:0b:ed:9f:e6:94", 
+                                "SourceDestCheck": true, 
+                                "VpcId": "vpc-d2d616b5", 
+                                "Description": "", 
+                                "NetworkInterfaceId": "eni-126062df", 
+                                "PrivateIpAddresses": [
+                                    {
+                                        "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                                        "PrivateIpAddress": "172.31.63.102", 
+                                        "Primary": true, 
+                                        "Association": {
+                                            "PublicIp": "54.210.46.230", 
+                                            "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                                            "IpOwnerId": "amazon"
+                                        }
+                                    }
+                                ], 
+                                "PrivateDnsName": "ip-172-31-63-102.ec2.internal", 
+                                "Attachment": {
+                                    "Status": "attached", 
+                                    "DeviceIndex": 0, 
+                                    "DeleteOnTermination": true, 
+                                    "AttachmentId": "eni-attach-b7e7f47a", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 56, 
+                                        "microsecond": 0, 
+                                        "year": 2018, 
+                                        "day": 12, 
+                                        "minute": 5
+                                    }
+                                }, 
+                                "Groups": [
+                                    {
+                                        "GroupName": "launch-wizard-6", 
+                                        "GroupId": "sg-52245925"
+                                    }
+                                ], 
+                                "Ipv6Addresses": [], 
+                                "OwnerId": "644160558196", 
+                                "PrivateIpAddress": "172.31.63.102", 
+                                "SubnetId": "subnet-3a334610", 
+                                "Association": {
+                                    "PublicIp": "54.210.46.230", 
+                                    "PublicDnsName": "ec2-54-210-46-230.compute-1.amazonaws.com", 
+                                    "IpOwnerId": "amazon"
+                                }
+                            }
+                        ], 
+                        "SourceDestCheck": true, 
+                        "Placement": {
+                            "Tenancy": "default", 
+                            "GroupName": "", 
+                            "AvailabilityZone": "us-east-1d"
+                        }, 
+                        "Hypervisor": "xen", 
+                        "BlockDeviceMappings": [
+                            {
+                                "DeviceName": "/dev/xvda", 
+                                "Ebs": {
+                                    "Status": "attached", 
+                                    "DeleteOnTermination": true, 
+                                    "VolumeId": "vol-067ab83921fe0cf08", 
+                                    "AttachTime": {
+                                        "hour": 18, 
+                                        "__class__": "datetime", 
+                                        "month": 2, 
+                                        "second": 57, 
+                                        "microsecond": 0, 
+                                        "year": 2018, 
+                                        "day": 12, 
+                                        "minute": 5
+                                    }
+                                }
+                            }
+                        ], 
+                        "Architecture": "x86_64", 
+                        "RootDeviceType": "ebs", 
+                        "RootDeviceName": "/dev/xvda", 
+                        "VirtualizationType": "hvm", 
+                        "Tags": [
+                            {
+                                "Value": "MarkForOpTest", 
+                                "Key": "Name"
+                            }, 
+                            {
+                                "Value": "Resource does not meet policy: stop@2018/02/12 23:00", 
+                                "Key": "hourly-mark"
+                            }, 
+                            {
+                                "Value": "joshuaroot", 
+                                "Key": "CreatorName"
+                            }
+                        ], 
+                        "AmiLaunchIndex": 0
+                    }
+                ], 
+                "ReservationId": "r-02d3311df84ec7fd4", 
+                "Groups": [], 
+                "OwnerId": "644160558196"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c592cf4a-b370-4938-a98c-d4924afdbb22", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Mon, 12 Feb 2018 20:10:00 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -570,6 +570,55 @@ class TestTag(BaseTest):
             tzinfo=localtz)
         self.assertEqual(result.date(), dt.date())
 
+    def test_ec2_mark_hours(self):
+        localtz = zoneinfo.gettz('America/New_York')
+        dt = datetime.now(localtz)
+        dt = dt.replace(year=2018, month=2, day=12, hour=17, minute=00)
+        session_factory = self.replay_flight_data('test_ec2_mark_hours')
+        session = session_factory(region='us-east-1')
+        ec2 = session.client('ec2')
+
+        policy = self.load_policy({
+            'name': 'ec2-mark-5-hours',
+            'resource': 'ec2',
+            'filters': [
+                {'tag:hourly-mark': 'absent'},
+                {'tag:CreatorName': 'joshuaroot'}],
+            'actions': [{
+                'type': 'mark-for-op',
+                'tag': 'hourly-mark',
+                'hours': 3,
+                'op': 'stop'}]
+        }, session_factory=session_factory)
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+
+        resource = ec2.describe_instances(
+            InstanceIds=[resources[0]['InstanceId']])[
+            'Reservations'][0]['Instances'][0]
+        tags = [
+            t['Value'] for t in resource['Tags'] if t['Key'] == 'hourly-mark']
+        result = datetime.strptime(
+            tags[0].strip().split('@', 1)[-1], '%Y/%m/%d %H:%M').replace(
+            tzinfo=localtz)
+        self.assertEqual(result.date(), dt.date())
+
+    def test_ec2_marked_hours(self):
+        session_factory = self.replay_flight_data('test_ec2_marked_hours')
+        policy = self.load_policy({
+            'name': 'ec2-mark-5-hours',
+            'resource': 'ec2',
+            'filters': [{
+                'type': 'marked-for-op',
+                'tag': 'hourly-mark',
+                'op': 'stop',
+                'skew_hours': 3
+            }]
+        }, session_factory=session_factory)
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['InstanceId'], 'i-0981bd7350d22dbcd')
+
 
 class TestStop(BaseTest):
 


### PR DESCRIPTION
Solves for #2006 
- adding support to enable an hour based mark-for-op
- adding support in marked-for-op to parse hourly
- ec2 unittests for mark/marked