### PR TITLE
Disable Cloudformation Stack  termination protection 

### DIFF
--- a/c7n/resources/cfn.py
+++ b/c7n/resources/cfn.py
@@ -91,6 +91,7 @@ class DisableProtection(BaseAction):
                   - disable-protection
     """
 
+    schema = type_schema('disable-protection')
     permissions = ('cloudformation:UpdateStack',)
 
     def process(self, stacks):
@@ -100,6 +101,7 @@ class DisableProtection(BaseAction):
     def process_stacks(self, stack):
         client = local_session(
             self.manager.session_factory).client('cloudformation')
+
         client.update_termination_protection(
             EnableTerminationProtection=False,
             StackName=stack['StackName'])

--- a/c7n/resources/cfn.py
+++ b/c7n/resources/cfn.py
@@ -15,6 +15,8 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import logging
 
+from concurrent.futures import as_completed
+
 from c7n.actions import BaseAction
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
@@ -72,8 +74,8 @@ class Delete(BaseAction):
         client.delete_stack(StackName=stack['StackName'])
 
 
-@CloudFormation.action_registry.register('disable-protection')
-class DisableProtection(BaseAction):
+@CloudFormation.action_registry.register('set-protection')
+class SetProtection(BaseAction):
     """Action to disable termination protection
 
     It is recommended to use a filter to avoid unwanted deletion of stacks
@@ -88,22 +90,33 @@ class DisableProtection(BaseAction):
                 filters:
                   - StackStatus: CREATE_COMPLETE
                 actions:
