### PR TITLE
Augment S3 Buckets with server side encryption details.

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -397,6 +397,7 @@ S3_AUGMENT_TABLE = (
     ('get_bucket_logging', 'Logging', None, 'LoggingEnabled'),
     ('get_bucket_notification_configuration', 'Notification', None, None),
     ('get_bucket_lifecycle_configuration', 'Lifecycle', None, None),
+    ('get_bucket_encryption', 'ServerSideEncryptionConfiguration', None, 'ServerSideEncryptionConfiguration')
     #        ('get_bucket_cors', 'Cors'),
 )
 


### PR DESCRIPTION
You can now specify default encryption configuration for S3 - this automatically augments s3 buckets with the result of this.

Note that this is lacking tests - I just realised my invite to the test account expired well before I could claim it; Could I get you to resend it if needed? (otherwise, happy to work out another way!)