### PR TITLE
Tag value interpolation w/ extended date formating

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -367,6 +367,8 @@ class Tag(Action):
         if msg:
             tags.append({'Key': tag, 'Value': msg})
 
+        self.interpolate_values(tags)
+
         batch_size = self.data.get('batch_size', self.batch_size)
 
         _common_tag_processer(
@@ -382,6 +384,18 @@ class Tag(Action):
             Resources=[v[self.id_key] for v in resource_set],
             Tags=tags,
             DryRun=self.manager.config.dryrun)
+
+    def interpolate_values(self, tags):
+        params = {
+            'account_id': self.manager.config.account_id,
+            'now': utils.FormatDate.utcnow(),
+            'region': self.manager.config.region}
+        interpolate_tag_values(tags, params)
+
+
+def interpolate_tag_values(tags, params):
+    for t in tags:
+        t['Value'] = t['Value'].format(**params)
 
 
 class RemoveTag(Action):

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -110,6 +110,14 @@ class UtilTest(unittest.TestCase):
     def test_format_date(self):
         d = parse_date("2018-02-02 12:00")
         self.assertEqual(
+            "{}".format(utils.FormatDate(d)),
+            "2018-02-02 12:00:00")
+
+        self.assertEqual(
+            "{:%Y-%m-%d}".format(utils.FormatDate(d)),
+            "2018-02-02")
+
+        self.assertEqual(
             "{:+5h%H}".format(utils.FormatDate(d)),
             "17")
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -21,6 +21,7 @@ import tempfile
 import time
 
 from botocore.exceptions import ClientError
+from dateutil.parser import parse as parse_date
 import six
 
 from c7n import ipaddress, utils
@@ -105,6 +106,20 @@ class WorkerDecorator(BaseTest):
 
 
 class UtilTest(unittest.TestCase):
+
+    def test_format_date(self):
+        d = parse_date("2018-02-02 12:00")
+        self.assertEqual(
+            "{:+5h%H}".format(utils.FormatDate(d)),
+            "17")
+
+        self.assertEqual(
+            "{:+5d%d}".format(utils.FormatDate(d)),
+            "07")
+
+        self.assertEqual(
+            "{:+5M%M}".format(utils.FormatDate(d)),
+            "05")
 
     def test_group_by(self):
         sorter = lambda x: x


### PR DESCRIPTION
with this branch you can now do tagging on resources with some interpolated values

ala

```
policies:
   - name: ec2-date-tag
      resource: ec2
      mode:
         type: cloudtrail
         events:
           - RunInstances
      actions:
        - type: tag
           tags:
             created: "{now}"
             expire: "{now:+60d}"
```
which will create two tags on the ec2 instances, one with the current date, and another with the current date +60 days into the future.

the date can be formatted per documentation at https://pyformat.info/

other values supported at the moment are `region` and `account_id`