-                  - disable-protection
+                  - type: set-protection
+                    state: False
     """
 
-    schema = type_schema('disable-protection')
+    schema = type_schema(
+        'set-protection', state={'type': 'boolean', 'default': False})
+
     permissions = ('cloudformation:UpdateStack',)
 
     def process(self, stacks):
-        with self.executor_factory(max_workers=10) as w:
-            list(w.map(self.process_stacks, stacks))
-
-    def process_stacks(self, stack):
         client = local_session(
             self.manager.session_factory).client('cloudformation')
 
+        with self.executor_factory(max_workers=3) as w:
+            futures = {}
+            for s in stacks:
+                futures[w.submit(self.process_stacks, client, s)] = s
+            for f in as_completed(futures):
+                s = futures[f]
+                if f.exception():
+                    self.log.error(
+                        "Error updating protection stack:%s error:%s",
+                        s['StackName'], f.exception())
+
+    def process_stacks(self, client, stack):
         client.update_termination_protection(
-            EnableTerminationProtection=False,
+            EnableTerminationProtection=self.data.get('state', False),
             StackName=stack['StackName'])
 
 

--- a/tests/data/placebo/test_cfn_disable_protection/cloudformation.DescribeStacks_1.json
+++ b/tests/data/placebo/test_cfn_disable_protection/cloudformation.DescribeStacks_1.json
@@ -1,0 +1,170 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Stacks": [
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sphere11-dev/514b9370-c6b0-11e6-a4cc-50d5cd26c2d2", 
+                "Description": "Automatically generated with Zappa", 
+                "Tags": [
+                    {
+                        "Value": "sphere11-dev", 
+                        "Key": "ZappaProject"
+                    }
+                ], 
+                "CreationTime": {
+                    "hour": 12, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 6, 
+                    "microsecond": 615000, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 32
+                }, 
+                "StackName": "sphere11-dev", 
+                "NotificationARNs": [], 
+                "StackStatus": "CREATE_COMPLETE", 
+                "DisableRollback": false
+            }, 
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sam-t1/f274c7c0-c6a2-11e6-b271-50d5cd0dfcc6", 
+                "LastUpdatedTime": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 23, 
+                    "microsecond": 677000, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 58
+                }, 
+                "Tags": [], 
+                "CreationTime": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 23, 
+                    "microsecond": 802000, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 56
+                }, 
+                "Capabilities": [
+                    "CAPABILITY_IAM"
+                ], 
+                "StackName": "sam-t1", 
+                "NotificationARNs": [], 
+                "StackStatus": "CREATE_COMPLETE", 
+                "DisableRollback": false, 
+                "ChangeSetId": "arn:aws:cloudformation:us-east-1:644160558196:changeSet/awscli-cloudformation-package-deploy-1482231515/7725c99f-1fe6-4900-aa20-228b4a56b683"
+            }, 
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sphere11-db-3/1bca95e0-c69f-11e6-bd30-500c286fcc61", 
+                "Tags": [], 
+                "CreationTime": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 54, 
+                    "microsecond": 983000, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 28
+                }, 
+                "StackName": "sphere11-db-3", 
+                "NotificationARNs": [], 
+                "StackStatus": "ROLLBACK_COMPLETE", 
+                "DisableRollback": false
+            }, 
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sphere11-db-2/19f1de40-c69f-11e6-9932-503aca4a5835", 
+                "Tags": [], 
+                "CreationTime": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 51, 
+                    "microsecond": 885000, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 28
+                }, 
+                "StackName": "sphere11-db-2", 
+                "NotificationARNs": [], 
+                "StackStatus": "ROLLBACK_COMPLETE", 
+                "DisableRollback": false
+            }, 
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sphere11-db-1/1863c430-c69f-11e6-bd47-503aca2616c5", 
+                "Tags": [], 
+                "CreationTime": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 49, 
+                    "microsecond": 274000, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 28
+                }, 
+                "StackName": "sphere11-db-1", 
+                "NotificationARNs": [], 
+                "StackStatus": "ROLLBACK_COMPLETE", 
+                "DisableRollback": false
+            }, 
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sphere11-db/5825dba0-c69d-11e6-881a-50d5ca632656", 
+                "Tags": [], 
+                "CreationTime": {
+                    "hour": 10, 
+                    "__class__": "datetime", 
+                    "month": 12, 
+                    "second": 17, 
+                    "microsecond": 252000, 
+                    "year": 2016, 
+                    "day": 20, 
+                    "minute": 16
+                }, 
+                "StackName": "sphere11-db", 
+                "NotificationARNs": [], 
+                "StackStatus": "CREATE_COMPLETE", 
+                "DisableRollback": false
+            }, 
+            {
+                "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/test2/39d87b70-6b3b-11e6-ba3d-500c2893c036", 
+                "Tags": [
+                    {
+                        "Value": "Zoo", 
+                        "Key": "Plat"
+                    }
+                ], 
+                "CreationTime": {
+                    "hour": 3, 
+                    "__class__": "datetime", 
+                    "month": 8, 
+                    "second": 40, 
+                    "microsecond": 159000, 
+                    "year": 2016, 
+                    "day": 26, 
+                    "minute": 14
+                }, 
+                "StackName": "test2", 
+                "NotificationARNs": [], 
+                "StackStatus": "CREATE_COMPLETE", 
+                "DisableRollback": false
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "7dbedc5c-c6b1-11e6-b3e7-9d7da24f9689", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "7dbedc5c-c6b1-11e6-b3e7-9d7da24f9689", 
+                "vary": "Accept-Encoding", 
+                "content-length": "3796", 
+                "content-type": "text/xml", 
+                "date": "Tue, 20 Dec 2016 12:40:30 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_cfn_disable_protection/cloudformation.DescribeStacks_2.json
+++ b/tests/data/placebo/test_cfn_disable_protection/cloudformation.DescribeStacks_2.json
@@ -19,18 +19,17 @@
                 "StackStatus": "CREATE_COMPLETE",
                 "DisableRollback": false,
                 "NotificationARNs": [],
-                "Tags": [],
-                "EnableTerminationProtection": true
+                "Tags": []
             }
         ],
         "ResponseMetadata": {
-            "RequestId": "57489a01-3a5f-11e8-ad4c-b37748d4efe4",
+            "RequestId": "577e4fe9-3a5f-11e8-9a2f-952c05ccedd1",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
-                "x-amzn-requestid": "57489a01-3a5f-11e8-ad4c-b37748d4efe4",
+                "x-amzn-requestid": "577e4fe9-3a5f-11e8-9a2f-952c05ccedd1",
                 "content-type": "text/xml",
-                "content-length": "915",
-                "date": "Sat, 07 Apr 2018 12:29:38 GMT"
+                "content-length": "843",
+                "date": "Sat, 07 Apr 2018 12:29:39 GMT"
             },
             "RetryAttempts": 0
         }

--- a/tests/data/placebo/test_cfn_disable_protection/cloudformation.DescribeStacks_3.json
+++ b/tests/data/placebo/test_cfn_disable_protection/cloudformation.DescribeStacks_3.json
@@ -20,17 +20,17 @@
                 "DisableRollback": false,
                 "NotificationARNs": [],
                 "Tags": [],
-                "EnableTerminationProtection": true
+                "EnableTerminationProtection": false
             }
         ],
         "ResponseMetadata": {
-            "RequestId": "57489a01-3a5f-11e8-ad4c-b37748d4efe4",
+            "RequestId": "57e1308c-3a5f-11e8-ad4c-b37748d4efe4",
             "HTTPStatusCode": 200,
             "HTTPHeaders": {
-                "x-amzn-requestid": "57489a01-3a5f-11e8-ad4c-b37748d4efe4",
+                "x-amzn-requestid": "57e1308c-3a5f-11e8-ad4c-b37748d4efe4",
                 "content-type": "text/xml",
-                "content-length": "915",
-                "date": "Sat, 07 Apr 2018 12:29:38 GMT"
+                "content-length": "916",
+                "date": "Sat, 07 Apr 2018 12:29:39 GMT"
             },
             "RetryAttempts": 0
         }

--- a/tests/data/placebo/test_cfn_disable_protection/cloudformation.UpdateTerminationProtection_1.json
+++ b/tests/data/placebo/test_cfn_disable_protection/cloudformation.UpdateTerminationProtection_1.json
@@ -1,17 +1,17 @@
 {
     "status_code": 200,
     "data": {
-        "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sphere11-dev/514b9370-c6b0-11e6-a4cc-50d5cd26c2d2",
+        "StackId": "arn:aws:cloudformation:us-east-2:644160558196:stack/mytopic/7efb2d40-3a5d-11e8-8c44-500cef930ce6",
         "ResponseMetadata": {
-            "RetryAttempts": 0,
+            "RequestId": "57af247e-3a5f-11e8-9a16-0bc34bbf8d72",
             "HTTPStatusCode": 200,
-            "RequestId": "7df15e4b-c6b1-11e6-b9b8-077e63d75d99",
             "HTTPHeaders": {
-                "x-amzn-requestid": "7df15e4b-c6b1-11e6-b9b8-077e63d75d99",
-                "date": "Tue, 20 Dec 2016 12:40:30 GMT",
-                "content-length": "212",
-                "content-type": "text/xml"
-            }
+                "x-amzn-requestid": "57af247e-3a5f-11e8-9a16-0bc34bbf8d72",
+                "content-type": "text/xml",
+                "content-length": "441",
+                "date": "Sat, 07 Apr 2018 12:29:40 GMT"
+            },
+            "RetryAttempts": 0
         }
     }
 }

--- a/tests/data/placebo/test_cfn_disable_protection/cloudformation.UpdateTerminationProtection_1.json
+++ b/tests/data/placebo/test_cfn_disable_protection/cloudformation.UpdateTerminationProtection_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200,
+    "data": {
+        "StackId": "arn:aws:cloudformation:us-east-1:644160558196:stack/sphere11-dev/514b9370-c6b0-11e6-a4cc-50d5cd26c2d2",
+        "ResponseMetadata": {
+            "RetryAttempts": 0,
+            "HTTPStatusCode": 200,
+            "RequestId": "7df15e4b-c6b1-11e6-b9b8-077e63d75d99",
+            "HTTPHeaders": {
+                "x-amzn-requestid": "7df15e4b-c6b1-11e6-b9b8-077e63d75d99",
+                "date": "Tue, 20 Dec 2016 12:40:30 GMT",
+                "content-length": "212",
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -41,35 +41,24 @@ class TestCFN(BaseTest):
 
     def test_disable_protection(self):
         factory = self.replay_flight_data('test_cfn_disable_protection')
+        client = factory().client('cloudformation')
+        stacks = client.describe_stacks(
+            StackName='mytopic').get('Stacks')
+        self.assertEqual(stacks[0].get('EnableTerminationProtection'), True)
         p = self.load_policy({
             'name': 'cfn-disable-protection',
             'resource': 'cfn',
-            'filters': [{'StackName': 'sphere11-db-1'}],
-            'actions': ['disable-protection']
+            'filters': [{'StackName': 'mytopic'}],
+            'actions': [{
+                'type': 'set-protection',
+                'state': False}]
             }, session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
-
-    def test_disable_protection_no_match(self):
-        factory = self.replay_flight_data('test_cfn_disable_protection')
-        p = self.load_policy({
-            'name': 'cfn-disable-protection',
-            'resource': 'cfn',
-            'filters': [{'StackName': 'NoMatch'}],
-            'actions': ['disable-protection']
-            }, session_factory=factory)
-        resources = p.run()
-        self.assertEqual(len(resources), 0)
-
-    def test_disable_protection_all_match(self):
-        factory = self.replay_flight_data('test_cfn_disable_protection')
-        p = self.load_policy({
-            'name': 'cfn-disable-protection',
-            'resource': 'cfn',
-            'actions': ['disable-protection']
-            }, session_factory=factory)
-        resources = p.run()
-        self.assertEqual(len(resources), 7)
+        client = factory().client('cloudformation')
+        stacks = client.describe_stacks(
+            StackName=resources[0]['StackName']).get('Stacks')
+        self.assertEqual(stacks[0].get('EnableTerminationProtection'), False)
 
     def test_cfn_add_tag(self):
         session_factory = self.replay_flight_data('test_cfn_add_tag')

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -44,11 +44,32 @@ class TestCFN(BaseTest):
         p = self.load_policy({
             'name': 'cfn-disable-protection',
             'resource': 'cfn',
-            'filters': [{'StackStatus': 'CREATE_COMPLETE'}, {'StackName': 'sphere11-db'}],
+            'filters': [{'StackName': 'sphere11-db-1'}],
             'actions': ['disable-protection']
             }, session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_disable_protection_no_match(self):
+        factory = self.replay_flight_data('test_cfn_disable_protection')
+        p = self.load_policy({
+            'name': 'cfn-disable-protection',
+            'resource': 'cfn',
+            'filters': [{'StackName': 'NoMatch'}],
+            'actions': ['disable-protection']
+            }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 0)
+
+    def test_disable_protection_all_match(self):
+        factory = self.replay_flight_data('test_cfn_disable_protection')
+        p = self.load_policy({
+            'name': 'cfn-disable-protection',
+            'resource': 'cfn',
+            'actions': ['disable-protection']
+            }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 7)
 
     def test_cfn_add_tag(self):
         session_factory = self.replay_flight_data('test_cfn_add_tag')

--- a/tests/test_cfn.py
+++ b/tests/test_cfn.py
@@ -39,6 +39,17 @@ class TestCFN(BaseTest):
         resources = p.run()
         self.assertEqual(resources, [])
 
+    def test_disable_protection(self):
+        factory = self.replay_flight_data('test_cfn_disable_protection')
+        p = self.load_policy({
+            'name': 'cfn-disable-protection',
+            'resource': 'cfn',
+            'filters': [{'StackStatus': 'CREATE_COMPLETE'}, {'StackName': 'sphere11-db'}],
+            'actions': ['disable-protection']
+            }, session_factory=factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
     def test_cfn_add_tag(self):
         session_factory = self.replay_flight_data('test_cfn_add_tag')
         p = self.load_policy({


### PR DESCRIPTION
- Cloudformation Stack with termination protection will prevent stack from being deleted.
- Add action to disable termination protection. user can choose to use this before delete stack or just as is for other reason
- Added tests