### PR TITLE
Fix bug when multiple S3 policy statements are similar

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -776,6 +776,7 @@ class HasStatementFilter(Filter):
                         found += 1
                 if found and found == len(required_statement):
                     required_statements.remove(required_statement)
+                    break
 
         if (self.data.get('statement_ids', []) and not required) or \
            (self.data.get('statements', []) and not required_statements):

--- a/tests/data/placebo/test_s3_has_statement/s3.GetBucketPolicy_3.json
+++ b/tests/data/placebo/test_s3_has_statement/s3.GetBucketPolicy_3.json
@@ -1,7 +1,7 @@
 {
     "status_code": 200, 
     "data": {
-        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}}]}", 
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}},{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"arn:aws:iam::086441151436:root\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\"}]}", 
         "ResponseMetadata": {
             "HTTPStatusCode": 200, 
             "HostId": "jL1IZT8BmFaliIyAn7834ng9hk11JPgxBLJYNMg2IPtcu8A6MVtzs/Yz6FMO5IVe4exEBQIGvGg=", 

--- a/tests/data/placebo/test_s3_has_statement/s3.GetBucketPolicy_3.json
+++ b/tests/data/placebo/test_s3_has_statement/s3.GetBucketPolicy_3.json
@@ -1,7 +1,7 @@
 {
     "status_code": 200, 
     "data": {
-        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}},{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"arn:aws:iam::086441151436:root\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\"}]}", 
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"*\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\",\"Condition\":{\"StringNotEquals\":{\"s3:x-amz-server-side-encryption\":[\"AES256\",\"aws:kms\"]}}},{\"Sid\":\"Zebra\",\"Effect\":\"Deny\",\"Principal\":\"arn:aws:iam::644160558196:root\",\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::custodian-policy-test/*\"}]}", 
         "ResponseMetadata": {
             "HTTPStatusCode": 200, 
             "HostId": "jL1IZT8BmFaliIyAn7834ng9hk11JPgxBLJYNMg2IPtcu8A6MVtzs/Yz6FMO5IVe4exEBQIGvGg=", 

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1196,7 +1196,7 @@ class S3Test(BaseTest):
                                 'AES256', 'aws:kms']}}},
                    {'Sid': 'Zebra2',
                     'Effect': 'Deny',
-                    'Principal': 'arn:aws:iam::086441151436:root',
+                    'Principal': 'arn:aws:iam::644160558196:root',
                     'Action': 's3:PutObject',
                     'Resource': 'arn:aws:s3:::%s/*' % bname}]}))
         p = self.load_policy({

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1193,7 +1193,12 @@ class S3Test(BaseTest):
                     'Condition': {
                         'StringNotEquals': {
                             's3:x-amz-server-side-encryption': [
-                                'AES256', 'aws:kms']}}}]}))
+                                'AES256', 'aws:kms']}}},
+                   {'Sid': 'Zebra2',
+                    'Effect': 'Deny',
+                    'Principal': 'arn:aws:iam::086441151436:root',
+                    'Action': 's3:PutObject',
+                    'Resource': 'arn:aws:s3:::%s/*' % bname}]}))
         p = self.load_policy({
             'name': 's3-has-policy',
             'resource': 's3',
@@ -1226,6 +1231,30 @@ class S3Test(BaseTest):
                    {'Effect': 'Deny',
                     'Action': 's3:PutObject',
                     'Principal': '*'}]}]},
+            session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_has_statement_similar_policies(self):
+        self.patch(s3.S3, 'executor_factory', MainThreadExecutor)
+        self.patch(
+            s3.MissingPolicyStatementFilter, 'executor_factory',
+            MainThreadExecutor)
+        self.patch(s3, 'S3_AUGMENT_TABLE', [
+            ('get_bucket_policy',  'Policy', None, 'Policy'),
+        ])
+        session_factory = self.replay_flight_data('test_s3_has_statement')
+        bname = "custodian-policy-test"
+        session = session_factory()
+        p = self.load_policy({
+            'name': 's3-has-policy',
+            'resource': 's3',
+            'filters': [
+                {'Name': bname},
+                {'type': 'has-statement',
+                 'statements': [
+                   {'Effect': 'Deny',
+                    'Action': 's3:PutObject'}]}]},
             session_factory=session_factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)


### PR DESCRIPTION
This fixes a bug in the `has-statement` s3 filter when a bucket policy has multiple similar statements.  The solution is to stop looking for required_statements once it has been found.

For example, a bucket policy like:

```
{
    "Version": "2012-10-17",
    "Statement": [
        {
            "Sid": "StatementOne",
            "Effect": "Allow",
            "Principal": "*",
            "Action": "s3:PutObject",
            "Condition": {
                "StringEquals": {
                    "s3:x-amz-acl": [
                        "public-read"
                    ]
                }
            }
            "Resource": "arn:aws:s3:::my-bucket/*"
        },
        {
            "Sid": "StatementTwo",
            "Effect": "Allow",
            "Principal": {
                "AWS": "arn:aws:iam::111122223333:root"
            },
            "Action": "s3:PutObject",
            "Resource": "arn:aws:s3:::my-bucket/*"
        }
    ]
}
```

paired with an policy like:

```
policies:
  - name: s3-public-bucket-policy
    resource: s3
    filters:
      - type: has-statement
        statements:
          - Effect: Allow
            Action: 's3:PutObject'
```

caused c7n to fail with an error like:
`ValueError: list.remove(x): x not in list`