### PR TITLE
Small update to mu docs - remove statement about using mu independently

### DIFF
--- a/docs/source/policy/mu.rst
+++ b/docs/source/policy/mu.rst
@@ -13,6 +13,4 @@ run.
 
 Mu will evaluate if a policy has changed by comparing the
 compiled Lambda function to the current Lambda function. Mu will also
-update the event sources if the policy has been updated. Mu can
-be used independently for managing Lambda functions with event
-sources.
+update the event sources if the policy has been updated.


### PR DESCRIPTION
Per conversation with @kapilt on gitter, mu should no longer be used for managing lambdas with event sources.  He suggests AWS SAM instead.