### PR TITLE
output blob registry

### DIFF
--- a/c7n/output.py
+++ b/c7n/output.py
@@ -29,12 +29,17 @@ import tempfile
 import os
 
 from boto3.s3.transfer import S3Transfer
-from c7n.utils import local_session, parse_s3, get_retry
+
+from c7n.registry import PluginRegistry
 from c7n.log import CloudWatchLogHandler
+from c7n.utils import local_session, parse_s3, get_retry
 
 DEFAULT_NAMESPACE = "CloudMaid"
 
 log = logging.getLogger('custodian.output')
+
+
+blob_outputs = PluginRegistry('c7n.blob-outputs')
 
 
 class MetricsOutput(object):
@@ -164,10 +169,11 @@ class FSOutput(LogOutput):
 
     @staticmethod
     def select(path):
-        if path.startswith('s3://'):
-            return S3Output
-        else:
-            return DirectoryOutput
+        for k in blob_outputs.keys():
+            if path.startswith('%s://' % k):
+                return blob_outputs[k]
+        # Fall back local disk
+        return blob_outputs['dir']
 
     @staticmethod
     def join(*parts):
@@ -192,10 +198,8 @@ class FSOutput(LogOutput):
                         shutil.copyfileobj(sfh, zfh, length=2**15)
                     os.remove(fp)
 
-    def use_s3(self):
-        raise NotImplementedError()  # pragma: no cover
 
-
+@blob_outputs.register('fs')
 class DirectoryOutput(FSOutput):
 
     permissions = ()
@@ -209,10 +213,8 @@ class DirectoryOutput(FSOutput):
     def __repr__(self):
         return "<%s to dir:%s>" % (self.__class__.__name__, self.root_dir)
 
-    def use_s3(self):
-        return False
 
-
+@blob_outputs.register('s3')
 class S3Output(FSOutput):
     """
     Usage:
@@ -269,9 +271,3 @@ class S3Output(FSOutput):
                     os.path.join(root, f), self.bucket, key,
                     extra_args={
                         'ServerSideEncryption': 'AES256'})
-
-    def use_s3(self):
-        return True
-
-
-s3_join = S3Output.join

--- a/c7n/output.py
+++ b/c7n/output.py
@@ -173,7 +173,7 @@ class FSOutput(LogOutput):
             if path.startswith('%s://' % k):
                 return blob_outputs[k]
         # Fall back local disk
-        return blob_outputs['dir']
+        return blob_outputs['file']
 
     @staticmethod
     def join(*parts):
@@ -199,7 +199,7 @@ class FSOutput(LogOutput):
                     os.remove(fp)
 
 
-@blob_outputs.register('fs')
+@blob_outputs.register('file')
 class DirectoryOutput(FSOutput):
 
     permissions = ()

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -276,7 +276,7 @@ class PullMode(PolicyExecutionMode):
                 start,
                 end,
             )
-        elif log_source.use_s3():
+        elif log_source.type == 's3':
             raw_entries = log_entries_from_s3(
                 self.policy.session_factory,
                 log_source,

--- a/c7n/reports/csvout.py
+++ b/c7n/reports/csvout.py
@@ -77,7 +77,7 @@ def report(policies, start_date, options, output_fh, raw_output_fh=None):
 
     records = []
     for policy in policies:
-        if policy.ctx.output.use_s3():
+        if policy.ctx.output.type == 's3':
             policy_records = record_set(
                 policy.session_factory,
                 policy.ctx.output.bucket,

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -54,7 +54,7 @@ class S3OutputTest(unittest.TestCase):
 
     def test_s3_output(self):
         output = self.get_s3_output()
-        self.assertEquals(output.use_s3(), True)
+        self.assertEquals(output.type, "s3")
 
         # Make sure __repr__ is defined
         name = str(output)


### PR DESCRIPTION
- allow cloud providers to specify their own blob/object storage 

todo. reporting and logging both use key iteration against blob/dir storage, we need to move to key iteration behind the blob storage output interface for them to work.
