### PR TITLE
Updates to mark-for-op support for hours

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -21,7 +21,6 @@ from concurrent.futures import as_completed
 from datetime import datetime, timedelta
 from dateutil import zoneinfo
 from dateutil.parser import parse
-from dateutil.tz import tzutc
 
 import logging
 import itertools

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -314,7 +314,7 @@ class TagActionFilter(Filter):
         if action_date.tzinfo:
             # if action_date is timezone aware, set to timezone provided
             action_date = action_date.astimezone(tz)
-            self.current_date = datetime.now(tz=tz).replace(minute=0)
+            self.current_date = datetime.now(tz=tz)
 
         return self.current_date >= (
             action_date - timedelta(days=skew, hours=skew_hours))
@@ -598,7 +598,7 @@ class TagDelayedAction(Action):
         return self
 
     def generate_timestamp(self, days, hours):
-        n = datetime.now(tz=self.tz).replace(minute=0)
+        n = datetime.now(tz=self.tz)
         if days == hours == 0:
             # maintains default value of days being 4 if nothing is provided
             days = 4

--- a/tests/data/placebo/test_asg_marked_for_op_hours/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/data/placebo/test_asg_marked_for_op_hours/autoscaling.DescribeAutoScalingGroups_1.json
@@ -1,0 +1,99 @@
+{
+  "status_code": 200,
+  "data": {
+    "AutoScalingGroups": [
+      {
+        "AutoScalingGroupName": "marked",
+        "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-1:899826514230:autoScalingGroup:11d5f55c-66b5-498a-82a3-c3c87801f58e:autoScalingGroupName/marked",
+        "LaunchConfigurationName": "spottest",
+        "MinSize": 1,
+        "MaxSize": 1,
+        "DesiredCapacity": 1,
+        "DefaultCooldown": 300,
+        "AvailabilityZones": [
+          "us-west-1a",
+          "us-west-1b"
+        ],
+        "LoadBalancerNames": [],
+        "TargetGroupARNs": [],
+        "HealthCheckType": "EC2",
+        "HealthCheckGracePeriod": 300,
+        "Instances": [
+          {
+            "InstanceId": "i-093f47f7bd590e7a5",
+            "AvailabilityZone": "us-west-1a",
+            "LifecycleState": "InService",
+            "HealthStatus": "Healthy",
+            "LaunchConfigurationName": "spottest",
+            "ProtectedFromScaleIn": false
+          }
+        ],
+        "CreatedTime": "2018-05-03T01:46:06.864000+00:00",
+        "SuspendedProcesses": [],
+        "VPCZoneIdentifier": "subnet-f7ee3590,subnet-a7dd34fc",
+        "EnabledMetrics": [],
+        "Tags": [
+          {
+            "ResourceId": "marked",
+            "ResourceType": "auto-scaling-group",
+            "Key": "maid_status",
+            "Value": "AutoScaleGroup does not meet org policy: delete@2018/05/03 0246 UTC",
+            "PropagateAtLaunch": true
+          }
+        ],
+        "TerminationPolicies": [
+          "Default"
+        ],
+        "NewInstancesProtectedFromScaleIn": false
+      },
+      {
+        "AutoScalingGroupName": "not_marked",
+        "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-1:899826514230:autoScalingGroup:b1d7fa70-f757-4fdb-bb0d-9d125337e6c8:autoScalingGroupName/not_marked",
+        "LaunchConfigurationName": "spottest",
+        "MinSize": 1,
+        "MaxSize": 1,
+        "DesiredCapacity": 1,
+        "DefaultCooldown": 300,
+        "AvailabilityZones": [
+          "us-west-1a",
+          "us-west-1b"
+        ],
+        "LoadBalancerNames": [],
+        "TargetGroupARNs": [],
+        "HealthCheckType": "EC2",
+        "HealthCheckGracePeriod": 300,
+        "Instances": [
+          {
+            "InstanceId": "i-07e83ec38ff679686",
+            "AvailabilityZone": "us-west-1b",
+            "LifecycleState": "InService",
+            "HealthStatus": "Healthy",
+            "LaunchConfigurationName": "spottest",
+            "ProtectedFromScaleIn": false
+          }
+        ],
+        "CreatedTime": "2018-05-03T01:45:46.259000+00:00",
+        "SuspendedProcesses": [],
+        "VPCZoneIdentifier": "subnet-f7ee3590,subnet-a7dd34fc",
+        "EnabledMetrics": [],
+        "Tags": [],
+        "TerminationPolicies": [
+          "Default"
+        ],
+        "NewInstancesProtectedFromScaleIn": false
+      }
+    ],
+    "ResponseMetadata": {
+      "RequestId": "f08f794b-4e73-11e8-94c9-85996aab7948",
+      "HTTPStatusCode": 200,
+      "HTTPHeaders": {
+        "x-amzn-requestid": "f08f794b-4e73-11e8-94c9-85996aab7948",
+        "content-type": "text/xml",
+        "content-length": "4239",
+        "vary": "Accept-Encoding",
+        "date": "Thu, 03 May 2018 01:47:29 GMT"
+      },
+      "RetryAttempts": 0
+    }
+  }
+}

