### PR TITLE
azure tests - request matching bug

### DIFF
--- a/tools/c7n_azure/tests/azure_common.py
+++ b/tools/c7n_azure/tests/azure_common.py
@@ -56,11 +56,11 @@ class AzureVCRBaseTest(VCRTestCase):
         r1_uri = re.sub(
             r"api-version=\d{4}-\d{2}-\d{2}&?",
             "",
-            r1.uri)
+            r1_uri.uri)
         r2_uri = re.sub(
             r"api-version=\d{4}-\d{2}-\d{2}&?",
             "",
-            r2.uri)
+            r2_uri.uri)
 
         return r1_uri == r2_uri
 

--- a/tools/c7n_azure/tests/azure_common.py
+++ b/tools/c7n_azure/tests/azure_common.py
@@ -56,11 +56,11 @@ class AzureVCRBaseTest(VCRTestCase):
         r1_uri = re.sub(
             r"api-version=\d{4}-\d{2}-\d{2}&?",
             "",
-            r1_uri.uri)
+            r1_uri)
         r2_uri = re.sub(
             r"api-version=\d{4}-\d{2}-\d{2}&?",
             "",
-            r2_uri.uri)
+            r2_uri)
 
         return r1_uri == r2_uri
 


### PR DESCRIPTION
I introduced this test bug in #2269

We also attempt to rewrite the subscription ID's before recording, so it may not have a significant effect, but fixing.