### PR TITLE
Add S3 has-policy-permission filter with support for wildcards in bucket policies

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -801,8 +801,8 @@ class HasPermissionFilter(Filter):
 
     Special considerations:
 
-    * Principals should be specified as "prefix:value" where prefix is one of AWS,
-      Federated, Service, etc.
+    * Principals should be specified as "prefix:value" where prefix an acceptable prefix from
+      https://docs.aws.amazon.com/IAM/latest/UserGuide/reference_policies_elements_principal.html
     * Partial wildcards (e.g. s3:Put*) cannot be used in filter definition.
 
     :example:
@@ -866,8 +866,8 @@ class HasPermissionFilter(Filter):
             if statement.get('Effect', 'Allow').lower() == 'deny':
                 continue
 
-            matched_actions = self.__get_action_matches(statement, required_actions)
-            matched_principals = self.__get_principal_matches(statement, required_principals)
+            matched_actions = self._get_action_matches(statement, required_actions)
+            matched_principals = self._get_principal_matches(statement, required_principals)
 
             if ((len(required_actions) == 0 or matched_actions) and
                     (len(required_principals) == 0 or matched_principals)):
@@ -875,7 +875,7 @@ class HasPermissionFilter(Filter):
 
         return None
 
-    def __get_action_matches(self, statement, required_actions):
+    def _get_action_matches(self, statement, required_actions):
         matches = []
         if 'Action' in statement:
             actions = statement.get('Action')
@@ -903,11 +903,11 @@ class HasPermissionFilter(Filter):
 
         return list(set(matches))
 
-    def __get_principal_matches(self, statement, required_principals):
+    def _get_principal_matches(self, statement, required_principals):
         matches = []
         wildcard_regex = re.compile('[^:]+:\*')
         if 'Principal' in statement:
-            principals = self.__normalize_principals(statement.get('Principal'))
+            principals = self._normalize_principals(statement.get('Principal'))
             for principal in principals:
                 for required_principal in required_principals:
                     if principal == '*' and wildcard_regex.match(required_principal):
@@ -918,7 +918,7 @@ class HasPermissionFilter(Filter):
                         matches.append(required_principal)
 
         elif 'NotPrincipal' in statement:
-            not_principals = self.__normalize_principals(statement.get('NotPrincipal'))
+            not_principals = self._normalize_principals(statement.get('NotPrincipal'))
             matches.externd(required_principals)
             for not_principal in not_principals:
                 for required_principal in required_principals:
@@ -927,7 +927,7 @@ class HasPermissionFilter(Filter):
 
         return list(set(matches))
 
-    def __normalize_principals(self, principals):
+    def _normalize_principals(self, principals):
         if not principals:
             return []
 

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -40,6 +40,7 @@ Actions:
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import copy
+import fnmatch
 import functools
 import json
 import itertools
@@ -47,6 +48,7 @@ import logging
 import math
 import os
 import time
+import re
 import ssl
 
 import six
@@ -781,6 +783,165 @@ class HasStatementFilter(Filter):
            (self.data.get('statements', []) and not required_statements):
             return b
         return None
