### PR TITLE
Revert "sns access policy"

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -865,14 +865,11 @@ class ModifyPolicyBase(BaseAction):
     )
 
     def __init__(self, data=None, manager=None):
-        if manager is not None:
-            config_args = {
-                'account_id': manager.config.get('account_id'),
-                'region': manager.config.get('region')
-            }
-            self.data = utils.format_string_values(data, **config_args)
-        else:
-            self.data = utils.format_string_values(data)
+        config_args = {
+            'account_id': manager.config.account_id,
+            'region': manager.config.region
+        }
+        self.data = utils.format_string_values(data, **config_args)
         self.manager = manager
 
     def add_statements(self, policy_statements):


### PR DESCRIPTION
Reverts capitalone/cloud-custodian#2152

Causes breaking change when executing:
```
Traceback (most recent call last):
  File "/Users/thisisshi/dev/cloud-custodian/c7n/cli.py", line 398, in main
    command(options)
  File "/Users/thisisshi/dev/cloud-custodian/c7n/commands.py", line 56, in _load_policies
    collection = policy_load(options, fp, vars=vars)
  File "/Users/thisisshi/dev/cloud-custodian/c7n/policy.py", line 77, in load
    collection = PolicyCollection.from_data(data, options)
  File "/Users/thisisshi/dev/cloud-custodian/c7n/policy.py", line 125, in from_data
    for p in data.get('policies', ())]
  File "/Users/thisisshi/dev/cloud-custodian/c7n/policy.py", line 703, in __init__
    self.resource_manager = self.get_resource_manager()
  File "/Users/thisisshi/dev/cloud-custodian/c7n/policy.py", line 804, in get_resource_manager
    return factory(self.ctx, self.data)
  File "/Users/thisisshi/dev/cloud-custodian/c7n/query.py", line 369, in __init__
    super(QueryResourceManager, self).__init__(data, options)
  File "/Users/thisisshi/dev/cloud-custodian/c7n/manager.py", line 51, in __init__
    self.data.get('actions', []), self)
  File "/Users/thisisshi/dev/cloud-custodian/c7n/actions.py", line 98, in parse
    results.append(self.factory(d, manager))
  File "/Users/thisisshi/dev/cloud-custodian/c7n/actions.py", line 117, in factory
    return action_class(data, manager).validate()
  File "/Users/thisisshi/dev/cloud-custodian/c7n/actions.py", line 870, in __init__
    'account_id': manager.config.get('account_id'),
AttributeError: 'Namespace' object has no attribute 'get'
```

The PR passed tests because it's mocking the Execution Context with a `Config` object which extends `Bag(Dict)`, `Namespace` doesn't have a `get` method so it's failing.

Could coerce `Namespace` with `vars(manager.config).get('account_id')` but it would be better to fix the Validate execution to pass in a `argparse.Namespace` object as the config obj imo