### PR TITLE
Using VCR tests against Azure?

### DIFF
--- a/tools/c7n_azure/requirements-dev.txt
+++ b/tools/c7n_azure/requirements-dev.txt
@@ -1,0 +1,1 @@
+vcr_unittest==1.11.0

--- a/tools/c7n_azure/tests/__init__.py
+++ b/tools/c7n_azure/tests/__init__.py
@@ -1,0 +1,14 @@
+# Copyright 2015-2017 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#

--- a/tools/c7n_azure/tests/cassettes/VMClientTest.test_client.yaml
+++ b/tools/c7n_azure/tests/cassettes/VMClientTest.test_client.yaml
@@ -1,0 +1,226 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Authorization: [bearer filtered]
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.14.2 msrest/0.4.27
+          msrest_azure/0.4.23 computemanagementclient/3.1.0rc3 Azure-SDK-For-Python]
+      accept-language: [en-US]
+      x-ms-client-request-id: [550371f0-344f-11e8-a7a5-1866da09a201]
+    method: GET
+    uri: https://management.azure.com/subscriptions/4bfa739e-0d8c-437e-9302-e3da21c66828/providers/Microsoft.Compute/virtualMachines?api-version=2017-12-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFH+Wx3+mm28+n2g/uzfHt/cv/T7ezhg3vbO3vne7sH
+        e7OH5+f5R6OP5lk9u8rq/GVdnRclwQOA18UP6LePXrfZckbf//4vfnJv/6NfMvqoaas6u/DbFgv6
+        +1V+ntf5csqfrNaTsmjmeU0AviimddVU5+13i+Wsumpe5/UlfTH6qKLO0aD7efN2TZ/u7ex+uv00
+        a7Npvmz5c/q2KaolfVdmbd60QKZqnhbNW3RZNW+uV9S5AUcvLLMFPrhC49//S275++/+/gcH57uf
+        nt+fPJhOz/cfPLj3cLazuz+Z7e4cfHq+9+n9c3pxWufUw5erVrp7VleLM4wRX2XTebG8oE9f5dns
+        u3XR4tNFtqSvZ+gBuBSg/d1mPWmmdcFQmrv7k/OMOsu3d2YH0+39ew/y7Yf3dva283uzbI9m6dOD
+        vYO7dd5U63qaf15X61Vzt2nz82x5Ud2lyb0sZjT+u5aa45NqsVq3+d0Zddrcfd9B/hIi3oyoi/bE
+        Md/7Pv1dNd6kTgV8/cIjIo00my2K5VdNXitxDYr01ZUQ/qRanhcX6zrDuAGJkcfM/eQXxxc0mR89
+        aut1PvooX2aTMj9et9WC2k6/WhE+4F58S9g0OU1DS38zbsu8varqtx6C+skZuOOcuAQtf0ikfyFd
+        3+2hINNwsE+CAqRnRXaxrBoanE/ZSVW1T903+EhIQahj7DR0EbGv6oIGM2/bVfPorsUIQD+9tzee
+        lNVkPK3qfKyEHxM6d3liy4KEpslDgfj9rYDxkDAhxMgk3sTBJObr6TTPZ4QDvd/Ki27Ahtcui7pd
+        Z+UXLAREceqqmtLkYaI/yrOmXeOzb2oOXr85fXb84vMvo3MwgJLMACGh/Cl//pIRs2FfQT6Y7t47
+        n0webk/O700IrWm2fbA/fbA93d2dfXpvSvSYfkrAssusKLNJURbt9eucOPibY7Tf5/nxT/1eXz05
+        ffPVmy9fnR0/3zjYDh7N3ePPT1+82T7+yeOz58dPzp6fvfl9Xp++2d4/3jl58PTTYxr37XT7073f
+        /3IPrZXzvMablftJtiQ2mmYlEcno868m62W7ttwm6nz30/HO/vbzN6/pE/oc3Gc+HZOqf7BzsHt/
+        FxhENPrzYrl+R+/plL49aLYJp2Vrx7m9s1010IPUiJQGcfSXPCPU2Nfdl3Oas1/80ToQq52dyXVZ
+        Pvh0cbG+vKjWJJbtzoBsSR93N/Q/Rhc0iLiVQAtQ/vMnHz26t0PNSOHdWgHHeiWYXX2c/WBd52v6
+        m74rQbeeOiYsoGxeZk1DymtG+ndOUGkOpYFqoGaOtjzV098rvwaG9GfW0scf3Z1XC+JF09PdMbW+
+        mxGcqqbRzX7/t2g/+oh+wH7TC/T9dt1k6TE9T+69+EF2sns93Tulv46fHv/E8RP6+eT4J56ev33T
+        XOW/9+91/Prd+uGr6bufevuLHv6i9fLNg7c/8fDp6/nJ04v893lzPJvtzp5m327z8ru/z0//ZLM6
+        vTg72cl+6uXdl68/X8wevCnKH2Rf/KLr736Z/VT5/Oq6nOWvZ89/r9/n9/rBxU/uLd6cnzz9fb46
+        ++T8p/a/2pvtV/V59fCnzi++Xbz99Lj6RdnL02//3rNPfq+f/Mmf/MH64vmT8uDL3d/73uc/sf9u
+        db7+6uXnv2hvb5Jn+z95+e51/d2fuH549vs8/eq7F2fLy9/rJ96dZqurpjx9Wf5ev8/9u7/P75MV
+        7Ve/9+XrH/z0d39wfX/v8vnLydmDqy8Ovv1TXzx/8Pn+D3b3X//06/zz408ffPt+WUx2zo6nT45n
+        d09ezD7/yemnl9lV9fKnDt5drl/+op3295q+OPvJnfrl/R/snj/79unri092VwfLX/TTzU8WXx7/
+        9Cc7e3u/z867d+XBu3d7y08Xx7/3vfbs6qufPi8WxU8+zUtYImKtn1trel1mP3i7nuQtGfu6yMqo
+        khu2qhHeJ6VD/E9ju4U5M8h8s2N6L8XdtVKREe3czd+1ZLYZoWmTY3QfZor36MM2u6BhkzaBWqQv
+        X/MQqEk2bbZjWNA7VT2dk9UklVFBn/9eNHE1TUrePNodPxg/oBarqipVL/H79JGhDj5+vT4/L97R
+        lwYsZuH/tXQn5FV5Rr8d9B1mU3Kq758/2J4cPMy29ycH97az7Hx3++D8fnaQk0WbPcQMdGw2APyc
+        kKKDR/Mj34HHub2rtpsasZD8sH0H0/8P13fYJZg/8h1+5Dv8fPUdSF9gMAwLCoUkjjQaiRpptvX/
+        53yH3Y7vgNGR7RcVeCNEkrdvxHeATvn55TtgxKo8o98O+g47Ow+me9NJvj092KG8w/692XZ2/979
+        7Wm2t3M+ebhzbyfPCHbHZgPAzwkpOng0P/IdeJzbe2q7qRELyQ/bdzD9/3B9B+iGH/kOP/Idfr76
+        DqSxMBiGBYVCEkcajUSNNNv6/3O+w17Hd8DoyPaLCrwRIsnbN+I74J2fX74DRqzKM/rtoO+wN31A
+        ixWfPtz+dIdM2342mW1Pdh/sbtM6xmzv4YP7+cE5chodmw0APyek6ODRDPgOx/eOH+w+eXJK4/7/
+        te9gxmnXDKgRC8l7+Q6fzvLzZtK+neTEXe/lO/T6/6H4Dq5Xgvkj3+FHvsPPI9/B8j4pHeJ/GhsZ
+        MsCCQiGJI41Gokaabf3/Fd/BjujndM3CYUHvfHO+gwGLWfh/Ld0JeVWe0W8HfYfzB7PZw08nu9vT
+        +w8Ptvd3Pr23/TCfnm9P7z2Y3p/sTHb2pvsEu2OzAeDnhBQdPJof+Q48TrtmQI1YSH7YvoPp/4fr
+        OyDb9iPf4Ue+w89X34H0BQbDsKBQSOJIo5GokWZb/3/Od/g5XbNwWNA7P798B4xYlWf020HfgRYl
+        du7dfzDdzh/cozWL/P7D7YMHD2e0enHwMNt7ONun7wh2x2YDwM8JKTp4ND/yHXicds2AGrGQ/LB9
+        B9P/D9d3gG74ke/wI9/h56vvQBoLg2FYUCgkcaTRSNRIs63/P+c7/JyuWTgs6J2fX74DRqzKM/rt
+        oO/w6YOdnQf3dyfbuzu7O+QxTLPth5/ev799vrv34CEx396n5zOC3bHZAPBzQooOHtTk+PWb01c9
+        58Es19DA/3/qPCyyhlSLHahdNaBWLCbv4T1MrsvywaeLi/XlRbVeNG095DvQ28J9Q51/gOvwiz8q
+        14Ttzg2DzNvpDHAIXGeYp4tVe00fA4WflSGarvuDfFEtu+Pb3TtgvX6TN9TrhuD8yB36kTv088Id
+        6jI/6VESABocGWcAg44kCSMlTfqDlPX6//3+UHdIP0cLMT006KX38ogEAH1mCITPrUtk4GIi/t9L
+        esJeNWj860Gn6Hw2mZ4/nDzczvfufbpNPlG2fTCjf6aT3YeTg92d6XSy2Sn64RLjtk6R8Qdp4P//
+        dorMQMloi19CrVhUnLdwo1MUJFTex2Podd73F74Rp8jrJ2/FMyFwnWFudIq+iSGarvuD/HCnyHVD
+        cH7kFP3IKfr55BRZ5ic9SgJAgyP7DGDQkSRhpKRJf5CyXv9/ximyQ/q5dYocGvTSN+gUGbiYiP/3
+        kp6wVw0a/3rQKbo/ezjdPzj/dPs8z863988fnG8f7D/Y3d7dnUx27u3m5CZhFubZbRyL3R+KYzHe
+        6bkWJUlN06Lrmz2Kxez83cU0/8GlGnL6hnnLmdcbvYiLaXb16Q/q/dn1L3rQLJYbDax0stO3pEPu
+        wt5Daua7C9ARm2yrGxChQsC6NvUib+f8GX33s2tTbU/flE09uVj/oq/uvvtFp09Of+L3mX/3F12s
+        v1P8xNOHn2bN7g9+n+c//fkvevj8J6q3uz/59NvH1fHvdb43ffeTWbaa1t/eqRbXzadvJjvf/uLt
+        dyeLZ5frN29++vz3+cH5y88nv/fl79Ne5N95vf+d84Nnl2++O3/y6osvlz9YXO9fLhaff+fZTy1m
+        X37ybPX6eTn/9uum/fbs3b2LH5wUzeu39fXTn/q0enu+uPv7XDVvXjx88unz7zx78e3sF83PLtvJ
+        5/un1+3um+OT5/XbveOT+7/P7/X7PPzip19++Z3vfPvLe199et6+XrydP797kv8+P3314OzTX/Tg
+        9U+8/akvf/oHq/ns/tuDn57Nshf58+Mq+33uEc+vf6918eTFt8t355NPX/z06fM3Tz+/O9+f/eDL
+        k+tV8fb3rp7+XuWb7/7U9c6nP716cbbYe7BavKre3d+f//TD+vKKIofLdrrc+0XVd6+/84PZT0w/
+        +ZJMbV7/3t/9zlfz+gHp5Z97m5otf1CRwp9vE/tG9d+wPSVVwaxOwyBFjlehBkiqSBOROJFGWv+s
+        W8/jFz/15fMvT769/cXTZ1H0h9Q3DddJq28xl/kV3FHBi8ZGpk/0140wSbCIkiqsH12RJlzjs/93
+        DZUQUn0UfjxomSgiz/YeTu9t3/t0cp/C9b1PyTLlk+2D3Wz34OHBpwf5vU8J6Jwsz48s09e3TLs/
+        JMu0S8DYNvzIMv3IMv3/2zJRagt486tQAyRVpIlInEgjrf+/YZl2f/5YJigm1Ufhx4OW6V4+u7+7
+        9zDb3pvuPaSYafZwO9s9P9+eTLOdT6ef5tm9BwgxM2L20iVwAeCHPvAODtTk6bPf+/OT05/6yeOf
+        pOQxjfFHBnTYgLbvbrafP5zIrn0HB4ot2I/s54/s5/+f7SdYnYbx/2X7SUP4+WI/aaiEkOqj8ONB
+        +5nN7mc7D6c72/v7tPy6/ymZzod7+f727t7s4UNKOe5ks30COifDc6Nhen7QUEc/i2bpAZkl+os+
+        w2TSJ+9jkJq3F7P88vf/khv+/ru//24+3ckf7uST3eze/u7sU4pj851Ps3vTew/uZft7MBgkudTB
+        lzyrBME3WHELs8iW9PUMPQAVpcTxdFrRcBStl3W+KNaL3//5KxjXb4p9KMl8ni0vqo2sQxboLTV9
+        X0IQefEmphums7eGCgWxyXRKhzRYtlqezTRI1zOiL4kXJuyWZpP4BcT66NF5VjY5IfBzq2fNSKLk
+        H9axQpmDfXLngPWsyC6WVUM+gU/NSVW1T903+ChfwpMg3NVpED77KvCeDEoAep9EJ+49fQQbxUhD
+        pIijSZqJlUmq1552/3+Jjnz95vTZ8YvPv4xSeQAlpTFhYZhO/h7UiA92HhzMdrO97b3JLN/e33uw
+        v51NH1DWa/dBtjedkYw8PCdoGZn/0nnzAPBNDfO7p6+335y+frN98vwrGvKrjcPt4EGG5PPTF2+2
+        j3/y+Oz58ZOz52dvfh8KLrYfPNzZf/bk9D6N+3bK/OnrvR9KmLHdDTL40/Hezu6DnYPd+wj9SLlA
+        1aCfIeWOlTbCadnagW7vfP3AY2fn/nReXt67nr4tZtd7JHrtUPZO+uCFQAIY6//2Mcl7K9ZYrwSz
+        q2azH6zrHF4Pffe1dKxqmZtDE9vTNxWaPP1Fn67Orn6f+zvf2flytnv//tmD+mr/O/tvnx7vV9cP
+        st/n97o6nv3g9/qJ/PfOf++Lrz5tn1/Pf9HF5Zu9L+dPn/305aR6cLUsf6K6XL549fmry73Z/oMv
+        rl++/PyTg09fnd+7fP5kWX5x0f7eb4r9neZ8dn728NPq/mrvyatX79Znn1y/rN/8oPiynZ/95Bfz
+        i+efrmfF21e75asXl+fH371cfnJ3Pm3PT6vvfL5+s3///Nn8y+/szr58fvqL7i2v7lc7b54+Lb5b
+        FS+/e/n04U99+yfX9z89/vKq+fa3P58cX301Ofm93v7EzndelT/9e1NUcvJ77a4+PfupNz/44uqr
+        5iebL0nQT5/du/uDh093spcHD14/y/eevjhf7v7ez7/9Ilvdm35y9+6rxcNycv+r3+d1+fAnJ+3v
+        89M/+Xx+P/+9nt37vT//8sHx6cuzJ9dvrl/snf7keXW8vvhFX+zt7ZFTeXK3nL355Luf/6L8bkoy
+        fl2uq+XF70mcUhD/ZJ/eq+fri3GdzxbVcgY+X40XVtkQ3/2+S9goYsifW0NLNmUbPt/2tFyThauj
+        unHY4EYkhlQVSQ2N7RZ20CDzzY7pvfR917xFRhQEPNMmx+g+2Ia32QWNmlQQdCl995pHQC2yabMd
+        Q4LeqerpnN4nPVPBCPxe6wnppJym79Hu+MEYeblVVZWqzPh9+sgQBx+/Xp+fF+/oSwMWk/D/WrIT
+        8qpxo98Oehy7kwcH9yfn1CajNbX9h3sHlL6cfrqd7e9+Oju/9+nO3iQj2B1LDwA/J6To4NH8yOOQ
+        gW7vqsWnRiwlP2yPw/T/w/U4kLP/kcfxI4/jRx7H+3gcpGUwGIYFNURySoqQBJQU4vr/cx5HsERJ
+        HgdGRy6DKM4bIZKUfhMeBxTRzy+PAyNWjRv9dtDj2NmnxdGD7GD7/vn9A2Q2drYP7t3b3b5/72Cy
+        c//Tgyx/sEewO5YeAH5OSNHBo/mRxyED3d5Ti0+NWEp+2B6H6f+H63Ewa/7I4/iRx/Ejj+M9PA7S
+        cxgMw4IaIjklRUgCSgpx/f85j2Ov43FgdOQyiOK8ESJJ6TfhcUAR/fzyODBi1bjRbwc9jvP709n9
+        B9OD7QeTe/e298/zA1pnfvBwOzvIzh9mk1k2PcfSbsfSA8DPCSk6eFCTY7zzDbgc/1/zOBYZVJAd
+        qF3WoFYsJu/hcgQOx6Jp6yGHg94W7hvq/AP8jV/8UbkmbHduGGTeTmeAQ+A6wzxdrNpr+hgo/KwM
+        0XTdH+SLatkd3+7eAav1m1yoXjcE5+fSh/pQH4pcpx/5UD/yoQa1Pdn0D/WhuiJD2pfEhgZHJh3A
+        oFlJLkm1k9YhFb/+f78T1R3Sz81KUQ8Leum93CgBQJ8Z+uDz/3f7UYJyOOZNBoiQJ/sf86Q+nT2c
+        EuL3t+/tT7Pt/f0H97cPzj/d3549vH9wcP/Bg9mn2UMC3vFgAOAbJMbvc/wl02MjHTooNANpm/v3
+        954cPDllr2ie3caH+v9o2ub+fRko2XhxY6gRC4lzLm70oXZ2Lq7O23tF8en1p1ez5r3SNvfvd/rv
+        exi3dqOgBW/yObq9EswfuRw/cjn+f+xyXGcVex1RtbjZ2+gIC2kpEhgaFhk+wIIGIhElHUiySbpw
+        /cNwNm6l5WPWrjOYnxs3o4sEvfNeXga/Tx8ZuuBj62Tcvy9gQf//N1Kc8FYVG/120Lt4sD99uLvz
+        8Hx7d/f84fZ+Pp1sT6a7+9u7+zt79+7lezvTHcDumHYA+GFToYNC8yPvQga6vavWnRqxbPywvQvT
+        /w/Xu8Ba6I+8ix95Fz/yLvinwyImoqSlSGBoWGTwAAsaiESUdCDJJunC9f+XvIvdjneBgZF7IOry
+        Rogkm9+EdwH18/PGu8BgVcVGvx30Lu7t7X766c55vv3g3nSf8KaloGw2m20ffDp7sJt/eu/B7h7I
+        1DHtAPDDpkIHheZH3oUMdHtPrTs1Ytn4YXsXpv8frneBdc8feRc/8i5+5F3wT4dFTERJS5HA0LDI
+        4AEWNBCJKOlAkk3Shev/L3kXex3vAgMj90DU5Y0QSTa/Ce8C6ufnjXeBwaqKjX476F3sHBx8+unD
+        +zvb00+nhPeD2d72wfRevj3Zf/DpzoP9+/ey/9fmLr44xqrSN+Be/H/Nu9CFr/v3ZaB2aYJasXAM
+        uRc0YV33InAuFk1bDzkX5DkI4w11/gG+xS/+qFwTQXZuGGTeTmeAQ+A6wzxdrNpr+hgo/KwM0XTd
+        H+SLatkd3+7eAevxm9ylXjcE50f+0o/8pR/5S/zTYREVSlK8JDE0LrLhAAalSiJJWp0UDmn39f+r
+        HabuaH5uVnt6WNBL7+UyCQD6zJAGn/+/1mcSbMPhqp6Nfz3oNT3Y35ncn96fbO+f793f3p9NPt1+
+        uLv/6fb+9DybHezs5tm9KQHvuCwA8E3R4cmL32f7i9Pnz798sX188nojKTpYNANpmQe7nz7df3h/
+        n0b9/1O/iXAifWnGSWZdPBdqxBLi/IlbZGXOZ7Ny8oN1+Wk+m63fKyvT67/vVNzac4L2u8nN6PZK
+        MP9/5GWcHFT3Ft/+/NWXP7W3Oih/UfPi0+P6fPK6fXn57t2zn5zWv/fz899nunfwycH101907/K7
+        P3hz75OvvixPvij22uMnBw/2X05+7/tfrr9sf/JBfvf+9b2Tl/vfvv/57/Xpcn71+jsn1U/+9INf
+        NF3sTR88+/b+6ur+/tOHnz+4fn35g9e/6Pf+9MmT5zuXP1H9oien7z797vwn19/d/cmXzx5m672d
+        t9+dXf6iWfXTq/Nlsbj+vebPzs6evLr/i86fH+xenHz5/PODs73f6/OfuPf2YH73weXusy/Kn9r7
+        qfXvnb8sf5+vHp68+Or3LrMffDK/+skHP3n55dXq+u7bTz+fTJ629d763rf3vty9+3t/d3X91fKL
+        N5Pf5zu793Yvn3739158+2m5t/fJ5M3Fk5+m2Xsy+fT02U+8/eLui/kn7YP71e/1e3313fmzT69X
+        y8nVC5r7ye99+ertT3z3J37y/PT49Ml3Ti+/8/L3evHi4Sf3fu/T5vmn5fMnd8n6/Nz7C5Pl9fYi
+        L8tquU0GK6riNrsMHc4nlUPcTyMjEwZYUCckb6TPSNBIr61/1j2G91DaMfvVGc836TNMCXKdlbdz
+        G7p40Dvv5TXw+/SRoQ4+tk6DAYtZ+H8p3Ql1VZzRbwe9hk/z84fZdHa+fe8g29ne39ubbB9M9me0
+        sLPzYDKZ7E1olYdgd+w1APwcEKKDRfMjr4HHub2rVpsasYD8sL0G0/8P12vA6iVZjh95DT/yGn4e
+        eg2kLTAUhgV1QvJG+owEjfTa+v9jXsNux2vA2Mjmi/q7ESLJ2jfkNUCj/HzyGjBeVZzRbwe9hv2H
+        O/fO7+093L43mTzY3v909972wd75zvaDB9PJvfuf7uwdTO4T7I69BoCfA0J0sGh+5DXwOLf31GpT
+        IxaQH7bXYPr/4XoNWJUky/Ejr+FHXsPPQ6+B9BWGwrCgTkjeSJ+RoJFeW/9/zGvY63gNGBvZfFF/
+        N0IkWfuGvAZolP/feg0D41XFGf120GuY5Hufnt8/ONg+//Th3vZ+nk+3D/Y+vb+d5fleNn24n0+y
+        fYLdsdcA8HPAgB0sqMnx6zenr34eug26BmUGatcIqBWLyHv4DYHXsGjaeshroLdF5oc6/wCn4Rd/
+        VK4J250bBpm30xngELjOME8Xq/aaPgYKPytDNF33B/miWnbHt7t3wDr9Jj+o1w3BIWP4I0foR47Q
+        /98doS7rkxYl9qeh/X/VE+oO6Ods2aWHCL30Xr6QAKDPDIHw+f+bUyiCcDhi1Z7xrwfdofufZvcm
+        u4T8LMsyQv7+g+1s7/zT7Xv5bPpwb5Lt3iOXlnR06IgAwDdFipdfvnrz3S9f/d5Eh9ONhOjg0Ayk
+        UHbv7ezc//T+QxrzLX2h17s/597Q7u7e7nt4Q4QTubtmpNs7v/+X/Nrvv/v77386/TSb7D2gbx7u
+        7z58+PDTT3d3svP9yb2Hk/3JARif5cg5Er6/5Gy878gssiV9PUMPQEyJdDydVjRSRfJlnS+K9eL3
+        f/4KQ/ymeGNV1S2p0nfHpE428gZ5BG9FNAizr0saIj/ggD/g09zOZ+v1BxB7v//57v3z3Xz/4Xme
+        7e9n+9nD2WSy/+ne7mTn3n7+4PyciNSZB+PQuTlQP+v/2+THV7cgB0hNLQ3tb+tPdrujwZNL8f8b
+        d/L60+OT/CfvTr/YPSivPjl79Tz7qfVPz1bfffHJ8Rc7v8/yp19/+q74vXd/+hddZ6tsJ3v5+3y6
+        ++zZD65/0U/VT9t3Z5Ns5xddXVxM773+4np3/94X335z+ot+n/UvqsrZw4Pv7i9fP3zyU6uXp9+9
+        93mVfyd7M995sZgdnHzSHN9vLi/vTqe/d3V+1jYnX3y6P/l2vjN98Z0X7aLaOWkfnK2Pv/sT9env
+        Pf30/PXs+qud3+viF/308f50Z/r29znde3N3uvp9Tr673H278+ru3rNv702+0/xebXn27vf+fL78
+        RW+PDw5eluWre9PvPrlfnr47u/v0Oxff3Zvcffp73X396bfrF3c/XX+3Xv/E2avd6mQx/XL5+euL
+        3+fs7OS71d7u3v7vNftFn3zn7cXbi5dPXp/Nz9+tPz2dnr8q6lX+9sWT/AfPm7s/fTptHu6efnu/
+        /OSr7P68/Kr6fX7Rl8unbTF/cP/g9/m97u+unrz+yfSn86ah2b2qlhe/p/7ebC8mq/HFmlwGBEmr
+        8cLyOHEdOTI/9w7ojcK42f3sSMry59z7vLXdjzlAndH8XLie+fKCXmYHtIsNvbnZ/3xILTz/k9+n
+        jwyF8LF1Pw1YzMT/K2lPiC8JYcIs+u2g6znZn2X3Hn462d6bTGn97sHs/vZBfn9v+2Cys/vp7MHO
+        p9NduCsdtw8Afuhk6ODQ/Mj11JFu7zr/6iEZhL3d7OHuXjbbz/cfTPLde/eznfvTyYRWau+DT1iO
+        nMvz/2/X831IQ+QHHPAH3J+v5Xruqq+Vnc/yHcpj078H+/ezyWTv/v5evrdz8PDTewf75/eISJ15
+        +P+l63lrcoDU1NLQ/mu6nrs0+B+5nj9yPX/kevpoxARzSa4nGRwMhGHBIpHWIaNIKp+M4/r/U67n
+        bsf1xMjIcRTdeCNEksxv1PWEFvr543pitEtCmDCLfjvoej749ODTB3v7M0qR0krwfn7wcDubffpw
+        O9+fZvu7e/n0/r0pwe64fQDwQydDB4fmR66njnR7z/lXlNM7fzDb2Z3df7CzTznrh7N79yeTLD+Y
+        Tnf3Hk4xlyxHzuUJXE9mMbg9/39xPd+HNER+wAF/wP35Wq7nnvpae5/ef3Bv73x/dv5gf39/9/xg
+        L7s/O995OJl8ujvNDkDWzjz8/9L1vDU5QGpqaWj/NV1PXqD5kev5I9fzR66nh0ZMMJfkepLJw0AY
+        FiwSaR0yiqTyyTiu/z/leu51XE+MjBxH0Y03QiTJ/EZdT2ihnz+uJ0a7JIQJs+i3g67n3r3d/Yd7
+        5+Rr7ubkek53zrcP7p1T/vNgOtndf3B/9uDBfYLdcfsA4IdOhg4O1OT49ZvTVz8vfc9F1pBisUOl
+        hc0v+T3ysB5OpgdkKmYP9j99uD/7lDJ6s3z33u75p1l+b29n5///zueH0IYmAIDAIfCAbud99jrc
+        ztvpDHCIEB1a///DwdwwYhCMfhoK3taH7EGkAf7IifyRE/kjJ9JHIyp8S/IiackGI2FgsC2kWsi8
+        ke4mM7f+f7cX2R3Oz/HieQ8devW9/EgBQJ8ZIuHz//c6koJuON4lYUyoxb8edCWnD8mcTnd2trPJ
+        7v3t/fN8f3vygEaSf/rg/MH0/t5kd++cgHfcOAD4pgjx5MXvs/3F6fPnX77YSIYOBs1ADvPk9PTp
+        3v3TAxrxbf3In3M3cudg9/57uJGEE8UJZqBkxquGTGjEbfFdxMs5Tdcv/mhdF/TFvG1XzaO7d3d2
+        fvqi+rTMa5rsvfk0u1i2O+NJWU1I69b5+KpYzqqrZkxSc1f6YOYjgLH+x+iCBuGcJN8ZRQuQHu5F
+        z0GDFrzJ1+j2SjD/f+RqPP3J89O31XrxnauHP2je7l+u3h2vjn+vn3zzi7774vKr+vLezg+eH7/+
+        9GqPXMnzBxdn59XuV9c7P3H57foH7e/94vrqp/Jf9MX1wfynjtvXO+efv6i++uLJ3Z3j+ge/9+eL
+        7CfqJz/5xdt89snd429//oP897m/t3v206cHr/ePrw5Oqv0vvlt++eSqev7wp758+N0H89/ryeXL
+        J8/evfry3Vf3Vj/94he9+UUvDr79yXe+fL3+anf97uW3P3/Tfv57P/3B809PP9m7/qnmu2/3did7
+        57PVTzz4/KenJ093P//2w3ZWffcg3z99sb+e7n5J/PduZ//Z6+cvLn+vHZquTxdPj3/Q/FR57/X1
+        t5v5zt0n6/bt7/1y9vnv9Xs/XJ0+/OrN69n8B6ufeHJSty9/8juvPv29J2fPfq/2B2dnL79d/17f
+        vXr9piY6LOoH3753tV7+Xp9cPH99/8GD2bPq9fzFT/3U2eynXj7Prh5e/KKXb1ZPnj8lI/Rz7zhM
+        ltfbi7wsq2VUv212GzpcT+qGOJ9GRcYLsKBKSNZImZGQkVJb/6x7DbfU1jGj1RnLN+kyEIrt/LZ+
+        A3sMXWTonc0OwwNq4TkM/D59ZMiDj62/YMBiGv5fSHhCWzVm9NtBX+Heg4PzbLJ3f/sBrQFRsim7
+        t53t7+5uk58w2X0wy7MHk5/ltNMtidDBoPmRryAD3d5VW02NWDJ+2L6C6f+H6ytgif9HvsL/z32F
+        n2tfgab7w/XbN+0rkKaAvDAsqBKSNVJmJGSk1Nb/H/IVdju+AsZFRl7U3o0QSca+SV8B6uTni6+A
+        sarGjH476Cs8nJ5Pzj8939ne3Z/Otvenn+5tHxxMp9vT6cMHs/sP7u3vHiAF07HUAPBDJkIHg+ZH
+        voIMdHtPbTU1Ysn4YfsKpv8frq+ANdkf+Qo/8hV+/uUVSFdhGAwLqoRkjZQZCRkptfX/h3yFvY6v
+        gHGRkRe1dyNEkrFv0leAOvn54itgrKoxo98O+grZgwd7ezv3s+2He/fJV9g/P9ieZPc+3Z7Nzu/f
+        y3anOaUbCHbHUgPAD5kIHQyaAV/h2dNPP909fogR///bVzADtWsA1Igl4718hWa5t1y9u9hbLH/Q
+        7r+Xr9Dr/4fiK7heCeaPfIUf+Qo/L3wFy/WkbojzaVRktwALqoRkjZQZCRkptfX/+30FO5b/N6xB
+        OGTonW/OVzBgMQ3/LyQ8oa0aM/rtoK9w/uDhwcHubHebEgy72/sP9vLtg4f3p9sH2cP8/u7DfEYr
+        EQS7Y6kB4IdMhA4GzY98hU8/xUDtGgA1Ysn4YfsKpv8frq+ARNqPfIUf+Qo//3wF0hQYBsOCKiFZ
+        I2VGQkZKbf3/IV/h/w1rEA4Zeufni6+AsarGjH476Cvsnj/4dH822dl+uH///vZ+PrtHGYbzB9v7
+        n07v3Z/u78zy3X2C3bHUAPBDJkIHg+ZHvsKnn2Kgdg2AGrFk/LB9BdP/D9dXQCLtR77C/8d8hR/5
+        Cn399t6+AukqDINhQZWQrJEyIyEjpbb+/5Cv8P+GNQiHDL3z88VXwFhVY0a/HfQVHs4+fbhzTm0o
+        wUBrEJRk2H54/2B/O7+f338wPc8ePrj3KcHuWGoA+CEToYMBNTl+/eb0Vc9ZMAsvNORbOgv/X/MV
+        FllD+sQO1C4CUCsWjfdwFn76ovq0zOtPH5zvzaeLpq2HXAV6W/huqPMP8BR+8UflmrDduWGQeTud
+        AQ6B6wzzdLFqr+ljoPCzMkTTdX+QL6pld3y7eweszG9yfnrdEJwfeT8/8n7+f+79dNmeNCixPg2L
+        TDGAQTuSbJF6Js1Banr9/2b3pzuYn9t1lR429NJ7OUACgD4zFMLn1gMycDET/2+kPeGtajP+9aAP
+        dLB7fv8e2eDt3b19ypc83J1sP9zZub99P7+3n3+6d+/BwWxKwDseCAD8kMnQwYCaxH0g4/jRkP//
+        7QOZgZKNFjeEWrF4OOfgRh8oSJe8j4PQ67zvHnwjPpDXT96KI0LgOsPc6AN9E0M0XfcH+eE+kOuG
+        4PzIB/qRD/TzwweybE8alFifhkXWGMCgHUm2SD2T5iA1vf7/gA9kB/P/Ch/IYUMvfYM+kIGLmfh/
+        I+0Jb1Wb8a8HfaBPd+9NH8wycnpm93a39w+m+XZ2nj/cvv8w3793//5+9nAPPtA8u4U38WS3oY7e
+        25doyI3IL2oiK02Z+hKY+woTL17Epwf0q3MfSpKPpkVfN3sNNOTzaUWeCb1NnzIDOfN5o5eAjtg+
+        LPK2LqZs75vd3XubDKnfJfk4Bzv3dh7sPNx7uP+gb0Rv7SlASWwyq36nBKtrTYvLbEkffy1Dep6V
+        TU7d/9xq3jc0E8eYiS9kJqJCM6x/ffo83L1HyonGMCtonaxqaKg+ZSdV1T513+CjfAkC0UjUqRAW
+        /+oGVskuyL8d4JSPYMt4CGBqYgYSI+ICEqe1p/W/YfWZLy/pa6bim+zigvogTinaF+sFqUb6Zjd8
+        6NtpRaaOvrnMHpXrHCitSuIkgqWMxaI5JM40vtl6SiGTEWh6n774Zvjh9PWb45/66tXpF6dvXp2d
+        vI7ywwC5Am4gPHUswae/5Pu/5P8B+L3yLOQ6AQA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['10688']
+      content-type: [application/json; charset=utf-8]
+      date: ['Fri, 30 Mar 2018 19:19:59 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [73759ef9-03a5-4dc6-8922-0c896acf6422]
+      x-ms-original-request-ids: [0e31830a-53c6-4a63-a3eb-b36560561491, 727de35a-1569-459c-8fe1-43d210768ae4,
+        827ebe93-6ad1-473c-81ec-5e29719593e3, d3506f8d-f23e-4aab-924a-4738a16df835,
+        1cc2d0a5-83c4-4e8f-b1bc-536a20cac83e]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [73759ef9-03a5-4dc6-8922-0c896acf6422]
+      x-ms-routing-request-id: ['WESTUS:20180330T191959Z:73759ef9-03a5-4dc6-8922-0c896acf6422']
+    status: {code: 200, message: OK}
+version: 1

--- a/tools/c7n_azure/tests/common.py
+++ b/tools/c7n_azure/tests/common.py
@@ -1,11 +1,12 @@
-import betamax
-import unittest
+from vcr_unittest import VCRTestCase
 
-with betamax.Betamax.configure() as config:
-    config.cassette_library_dir = 'tests/data/cassettes'
 
-    
-class BaseTest(unittest.TestCase):
+class BaseTest(VCRTestCase):
+
+    def _get_vcr_kwargs(self):
+        return super(BaseTest, self)._get_vcr_kwargs(
+            filter_headers=[('Authorization', 'bearer filtered')],
+        )
 
     def load_policy(
             self, data, config=None, session_factory=None):

--- a/tools/c7n_azure/tests/test_vm.py
+++ b/tools/c7n_azure/tests/test_vm.py
@@ -1,0 +1,28 @@
+# Copyright 2015-2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+from __future__ import absolute_import, division, print_function, unicode_literals
+from .common import BaseTest
+from c7n_azure.session import Session
+
+
+class VMClientTest(BaseTest):
+    def setUp(self):
+        super(VMClientTest, self).setUp()
+        session = Session()
+        self.client = session.client('azure.mgmt.compute.ComputeManagementClient')
+
+    def test_client(self):
+        """Simple example showing a VCR recorded test working"""
+        machines = list(self.client.virtual_machines.list_all())
+        self.assertGreater(len(machines), 1)


### PR DESCRIPTION
Was playing with some options on Azure tests. Azure SDK uses VCR internally and it appears to work well if we stick with 1.11.0 - The Azure SDK has pinned that as the new 1.11.1 seems to break SSL somehow.

I wasn't successful with betamax and its session implementation.

This PR has a simple BaseTest and a cassette for enumerating virtual machines, which should at least point people in the right direction for getting some tests going.

We'll want most of the C7N common test stuff, so will need to look at the right way to do that next.