### PR TITLE
Inherits IAM Credential Report value_type from the ValueFilter.

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -625,8 +625,7 @@ class CredentialReport(Filter):
     """
     schema = type_schema(
         'credential',
-        value_type={'type': 'string', 'enum': [
-            'age', 'expiration', 'size', 'regex']},
+        value_type=ValueFilter.schema['properties']['value_type'],
 
         key={'type': 'string',
              'title': 'report key to search',


### PR DESCRIPTION
The ValueFilter is used for the actual implementation here, so we should inherit / support the same value_type options as ValueFilter.