### PR TITLE
Allow CSV files to contain UTF-8 characters.

### DIFF
--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -43,7 +43,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from concurrent.futures import as_completed
 
-import csv
 from datetime import datetime
 import gzip
 import io
@@ -59,7 +58,7 @@ from dateutil.parser import parse as date_parse
 
 from c7n.executor import ThreadPoolExecutor
 from c7n.utils import local_session, dumps
-
+from c7n.utils import UnicodeWriter
 
 log = logging.getLogger('custodian.reports')
 
@@ -97,7 +96,7 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
 
     rows = formatter.to_csv(records)
     if options.format == 'csv':
-        writer = csv.writer(output_fh, formatter.headers())
+        writer = UnicodeWriter(output_fh, formatter.headers())
         writer.writerow(formatter.headers())
         writer.writerows(rows)
     else:

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -27,6 +27,9 @@ import random
 import threading
 import time
 import six
+import codecs
+import cStringIO
+import csv
 
 from c7n import ipaddress
 
@@ -47,6 +50,37 @@ else:
             SafeLoader = None
 
 log = logging.getLogger('custodian.utils')
+
+
+# From https://docs.python.org/2/library/csv.html#examples
+class UnicodeWriter:
+    """
+    A CSV writer which will write rows to CSV file "f",
+    which is encoded in the given encoding.
+    """
+
+    def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
+        # Redirect output to a queue
+        self.queue = cStringIO.StringIO()
+        self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
+        self.stream = f
+        self.encoder = codecs.getincrementalencoder(encoding)()
+
+    def writerow(self, row):
+        self.writer.writerow([s.encode("utf-8") for s in row])
+        # Fetch UTF-8 output from the queue ...
+        data = self.queue.getvalue()
+        data = data.decode("utf-8")
+        # ... and reencode it into the target encoding
+        data = self.encoder.encode(data)
+        # write to the target stream
+        self.stream.write(data)
+        # empty queue
+        self.queue.truncate(0)
+
+    def writerows(self, rows):
+        for row in rows:
+            self.writerow(row)
 
 
 class VarsSubstitutionError(Exception):

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -17,6 +17,7 @@ from botocore.exceptions import ClientError
 
 import boto3
 import copy
+import csv
 from datetime import datetime
 import functools
 import json
@@ -27,9 +28,7 @@ import random
 import threading
 import time
 import six
-import codecs
-import cStringIO
-import csv
+
 
 from c7n import ipaddress
 
@@ -52,31 +51,14 @@ else:
 log = logging.getLogger('custodian.utils')
 
 
-# From https://docs.python.org/2/library/csv.html#examples
 class UnicodeWriter:
-    """
-    A CSV writer which will write rows to CSV file "f",
-    which is encoded in the given encoding.
-    """
+    """utf8 encoding csv writer."""
 
-    def __init__(self, f, dialect=csv.excel, encoding="utf-8", **kwds):
-        # Redirect output to a queue
-        self.queue = cStringIO.StringIO()
-        self.writer = csv.writer(self.queue, dialect=dialect, **kwds)
-        self.stream = f
-        self.encoder = codecs.getincrementalencoder(encoding)()
+    def __init__(self, f, dialect=csv.excel, **kwds):
+        self.writer = csv.writer(f, dialect=dialect, **kwds)
 
     def writerow(self, row):
         self.writer.writerow([s.encode("utf-8") for s in row])
-        # Fetch UTF-8 output from the queue ...
-        data = self.queue.getvalue()
-        data = data.decode("utf-8")
-        # ... and reencode it into the target encoding
-        data = self.encoder.encode(data)
-        # write to the target stream
-        self.stream.write(data)
-        # empty queue
-        self.queue.truncate(0)
 
     def writerows(self, rows):
         for row in rows:

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -15,7 +15,6 @@
 """
 
 from collections import Counter
-import csv
 import logging
 import os
 import multiprocessing
@@ -43,6 +42,7 @@ from c7n.manager import resources as resource_registry
 from c7n.utils import CONN_CACHE, dumps
 
 from c7n_org.utils import environ, account_tags
+from c7n.utils import UnicodeWriter
 
 log = logging.getLogger('c7n_org')
 
@@ -264,7 +264,7 @@ def report(config, output, use, output_dir, accounts, field, no_default_fields, 
         fields=prefix_fields)
 
     rows = formatter.to_csv(records, unique=False)
-    writer = csv.writer(output, formatter.headers())
+    writer = UnicodeWriter(output, formatter.headers())
     writer.writerow(formatter.headers())
     writer.writerows(rows)
 


### PR DESCRIPTION
The UnicodeWriter class from Python 2 examples is used to
write UTF-8 CSV files.