+
+
+@filters.register('has-policy-permission')
+class HasPermissionFilter(Filter):
+    """Filters buckets with certain permissions.
+
+    A bucket is filtered if any of the given actions and any of the given principals match
+    the bucket's policy.
+
+    This allows matching bucket policies that contain wildcards.  For example, if you
+    specify `s3:PutObject` in a filter and a bucket policy has a `s3:Put*` action, the
+    bucket will match.
+
+    Conversely, if you specify a wildcard in a filter (e.g `*`), this will match all bucket
+    policy permissions.
+
+    Special considerations:
+
+    * Principals should be specified as "prefix:value" where prefix is one of AWS,
+      Federated, Service, etc.
+    * Partial wildcards (e.g. s3:Put*) cannot be used in filter definition.
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: s3-public-writable-policy
+                resource: s3
+                filters:
+                  - type: has-policy-permission
+                    actions:
+                      - s3:PutObject
+                      - s3:PutObjectAcl
+                      - s3:PutBucketPolicy
+                    principals:
+                      - 'AWS:*'
+
+            policies:
+              - name: s3-public-access-policy
+                resource: s3
+                filters:
+                  - type: has-policy-permission
+                    actions:
+                      - '*'
+                    principals:
+                      - '*'
+    """
+    schema = type_schema(
+        'has-policy-permission',
+        actions={'type': 'array', 'items': {'type': 'string'}},
+        principals={'type': 'array', 'items': {'type': 'string'}}
+    )
+
+    def process(self, buckets, event=None):
+        return list(filter(None, map(self.process_bucket, buckets)))
+
+    def process_bucket(self, b):
+        p = b.get('Policy')
+        if p is None:
+            return None
+        p = json.loads(p)
+
+        required_actions = list(self.data.get('actions', []))
+        for required_action in required_actions:
+            if ("*" in required_action and len(required_action) > 1):
+                raise ValueError(
+                    "partial wildcards in action filters are not supported: %s" %
+                    required_action)
+
+        required_principals = list(self.data.get('principals', []))
+        for required_principal in required_principals:
+            if ("*" in required_principal and len(required_principal) > 1 and
+                    not re.match('^[^:]+:\*$', required_principal)):
+                raise ValueError(
+                    "partial wildcards in principal filters are not supported: %s" %
+                    required_principal)
+
+        statements = p.get('Statement', [])
+        for statement in statements:
+            if statement.get('Effect', 'Allow').lower() == 'deny':
+                continue
+
+            matched_actions = self.__get_action_matches(statement, required_actions)
+            matched_principals = self.__get_principal_matches(statement, required_principals)
+
+            if ((len(required_actions) == 0 or matched_actions) and
+                    (len(required_principals) == 0 or matched_principals)):
+                return b
+
+        return None
+
+    def __get_action_matches(self, statement, required_actions):
+        matches = []
+        if 'Action' in statement:
+            actions = statement.get('Action')
+            if isinstance(actions, six.string_types):
+                actions = [actions]
+            for action in actions:
+                regex = re.compile(fnmatch.translate(action), re.IGNORECASE)
+                for required_action in required_actions:
+                    if (required_action == '*' or
+                            required_action.lower() == action.lower() or
+                            regex.match(required_action)):
+                        matches.append(required_action)
+
+        elif 'NotAction' in statement:
+            not_actions = statement.get('NotAction')
+            if isinstance(not_actions, six.string_types):
+                not_actions = [not_actions]
+            matches.extend(required_actions)
+            for not_action in not_actions:
+                regex = re.compile(fnmatch.translate(not_action), re.IGNORECASE)
+                for required_action in required_actions:
+                    if (required_action.lower() == not_action.lower() or
+                            regex.match(required_action)):
+                        matches.remove(required_action)
+
+        return list(set(matches))
+
+    def __get_principal_matches(self, statement, required_principals):
+        matches = []
+        wildcard_regex = re.compile('[^:]+:\*')
+        if 'Principal' in statement:
+            principals = self.__normalize_principals(statement.get('Principal'))
+            for principal in principals:
+                for required_principal in required_principals:
+                    if principal == '*' and wildcard_regex.match(required_principal):
+                        matches.append(required_principal)
+                    elif required_principal == '*' and wildcard_regex.match(principal):
+                        matches.append(required_principal)
+                    elif required_principal == principal:
+                        matches.append(required_principal)
+
+        elif 'NotPrincipal' in statement:
+            not_principals = self.__normalize_principals(statement.get('NotPrincipal'))
+            matches.externd(required_principals)
+            for not_principal in not_principals:
+                for required_principal in required_principals:
+                    if required_principal == not_principal:
+                        matches.remove(required_principal)
+
+        return list(set(matches))
+
+    def __normalize_principals(self, principals):
+        if not principals:
+            return []
+
+        if isinstance(principals, six.string_types):
+            return [principals]
+
+        normalized = []
+        for key, values in principals.items():
+            if isinstance(values, six.string_types):
+                values = [values]
+            for val in values:
+                normalized.append("{}:{}".format(key, val))
+
+        return normalized
 
 
 ENCRYPTION_STATEMENT_GLOB = {

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.CreateBucket_1.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.CreateBucket_1.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Location": "/custodian-policy-permission-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "BUBh59aj1IUDmGhDTANjcVAPd0kHCZ7DmvkFeq87A8OXZl7+ab9EBeSu7lepEaih7fqQJVOIhhI=", 
+            "RequestId": "20062D9C9972D843"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.DeleteBucket_1.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.DeleteBucket_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "XdFLAsCakeeyIL0Jn4/SFlWmkIJCtZ4RqLxBZC8sggvLnWw2jTu0vxPEfibpmszCT1JvGRVZ+bw=", 
+            "RequestId": "3C297A1E9E733A21"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_1.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "HostId": "N/r54UyuioFB+1JEh4nEgIfbuqiWpayzIIIpHtqGizi5RFZcXhibOGyarc8hJgvg2LB+JsU1L4Q=", 
+            "RequestId": "8E4B0DD43705C703"
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "cf-templates-nyrabrca5x2n-us-east-1"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_2.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_2.json
@@ -1,0 +1,15 @@
+{
+    "status_code": 404, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 404, 
+            "HostId": "dNEMxpHojUF874nF2mlg5ME/edI981nnx8hSN+Ite3NeaoKdqtRlyt+JfkeV/YuTpU/RVjEKdOc=", 
+            "RequestId": "7FEBB8E0DA3C7084"
+        }, 
+        "Error": {
+            "Message": "The bucket policy does not exist", 
+            "Code": "NoSuchBucketPolicy", 
+            "BucketName": "config-bucket-619193117841"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_3.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_3.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"Wildcard\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"Action\":\"s3:Put*\",\"Resource\":\"arn:aws:s3:::custodian-policy-permission-test/*\"}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "jL1IZT8BmFaliIyAn7834ng9hk11JPgxBLJYNMg2IPtcu8A6MVtzs/Yz6FMO5IVe4exEBQIGvGg=", 
+            "RequestId": "2592899758274ED6"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_4.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_4.json
@@ -1,0 +1,10 @@
+{    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2012-10-17\",\"Statement\":[{\"Sid\":\"WildcardNotAction\",\"Effect\":\"Allow\",\"Principal\":\"*\",\"NotAction\":\"s3:Put*\",\"Resource\":\"arn:aws:s3:::custodian-policy-permission-test-notaction/*\"}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "jL1IZT8BmFaliIyAn7834ng9hk11JPgxBLJYNMg2IPtcu8A6MVtzs/Yz6FMO5IVe4exEBQIGvGg=", 
+            "RequestId": "2592899758274ED6"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_5.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.GetBucketPolicy_5.json
@@ -1,0 +1,11 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Policy": "{\"Version\":\"2008-10-17\",\"Statement\":[{\"Sid\":\"AWSCloudTrailAclCheck20131101\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::113285607260:root\",\"arn:aws:iam::086441151436:root\"]},\"Action\":\"s3:GetBucketAcl\",\"Resource\":\"arn:aws:s3:::hazmat-audit-logs\"},{\"Sid\":\"AWSCloudTrailWrite20131101\",\"Effect\":\"Allow\",\"Principal\":{\"AWS\":[\"arn:aws:iam::113285607260:root\",\"arn:aws:iam::086441151436:root\"]},\"Action\":\"s3:PutObject\",\"Resource\":\"arn:aws:s3:::hazmat-audit-logs/api/AWSLogs/619193117841/*\",\"Condition\":{\"StringEquals\":{\"s3:x-amz-acl\":\"bucket-owner-full-control\"}}}]}", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "e0K7ezq0+FJG7XU3j0XyFdlS9/wss6PTSm2j/FL0qrznFFHE6E2xTmePu0z2X6nvZp/ne28VgwQ=", 
+            "RequestId": "8BF7465CC34BD8C0"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.ListBuckets_1.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.ListBuckets_1.json
@@ -1,0 +1,81 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Owner": {
+            "DisplayName": "k_vertigo", 
+            "ID": "904fc4c4790937100e9eb293a15e6a0a1f265a064888055b43d030034f8881ee"
+        }, 
+        "Buckets": [
+            {
+                "CreationDate": {
+                    "hour": 1, 
+                    "__class__": "datetime", 
+                    "month": 3, 
+                    "second": 1, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 9, 
+                    "minute": 35
+                }, 
+                "Name": "cf-templates-nyrabrca5x2n-us-east-1"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 2, 
+                    "second": 54, 
+                    "microsecond": 0, 
+                    "year": 2015, 
+                    "day": 23, 
+                    "minute": 54
+                }, 
+                "Name": "config-bucket-619193117841"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 18, 
+                    "minute": 15
+                }, 
+                "Name": "custodian-policy-permission-test"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 17, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 45, 
+                    "microsecond": 0, 
+                    "year": 2016, 
+                    "day": 18, 
+                    "minute": 15
+                }, 
+                "Name": "custodian-policy-permission-test-notaction"
+            }, 
+            {
+                "CreationDate": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 51, 
+                    "microsecond": 0, 
+                    "year": 2013, 
+                    "day": 21, 
+                    "minute": 12
+                }, 
+                "Name": "hazmat-audit-logs"
+            }
+        ], 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "N4Ka3KSZO3Y3s5B83Kspi9VvuUEVx9p6UaiQkBxmyslMUZtOQB/75F61oq9wsE1fHn07nK0sMKo=", 
+            "RequestId": "80ED9683CA2CAB57"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.ListObjects_1.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.ListObjects_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "MaxKeys": 1000, 
+        "Prefix": "", 
+        "Name": "custodian-policy-permission-test", 
+        "ResponseMetadata": {
+            "HTTPStatusCode": 200, 
+            "HostId": "q5PdMSuJxDD6D9rEZMcXpasl5NTJP5CqDVwmQg23waLxzjW2RIS8D/in+ozutEQ0W/jZvMrMGv0=", 
+            "RequestId": "2CA9F6362A4E53BF"
+        }, 
+        "Marker": "", 
+        "EncodingType": "url", 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.PutBucketPolicy_1.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.PutBucketPolicy_1.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "DVtRLymbtCcgGHevhBN5d27KUXmZzFfpvdJkNIljMTOJ8zKt2qw517MPhNCSacULO0Yw12KXxzw=", 
+            "RequestId": "96D458223D9AF7EA"
+        }
+    }
+}

