### PR TITLE
cli tests remove network call due to a missed mock on provider refactoring

### DIFF
--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -21,6 +21,7 @@ from argparse import ArgumentTypeError
 from c7n import cli, version, commands, utils
 from datetime import datetime, timedelta
 
+from c7n.resources import aws
 from .common import BaseTest, TextTestIO
 
 
@@ -31,7 +32,7 @@ class CliTest(BaseTest):
         def test_account_id(options):
             options.account_id = self.account_id
 
-        self.patch(cli, '_default_account_id', test_account_id)
+        self.patch(aws, '_default_account_id', test_account_id)
 
     def get_output(self, argv):
         """ Run cli.main with the supplied argv and return the output. """


### PR DESCRIPTION

in environments with proxies executing via tox these would have to wait on socket timeouts causing testing slow downs.

for now just target the patch/mock towards the refactored location, in future we should target the cloud provider initializer methods for the mock to avoid having the cli tests depend on aws.