### PR TITLE
switch out to python:2.7 for drone ci build and doc build

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -1,7 +1,7 @@
 build:
 
   unit_tests:
-    image: python:2-slim
+    image: python:2.7
     commands:
       - apt-get update
       - apt-get install build-essential
@@ -19,7 +19,7 @@ build:
 #      branch: master
 
   documentation:
-     image: python:2-alpine
+     image: python:2.7
      commands:
        - apk update
        - apk add git make build-base python-dev

--- a/.drone.yml
+++ b/.drone.yml
@@ -3,8 +3,6 @@ build:
   unit_tests:
     image: python:2.7
     commands:
-      - apt-get update
-      - apt-get install build-essential
       - pip install tox
       - tox -e py27
 
@@ -21,8 +19,6 @@ build:
   documentation:
      image: python:2.7
      commands:
-       - apk update
-       - apk add git make build-base python-dev
        - git config --global user.email "cibot@cloud-custodian.io"
        - git config --global user.name "Custodian CI"
        - pip install tox


### PR DESCRIPTION
normalize drone builds to avoid libffi errors and remove need for runtime install