### PR TITLE
Make lambda deployed by c7n_mailer more configurable.

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -28,6 +28,10 @@ CONFIG_SCHEMA = {
         'subnets': {'type': 'array', 'items': {'type': 'string'}},
         'security_groups': {'type': 'array', 'items': {'type': 'string'}},
         'dead_letter_config': {'type': 'object'},
+        'lambda_name': {'type': 'string'},
+        'lambda_description': {'type': 'string'},
+        'lambda_tags': {'type': 'object'},
+        'lambda_schedule': {'type': 'string'},
 
         # Mailer Infrastructure Config
         'cache_engine': {'type': 'string'},

--- a/tools/c7n_mailer/c7n_mailer/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/deploy.py
@@ -59,8 +59,9 @@ def get_archive(config):
 
 def provision(config, session_factory):
     func_config = dict(
-        name='cloud-custodian-mailer',
-        description='Cloud Custodian Mailer',
+        name=config.get('lambda_name', 'cloud-custodian-mailer'),
+        description=config.get('lambda_description', 'Cloud Custodian Mailer'),
+        tags=config.get('lambda_tags', {}),
         handler='periodic.dispatch',
         runtime=config['runtime'],
         memory_size=config['memory'],
@@ -72,7 +73,7 @@ def provision(config, session_factory):
         events=[
             CloudWatchEventSource(
                 {'type': 'periodic',
-                 'schedule': 'rate(5 minutes)'},
+                 'schedule': config.get('lambda_schedule', 'rate(5 minutes)')},
                 session_factory,
                 prefix="")
         ])


### PR DESCRIPTION
    The following elements are now customizable:
    - the lambda name
    - the lambda description
    - the tags associated to the lambda
    - the schedule of the lambda