### PR TITLE
tools/c7n_mailer fix ldap lookup of assumed roles

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -276,7 +276,10 @@ class EmailDelivery(object):
         if identity['type'] == 'AssumedRole':
             self.logger.debug('In some cases there is no ldap uid is associated with AssumedRole: %s' % identity['arn'])
             self.logger.debug('We will try to assume that identity is in the AssumedRoleSessionName')
-            return identity['arn'].split('/')[-1]
+            session_name = identity['arn'].split('/')[-1]
+            if ':' in session_name:
+                session_name = session_name.split(':', 1)[-1]
+            return session_name
         if identity['type'] == 'IAMUser' or identity['type'] == 'WebIdentityUser':
             return identity['userName']
         if identity['type'] == 'Root':

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -276,10 +276,12 @@ class EmailDelivery(object):
         if identity['type'] == 'AssumedRole':
             self.logger.debug('In some cases there is no ldap uid is associated with AssumedRole: %s' % identity['arn'])
             self.logger.debug('We will try to assume that identity is in the AssumedRoleSessionName')
-            session_name = identity['arn'].split('/')[-1]
-            if ':' in session_name:
-                session_name = session_name.split(':', 1)[-1]
-            return session_name
+            user = identity['arn'].rsplit('/', 1)[-1]
+            if user is None or user.startswith('i-') or user.startswith('awslambda'):
+                return None
+            if ':' in user:
+                user = user.split(':', 1)[-1]
+            return user
         if identity['type'] == 'IAMUser' or identity['type'] == 'WebIdentityUser':
             return identity['userName']
         if identity['type'] == 'Root':

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -274,9 +274,9 @@ class EmailDelivery(object):
                 format_struct(event)))
             return None
         if identity['type'] == 'AssumedRole':
-            assume_role_msg = 'No ldap uid is associated with AssumedRole: %s' % identity['arn']
-            self.logger.debug(assume_role_msg)
-            return None
+            self.logger.debug('In some cases there is no ldap uid is associated with AssumedRole: %s' % identity['arn'])
+            self.logger.debug('We will try to assume that identity is in the AssumedRoleSessionName')
+            return identity['arn'].split('/')[-1]
         if identity['type'] == 'IAMUser' or identity['type'] == 'WebIdentityUser':
             return identity['userName']
         if identity['type'] == 'Root':


### PR DESCRIPTION
Previously, the mailer will return `None` when the event's userIdentity was of type `AssumedRole`
This may have been because the original author did not have role session names that were an LDAP uid.

This code proposes to change that and assume that the session name is searchable in LDAP.
For the original author, the failure to look up the LDAP uid will occur later in the ldap_lookup.py code.

An example event:
```
"userIdentity": {
        "type": "AssumedRole",
        "principalId": "XXXXXXXXXXXXX:abc123",
        "arn": "arn:aws:sts::123123123123:assumed-role/XXXXXXXXXXXXX/abcd123",
        "accountId": "123123123123",
        "accessKeyId": "XXXXXXXXXXXXX",
        "sessionContext": {
            ...
        }
    },
```