### PR TITLE
tools/c7n_org support profile for credentials, and `all` symbolic region in parallel

### DIFF
--- a/tools/c7n_guardian/c7n_guardian/cli.py
+++ b/tools/c7n_guardian/c7n_guardian/cli.py
@@ -32,7 +32,8 @@ log = logging.getLogger('c7n-guardian')
 
 # make email required in org schema
 CONFIG_SCHEMA['definitions']['account']['properties']['email'] = {'type': 'string'}
-CONFIG_SCHEMA['definitions']['account']['required'].append('email')
+for el in CONFIG_SCHEMA['definitions']['account']['oneOf']:
+    el['required'].append('email')
 
 
 @click.group()


### PR DESCRIPTION
- support profile as credential source for multi-account
- support parallel execution when executing across all regions