### PR TITLE
Azure Client - Drop ADAL verbosity

### DIFF
--- a/tools/c7n_azure/c7n_azure/__init__.py
+++ b/tools/c7n_azure/c7n_azure/__init__.py
@@ -11,3 +11,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+import adal
+
+# Don't log about basic token retrieval on each API call
+adal.set_logging_options({'level': 'WARNING'})

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -18,7 +18,6 @@ import logging
 from azure.cli.core.cloud import AZURE_PUBLIC_CLOUD
 from azure.cli.core._profile import Profile
 from azure.common.credentials import ServicePrincipalCredentials, BasicTokenAuthentication
-import adal
 
 
 class Session(object):
@@ -26,7 +25,6 @@ class Session(object):
     def __init__(self):
         self.log = logging.getLogger('custodian.azure.session')
         self._provider_cache = {}
-        adal.set_logging_options({'level': 'WARNING'})
 
         tenant_auth_variables = ['AZURE_TENANT_ID', 'AZURE_SUBSCRIPTION_ID', 'AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET']
         token_auth_variables = ['AZURE_ACCESS_TOKEN', 'AZURE_SUBSCRIPTION_ID']

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -18,6 +18,7 @@ import logging
 from azure.cli.core.cloud import AZURE_PUBLIC_CLOUD
 from azure.cli.core._profile import Profile
 from azure.common.credentials import ServicePrincipalCredentials, BasicTokenAuthentication
+import adal
 
 
 class Session(object):
@@ -25,6 +26,7 @@ class Session(object):
     def __init__(self):
         self.log = logging.getLogger('custodian.azure.session')
         self._provider_cache = {}
+        adal.set_logging_options({'level': 'WARNING'})
 
         tenant_auth_variables = ['AZURE_TENANT_ID', 'AZURE_SUBSCRIPTION_ID', 'AZURE_CLIENT_ID', 'AZURE_CLIENT_SECRET']
         token_auth_variables = ['AZURE_ACCESS_TOKEN', 'AZURE_SUBSCRIPTION_ID']

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -31,5 +31,5 @@ setup(
         "custodian.resources": [
             'azure = c7n_azure.entry:initialize_azure']
     },
-    install_requires=["c7n", "click", "azure", "azure-cli-core"]
+    install_requires=["c7n", "click", "azure", "azure-cli-core", "adal"]
 )


### PR DESCRIPTION
This hides the `getting token from cache` message on every API call.

`adal` package was already required, but I explicitly add it as a dependency here now since I am importing it.