### PR TITLE
adding cross-account filter to ami

### DIFF
--- a/tests/data/placebo/test_ami_cross_accounts/ec2.DescribeImageAttribute_1.json
+++ b/tests/data/placebo/test_ami_cross_accounts/ec2.DescribeImageAttribute_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "e1e75729-a0bf-4c58-8b5c-cb1720ff1a70", 
+            "HTTPHeaders": {
+                "date": "Wed, 28 Mar 2018 17:36:57 GMT", 
+                "content-length": "375", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }, 
+        "LaunchPermissions": [
+            {
+                "UserId": "185106417252"
+            }
+        ], 
+        "ImageId": "ami-a63ae2db"
+    }
+}

--- a/tests/data/placebo/test_ami_cross_accounts/ec2.DescribeImages_1.json
+++ b/tests/data/placebo/test_ami_cross_accounts/ec2.DescribeImages_1.json
@@ -1,0 +1,49 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Images": [
+            {
+                "VirtualizationType": "hvm", 
+                "Description": "Test AMI", 
+                "Hypervisor": "xen", 
+                "EnaSupport": true, 
+                "SriovNetSupport": "simple", 
+                "ImageId": "ami-a63ae2db", 
+                "State": "available", 
+                "BlockDeviceMappings": [
+                    {
+                        "DeviceName": "/dev/xvda", 
+                        "Ebs": {
+                            "Encrypted": false, 
+                            "DeleteOnTermination": true, 
+                            "VolumeType": "gp2", 
+                            "VolumeSize": 8, 
+                            "SnapshotId": "snap-0507048b4551a4ab4"
+                        }
+                    }
+                ], 
+                "Architecture": "x86_64", 
+                "ImageLocation": "644160558196/c7n-test-ami", 
+                "RootDeviceType": "ebs", 
+                "OwnerId": "644160558196", 
+                "RootDeviceName": "/dev/xvda", 
+                "CreationDate": "2018-03-28T17:29:36.000Z", 
+                "Public": false, 
+                "ImageType": "machine", 
+                "Name": "c7n-test-ami"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "078a7b9b-d48e-4354-9fd3-7692f64c702a", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "date": "Wed, 28 Mar 2018 17:36:56 GMT"
+            }
+        }
+    }
+}

--- a/tests/test_ami.py
+++ b/tests/test_ami.py
@@ -51,3 +51,15 @@ class TestAMI(BaseTest):
         }, session_factory=factory)
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_ami_cross_accounts(self):
+        session_factory = self.replay_flight_data('test_ami_cross_accounts')
+        p = self.load_policy({
+            'name': 'cross-account-ami',
+            'resource': 'ami',
+            'filters': [{
+                'type': 'cross-account',
+                'whitelist': ['644160558196']
+            }]}, session_factory=session_factory)
+        resources = p.run()
+        self.assertEqual(len(resources), 1)


### PR DESCRIPTION
per #238 

adding `cross-account` filter to ami.py to check launchPermissions for invalid access