### PR TITLE
Add an instance attribute filter.

### DIFF
--- a/c7n/resources/ec2.py
+++ b/c7n/resources/ec2.py
@@ -1188,3 +1188,54 @@ class QueryFilter(object):
             value = [self.value]
 
         return {'Name': self.key, 'Values': value}
+
+@filters.register('instance-attribute')
+class InstanceAttribute(ValueFilter):
+    """EC2 Instance Value FIlter on a given instance attribute.
+
+    Filters EC2 Instances with the given instance attribute
+
+    :Example:
+
+    .. code-block:: yaml
+
+        policies:
+          - name: ec2-disabled-termination-protection
+            resource: ec2
+            filters:
+              - type: instance-attribute
+                key: termination-protection
+                value: true
+    """
+
+    schema = type_schema(
+        'instance-attribute',
+        rinherit=ValueFilter.schema, **{
+            'attribute-name':  {'type': 'string'}
+        })
+
+    def get_permissions(self):
+        return ('ecc2:DescribeInstanceAttribute',)
+
+    def process(self, resources, event=None):
+        attribute_mapping = self.get_instance_attribute_mapping(resources)
+        return [resource for resource in resources if self.matches_store(resource, attribute_mapping)]
+
+    def matches_store(self, resource, mapping):
+        stored = mapping[resource['InstanceId']]
+        resource['instance-attribute:' + self.data.get('attribute-name')] = stored
+        return self.match(stored)
+
+    def get_instance_attribute_mapping(self, resources):
+        instance_value_map = {}
+        attribute = self.data.get('attribute-name')
+        client = utils.local_session(
+            self.manager.session_factory).client('ec2')
+
+        for resource in resources:
+            instance_id = resource['InstanceId']
+            fetched_attribute = client.describe_instance_attribute(
+                Attribute=attribute,
+                InstanceId=instance_id)
+            instance_value_map[instance_id] = fetched_attribute
+        return instance_value_map


### PR DESCRIPTION
We've been using this in prod for a while - I didn't redeem invite to the test AWS account in time, so either I'll have to get someone on your side to add a test - or I can do so myself.

This adds the ability to filter EC2 instances by instance attributes - in our case, we use it for termination protection and a few other things.