--- a/tests/data/placebo/test_s3_has_policy_permission/s3.PutBucketPolicy_2.json
+++ b/tests/data/placebo/test_s3_has_policy_permission/s3.PutBucketPolicy_2.json
@@ -1,0 +1,10 @@
+{
+    "status_code": 204, 
+    "data": {
+        "ResponseMetadata": {
+            "HTTPStatusCode": 204, 
+            "HostId": "DVtRLymbtCcgGHevhBN5d27KUXmZzFfpvdJkNIljMTOJ8zKt2qw517MPhNCSacULO0Yw12KXxzw=", 
+            "RequestId": "96D458223D9AF7EA"
+        }
+    }
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -182,7 +182,7 @@ class PolicyPermissions(BaseTest):
                          'capacity-delta', 'is-ssl', 'global-grants',
                          'missing-policy-statement', 'missing-statement',
                          'healthcheck-protocol-mismatch', 'image-age',
-                         'has-statement', 'no-access',
+                         'has-statement', 'has-policy-permission', 'no-access',
                          'instance-age', 'ephemeral', 'instance-uptime'):
                     continue
                 qk = "%s.filters.%s" % (k, n)


### PR DESCRIPTION
This adds a new `has-policy-permission` S3 filter.  The filter looks for specific S3 permissions (actions and principals) in a S3 bucket policy.  It works even when bucket policies have wildcards in actions.

For example, it can be hard to determine if a bucket policy grants write access with existing filters (such as `has-statement`) because actions can have wildcards.  For example, any of the following actions can grant write access to a bucket:

* `s3:*`
* `s3:Put*`
* `s3:PutObject`

By using the `has-policy-permission` filter, users can specify the permission(s) they are looking for and this filter will match if the bucket policy grants that permission.

Example filter:

```
policies:
  - name: s3-public-writable-policy
    resource: s3
    filters:
    - type: has-policy-permission
      actions:
        - s3:PutObject
        - s3:PutObjectAcl
        - s3:PutBucketPolicy
      principals:
        - AWS:*
```

The filter matches if any specified s3 actions are allowed by the bucket policy _and_ any of the specified principals are allowed by the policy.