### PR TITLE
Adding a Lambda version, removing filters, and changing condition

### DIFF
--- a/docs/source/usecases/s3denypublicobjectacls.rst
+++ b/docs/source/usecases/s3denypublicobjectacls.rst
@@ -3,9 +3,9 @@
 S3 - Block Public S3 Object ACLs
 =================================================
 
-The following example policy will append a S3 bucket policy to every bucket which
-is missing the bucket policy statement called **DenyS3PublicObjectACL**  This will
-prevent any object in these buckets from being set to public-read, public-read-write
+The following example policies will append a S3 bucket policy to every S3 bucket with
+a policy statement called **DenyS3PublicObjectACL**  This will prevent any object
+in these buckets from being set to public-read, public-read-write
 ,or authenticated-read (Any authenticated AWS user, not just local to account).
 Being that S3 object permissions can be hard to track and restrict due to the huge
 amount of S3 objects usually present in accounts, this policy allows you to prevent
@@ -16,13 +16,12 @@ to avoid accidentally setting sensitive S3 objects to public.
 
    policies:
 
-     - name: s3-deny-public-put-object-acl
+     - name: s3-deny-public-object-acl-poll
        resource: s3
-       filters:
-         - not:
-              - type: has-statement
-                statements:
-                 - Sid: "DenyS3PublicObjectACL"
+       description: |
+         Appends a bucket policy statement to all existing s3 buckets to
+         deny anyone from setting s3 objects in the bucket to public-read,
+         public-read-write, or any authenticated AWS user.
        actions:
          - type: set-statements
            statements:
@@ -32,11 +31,45 @@ to avoid accidentally setting sensitive S3 objects to public.
                 Principal: "*"
                 Resource:
                    - "arn:aws:s3:::{bucket_name}/*"
-                   - "arn:aws:s3:::{bucket_name}*"
+                   - "arn:aws:s3:::{bucket_name}"
                 Condition:
-                  StringEquals:
+                  StringEqualsIgnoreCaseIfExists:
                      's3:x-amz-acl':
                          - "public-read"
                          - "public-read-write"
                          - "authenticated-read"
+
+
+     - name: s3-deny-public-object-acl-realtime
+       resource: s3
+       mode:
+         type: cloudtrail
+         events:
+           - CreateBucket
+           - source: 's3.amazonaws.com'
+             event: PutBucketPolicy
+             ids: "requestParameters.bucketName"
+         role: arn:aws:iam::{account_id}:role/Cloud_Custodian_Role
+         timeout: 200
+       description: |
+         Appends a bucket policy statement to an s3 bucket when it detects
+         a policy change to the bucket or a new bucket is created which
+         will deny anyone from setting s3 objects in the bucket to public-read,
+         public-read-write, or any authenticated AWS user.
+       actions:
+         - type: set-statements
+           statements:
+             - Sid: "DenyS3PublicObjectACL"
+               Effect: "Deny"
+               Action: "s3:PutObjectAcl"
+               Principal: "*"
+               Resource:
+                  - "arn:aws:s3:::{bucket_name}/*"
+                  - "arn:aws:s3:::{bucket_name}"
+               Condition:
+                 StringEqualsIgnoreCaseIfExists:
+                    's3:x-amz-acl':
+                        - "public-read"
+                        - "public-read-write"
+                        - "authenticated-read"
 


### PR DESCRIPTION
I added a lambda version of this policy to set the policy on all future buckets.  I found I had to change the condition from StringEquals to StringEqualsIgnoreCaseIfExists for this to block the "Make Public" button in the console.
I removed the filters as well as they didn't work the greatest as customers could modify the bucket policy after the fact and it wouldn't always get picked up on as being changed.