### PR TITLE
c7n-mailer | ancient AMIs do not have 'name' attribute

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -147,7 +147,7 @@ def resource_format(resource, resource_type):
             resource.get('PrivateIpAddress'))
     elif resource_type == 'ami':
         return "%s %s %s" % (
-            resource['Name'], resource['ImageId'], resource['CreationDate'])
+            resource.get('Name'), resource['ImageId'], resource['CreationDate'])
     elif resource_type == 's3':
         return "%s" % (resource['Name'])
     elif resource_type == 'ebs':


### PR DESCRIPTION
I have some ancient AMIs in my account (dated 2010) which do not have "Name" attributes, and it causes c7n-mailer to throw an exception when it encounters them. 