### PR TITLE
Support a unique_size value type

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -311,7 +311,7 @@ class ValueFilter(Filter):
             'key': {'type': 'string'},
             'value_type': {'enum': [
                 'age', 'integer', 'expiration', 'normalize', 'size',
-                'cidr', 'cidr_size', 'swap', 'resource_count', 'expr']},
+                'cidr', 'cidr_size', 'swap', 'resource_count', 'expr', 'unique_size']},
             'default': {'type': 'object'},
             'value_from': ValuesFrom.schema,
             'value': {'oneOf': [
@@ -481,6 +481,11 @@ class ValueFilter(Filter):
         elif self.vtype == 'size':
             try:
                 return sentinel, len(value)
+            except TypeError:
+                return sentinel, 0
+        elif self.vtype == 'unique_size':
+            try:
+                return sentinel, len(set(value))
             except TypeError:
                 return sentinel, 0
         elif self.vtype == 'swap':

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -163,6 +163,11 @@ class TestValueFilter(unittest.TestCase):
         res = vf.process_value_type(sentinel, value, resource)
         self.assertEqual(res, (None, 1))
 
+        vf.vtype = 'unique_size'
+        value = [1, 2, 3, 1, 5]
+        res = vf.process_value_type(sentinel, value, resource)
+        self.assertEqual(res, (None, 4))
+
 
 class TestAgeFilter(unittest.TestCase):
 


### PR DESCRIPTION
It's useful in some cases to be able to look at unique value sizes for a given value, rather than just the size.

One example here would be comparing the instance AZs for an ASG to ensure there are instances in more than one AZ. 