### PR TITLE
Adding 'account-emails' for notifying to a list of emails

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -56,7 +56,10 @@ CONFIG_SCHEMA = {
         # SDK Config
         'profile': {'type': 'string'},
         'http_proxy': {'type': 'string'},
-        'https_proxy': {'type': 'string'}
+        'https_proxy': {'type': 'string'},
+
+        # Mapping account / emails
+        'account_emails': {'type': 'object'}
     }
 }
 

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -112,6 +112,23 @@ class EmailDelivery(object):
         resource_owner_tag_values = get_resource_tag_targets(resource, resource_owner_tag_keys)
         return self.get_valid_emails_from_list(resource_owner_tag_values)
 
+    def get_account_emails(self, sqs_message):
+        email_list = []
+
+        if 'account-emails' not in sqs_message['action']['to']:
+            return []
+
+        account_id = sqs_message.get('account_id', None)
+        self.logger.debug('get_account_emails for account_id: %s.', account_id)
+
+        if account_id is not None:
+            account_email_mapping = self.config.get('account_emails', {})
+            self.logger.debug('get_account_emails account_email_mapping: %s.', account_email_mapping)
+            email_list = account_email_mapping.get(account_id, [])
+            self.logger.debug('get_account_emails email_list: %s.', email_list)
+
+        return self.get_valid_emails_from_list(email_list)
+
     # this function returns a dictionary with a tuple of emails as the key
     # and the list of resources as the value. This helps ensure minimal emails
     # are sent, while only ever sending emails to the respective parties.
@@ -129,7 +146,10 @@ class EmailDelivery(object):
         # if event-owner is set, and the aws_username has an ldap_lookup email
         # we add that email to the policy emails for these resource(s) on this sqs_message
         event_owner_email = self.get_event_owner_email(targets, sqs_message['event'])
-        policy_to_emails = policy_to_emails + event_owner_email
+
+        account_emails = self.get_account_emails(sqs_message)
+
+        policy_to_emails = policy_to_emails + event_owner_email + account_emails
         for resource in sqs_message['resources']:
             # this is the list of emails that will be sent for this resource
             resource_emails = []


### PR DESCRIPTION
    Adding 'account-emails' for notifying to a list of emails
    of the resource's account.

    You can now define a list of email addresses in c7n_mailer configuration
    file ; under the 'account_emails' config key.
    (account_emails is a hash map where each key is an account ID, and the
    value is a list of email accounts)

    To use it:
    - Define the account_emails hash in c7n_mailer configuration
    - Add the special name 'account-emails' in the 'to' of your 'notify'
    in c7n policy (same as 'resource-owner')