### PR TITLE
 Adds ami.copy action with encryption support

### DIFF
--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -129,6 +129,56 @@ class RemoveLaunchPermissions(BaseAction):
             ImageId=image['ImageId'], Attribute="launchPermission")
 
 
+@actions.register('copy')
+class Copy(BaseAction):
+    """Action to copy AMIs with optional encryption
+
+    This action can copy AMIs while optionally encrypting or decrypting
+    the target AMI. It is advised to use in conjunction with a filter.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: ami-ensure-encrypted
+                resource: ami
+                filters:
+                  - not:
+                    - type: encrypted
+                actions:
+                  - type: copy
+                    encrypt: true
+                    key-id: 00000000-0000-0000-0000-000000000000
+    """
+
+    permissions = ('ec2:CopyImage',)
+    schema = {
+        'type': 'object',
+        'additionalProperties': False,
+        'properties': {
+            'type': {'enum': ['copy']},
+            'name': {'type': 'string'},
+            'description': {'type': 'string'},
+            'encrypt': {'type': 'boolean'},
+            'key-id': {'type': 'string'}
+        }
+    }
+
+    def process(self, images):
+        session = local_session(self.manager.session_factory)
+        client = session.client('ec2')
+
+        for image in images:
+            client.copy_image(
+                Name=self.data.get('name', image['Name']),
+                Description=self.data.get('description', image['Description']),
+                SourceRegion=session.region_name,
+                SourceImageId=image['ImageId'],
+                Encrypted=self.data.get('encrypt', False),
+                KmsKeyId=self.data.get('key-id', ''))
+
+
 @filters.register('image-age')
 class ImageAgeFilter(AgeFilter):
     """Filters images based on the age (in days)

--- a/c7n/resources/ami.py
+++ b/c7n/resources/ami.py
@@ -160,6 +160,7 @@ class Copy(BaseAction):
             'type': {'enum': ['copy']},
             'name': {'type': 'string'},
             'description': {'type': 'string'},
+            'region': {'type': 'string'},
             'encrypt': {'type': 'boolean'},
             'key-id': {'type': 'string'}
         }
@@ -167,7 +168,9 @@ class Copy(BaseAction):
 
     def process(self, images):
         session = local_session(self.manager.session_factory)
-        client = session.client('ec2')
+        client = session.client(
+            'ec2',
+            region_name=self.data.get('region', None))
 
         for image in images:
             client.copy_image(


### PR DESCRIPTION
Hi again, this is the follow-up PR for #2068 which only contains the copy action for the ami resource, including support for encryption, region, name and description.

Example:
```yaml
policies:
- name: ami-ensure-encrypted
  resource: ami
  filters:
    - not:
      - type: encrypted
  actions:
    - type: copy
      encrypt: true
      key-id: 00000000-0000-0000-0000-000000000000
```