### PR TITLE
Return single record if no delimiter is found

### DIFF
--- a/tools/c7n_logexporter/c7n_logexporter/flowdeliver.py
+++ b/tools/c7n_logexporter/c7n_logexporter/flowdeliver.py
@@ -147,6 +147,8 @@ def records_iter(fh, buffer_size=1024 * 1024 * 16):
     while True:
         chunk = fh.read(buffer_size)
         if not chunk:
+            if buf:
+                yield json.loads(buf)
             return
         if buf:
             chunk = b"%s%s" % (buf, chunk)


### PR DESCRIPTION
It is possible for firehose to deliver an s3 log with only one record. When this happens, records_iter would have returned nothing instead of the single record. This checks buf one final time after the complete file has been read.