### PR TITLE
Misc. bugfixes.

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -399,6 +399,7 @@ class AllowAllIamPolicies(Filter):
                     'Action' in s and
                     isinstance(s['Action'], six.string_types) and
                     s['Action'] == "*" and
+                    'Resource' in s and
                     isinstance(s['Resource'], six.string_types) and
                     s['Resource'] == "*" and
                     s['Effect'] == "Allow"):

--- a/c7n/resources/storagegw.py
+++ b/c7n/resources/storagegw.py
@@ -23,6 +23,6 @@ class StorageGateway(QueryResourceManager):
     class resource_type(object):
         service = 'storagegateway'
         enum_spec = ('list_gateways', 'Gateways', None)
-        id = 'GatewayArn'
+        id = 'GatewayARN'
         name = 'GatewayName'
         dimension = None

--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -371,6 +371,8 @@ class IPv4Network(ipaddress.IPv4Network):
 
     # Override for net 2 net containment comparison
     def __contains__(self, other):
+        if other is None:
+            return False
         if isinstance(other, ipaddress._BaseNetwork):
             return self.supernet_of(other)
         return super(IPv4Network, self).__contains__(other)


### PR DESCRIPTION
This is a bundling of a few small bugs we saw in production when running cloud custodian:

1. It was possible (I don't know the situation) for a IAM policy to have no resource specified, which would crash this check.
2. Corrects the capitalisation of the GatewayARN field.
3. Adds a check for when the other net in a network containment is missing / None.