### PR TITLE
Add tagging to network-addr

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1460,13 +1460,13 @@ class Address(query.QueryResourceManager):
         service = 'ec2'
         type = 'network-addr'
         enum_spec = ('describe_addresses', 'Addresses', None)
-        name = id = 'PublicIp'
+        name = 'PublicIp'
+        id = 'AllocationId'
         filter_name = 'PublicIps'
         filter_type = 'list'
         date = None
         dimension = None
         config_type = "AWS::EC2::EIP"
-        taggable = False
 
 
 @resources.register('customer-gateway')


### PR DESCRIPTION
Note that I also changed the id to be the AllocationId rather than the
PublicIp, since the tagging action needs this. I'm not sure if this can
affect any other operations; I don't think so, but I'm new to c7n ;-)