### PR TITLE
Adds copy and encryption filter to AMI resources

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -129,6 +129,56 @@ class RemoveLaunchPermissions(BaseAction):
             ImageId=image['ImageId'], Attribute="launchPermission")
 
 
+@actions.register('copy')
+class Copy(BaseAction):
+    """Action to copy AMIs with optional encryption
+
+    This action can copy AMIs while optionally encrypting or decrypting
+    the target AMI. It is advised to use in conjunction with a filter.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: ami-ensure-encrypted
+                resource: ami
+                filters:
+                  - not:
+                    - type: encrypted
+                actions:
+                  - type: copy
+                    encrypt: true
+                    key-id: 00000000-0000-0000-0000-000000000000
+    """
+
+    permissions = ('ec2:CopyImage',)
+    schema = {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'type': {'enum': ['copy']},
+            'name': {'type': 'string'},
+            'description': {'type': 'string'},
+            'encrypt': {'type': 'boolean'},
+            'key-id': {'type': 'string'}
+        }
+    }
+
+    def process(self, images):
+        session = local_session(self.manager.session_factory)
+        client = session.client('ec2')
+
+        for image in images:
+            client.copy_image(
+                Name=self.data.get('name', image['Name']),
+                Description=self.data.get('description', image['Description']),
+                SourceRegion=session.region_name,
+                SourceImageId=image['ImageId'],
+                Encrypted=self.data.get('encrypt', False),
+                KmsKeyId=self.data.get('key-id', ''))
+
+
 @filters.register('image-age')
 class ImageAgeFilter(AgeFilter):
     """Filters images based on the age (in days)

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -195,3 +195,32 @@ class ImageUnusedFilter(Filter):
         if self.data.get('value', True):
             return [r for r in resources if r['ImageId'] not in images]
         return [r for r in resources if r['ImageId'] in images]
+
+
+@filters.register('encrypted')
+class Encrypted(Filter):
+    """Filters images on encryption status
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: ami-is-unencrypted
+                resource: ami
+                filters:
+                  - not:
+                    - type: encrypted
+    """
+
+    permissions = ('ec2:DescribeImages',)
+    schema = type_schema('encrypted')
+
+    def __call__(self, i):
+        for block_device in i['BlockDeviceMappings']:
+            if not block_device['Ebs']:
+                continue
+            if not block_device['Ebs']['Encrypted']:
+                return False
+
+        return True

--- a/tests/data/placebo/test_ami_encrypted_filter/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_encrypted_filter/ec2.DescribeImages_1.json
@@ -1,0 +1,79 @@
+{
+    "status_code": 200,
+    "data": {
+        "Images": [
+            {
+                "VirtualizationType": "hvm",
+                "Name": "c7n-ami-02",
+                "Hypervisor": "xen",
+                "EnaSupport": true,
+                "SriovNetSupport": "simple",
+                "ImageId": "ami-04e2b113",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-af0eb71b",
+                            "VolumeSize": 8,
+                            "VolumeType": "gp2",
+                            "Encrypted": true
+                        }
+                    }
+                ],
+                "Architecture": "x86_64",
+                "ImageLocation": "644160558196/c7n-ami-02",
+                "RootDeviceType": "ebs",
+                "OwnerId": "644160558196",
+                "RootDeviceName": "/dev/xvda",
+                "CreationDate": "2016-10-21T16:59:46.000Z",
+                "Public": false,
+                "ImageType": "machine",
+                "Description": "Encrypted AMI"
+            },
+            {
+                "VirtualizationType": "hvm",
+                "Name": "c7n-image-01",
+                "Hypervisor": "xen",
+                "EnaSupport": true,
+                "SriovNetSupport": "simple",
+                "ImageId": "ami-e0fba8f7",
+                "State": "available",
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda",
+                        "Ebs": {
+                            "DeleteOnTermination": true,
+                            "SnapshotId": "snap-07459fee",
+                            "VolumeSize": 8,
+                            "VolumeType": "gp2",
+                            "Encrypted": false
+                        }
+                    }
+                ],
+                "Architecture": "x86_64",
+                "ImageLocation": "644160558196/c7n-image-01",
+                "RootDeviceType": "ebs",
+                "OwnerId": "644160558196",
+                "RootDeviceName": "/dev/xvda",
+                "CreationDate": "2016-10-21T15:38:09.000Z",
+                "Public": false,
+                "ImageType": "machine",
+                "Description": "Unencrypted AMI"
+            }
+        ],
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "ef3ad1b8-5287-429a-86f1-b30e1b38bef9",
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked",
+                "vary": "Accept-Encoding",
+                "server": "AmazonEC2",
+                "content-type": "text/xml;charset=UTF-8",
+                "date": "Fri, 21 Oct 2016 17:35:46 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -51,3 +51,14 @@ class TestAMI(BaseTest):
         }, session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_ami_encrypted_filter(self):
+        factory = self.replay_flight_data('test_ami_encrypted_filter')
+        p = self.load_policy({
+            'name': 'test-encrypted-ami',
+            'resource': 'ami',
+            'filters': [{
+                'type': 'encrypted'}]
+        }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
Hello,

I want to use cloud custodian to automatically encrypt all AMIs on my AWS account and deregister the unencrypted ones afterwards. To achieve that I have added a filter to the AMI resource `encrypted` which filters AMIs based on if they are encrypted through KMS or not, as well as an action `copy` to which is cappable of encrypting and decrypting of AMIs using the [copy-image](https://docs.aws.amazon.com/cli/latest/reference/ec2/copy-image.html) API endpoint.

Here is the policy I'm currently using in production and it works like a charm:
```yaml
policies:
- name: ami-ensure-encrypted
  resource: ami
  filters:
    - not:
      - type: encrypted
  actions:
    - type: copy
      encrypt: true
      key-id: 00000000-0000-0000-0000-000000000000
    - deregister
```