--- a/tests/data/placebo/test_asg_marked_for_op_hours/autoscaling.DescribeAutoScalingGroups_1.json
+++ b/tests/data/placebo/test_asg_marked_for_op_hours/autoscaling.DescribeAutoScalingGroups_1.json
@@ -4,7 +4,7 @@
     "AutoScalingGroups": [
       {
         "AutoScalingGroupName": "marked",
-        "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-1:899826514230:autoScalingGroup:11d5f55c-66b5-498a-82a3-c3c87801f58e:autoScalingGroupName/marked",
+        "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-1:123456789012:autoScalingGroup:11d5f55c-66b5-498a-82a3-c3c87801f58e:autoScalingGroupName/marked",
         "LaunchConfigurationName": "spottest",
         "MinSize": 1,
         "MaxSize": 1,
@@ -37,7 +37,7 @@
             "ResourceId": "marked",
             "ResourceType": "auto-scaling-group",
             "Key": "maid_status",
-            "Value": "AutoScaleGroup does not meet org policy: delete@2018/05/03 0246 UTC",
+            "Value": "AutoScaleGroup does not meet org policy: delete@2018/05/01 0246 UTC",
             "PropagateAtLaunch": true
           }
         ],
@@ -48,7 +48,7 @@
       },
       {
         "AutoScalingGroupName": "not_marked",
-        "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-1:899826514230:autoScalingGroup:b1d7fa70-f757-4fdb-bb0d-9d125337e6c8:autoScalingGroupName/not_marked",
+        "AutoScalingGroupARN": "arn:aws:autoscaling:us-west-1:123456789012:autoScalingGroup:b1d7fa70-f757-4fdb-bb0d-9d125337e6c8:autoScalingGroupName/not_marked",
         "LaunchConfigurationName": "spottest",
         "MinSize": 1,
         "MaxSize": 1,
@@ -85,15 +85,7 @@
     ],
     "ResponseMetadata": {
       "RequestId": "f08f794b-4e73-11e8-94c9-85996aab7948",
-      "HTTPStatusCode": 200,
-      "HTTPHeaders": {
-        "x-amzn-requestid": "f08f794b-4e73-11e8-94c9-85996aab7948",
-        "content-type": "text/xml",
-        "content-length": "4239",
-        "vary": "Accept-Encoding",
-        "date": "Thu, 03 May 2018 01:47:29 GMT"
-      },
-      "RetryAttempts": 0
+      "HTTPStatusCode": 200
     }
   }
 }

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -230,6 +230,20 @@ class AutoScalingTest(BaseTest):
         self.assertTrue('custodian_action' in tag_map)
         self.assertTrue('suspend@' in tag_map['custodian_action'])
 
+    def test_asg_marked_for_op_hours(self):
+        session_factory = self.replay_flight_data('test_asg_marked_for_op_hours')
+        policy = self.load_policy({
+            'name': 'asg-marked-for-delete',
+            'resource': 'asg',
+            'filters': [{
+                'type': 'marked-for-op',
+                'op': 'delete'
+            }]
+        }, session_factory=session_factory)
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['AutoScalingGroupName'], 'marked')
+
     def test_asg_rename_tag(self):
         factory = self.replay_flight_data('test_asg_rename')
         p = self.load_policy({


### PR DESCRIPTION
* Makes updates discussed in #2006
* Changes hour support so that it includes the minutes as well. Prior the minutes were replaced with `0` leading to unexpected behavior.
* Added mark-for-op hours support for asgs
* Added test_asg_marked_for_op_hours unit test