### PR TITLE
Support `make lint`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -44,6 +44,9 @@ ghpages:
 	git add -A && \
 	git commit -m "Updated generated Sphinx documentation"
 
+lint:
+	flake8 c7n tools/c7n_org tools/c7n_gcp tools/c7n_logexporter tools/c7n_mailer tools/c7n_sentry tools/c7n_sphinxext tools/zerodark tools/ops tools/c7n_azure
+
 clean:
 	rm -rf .tox .Python bin include lib pip-selfcheck.json
 

--- a/tox.ini
+++ b/tox.ini
@@ -42,7 +42,7 @@ commands =
     py.test -n auto tests tools/c7n_logexporter tools/c7n_mailer {posargs}
 
 [testenv:lint]
-commands = flake8 c7n tools/c7n_org tools/c7n_gcp tools/c7n_logexporter tools/c7n_mailer tools/c7n_sentry tools/c7n_sphinxext tools/zerodark tools/ops tools/c7n_azure
+commands = make lint
 
 [testenv:docs]
 whitelist_externals = make


### PR DESCRIPTION
With our new and improved flake8 runs on tools I thought this would be pleasant so its easier to run outside of the tox run.  Feel free to close as unnecessary.

(`make` is already required for `tox -e docs`)