### PR TITLE
c7n-mailer | not all cache snapshots have a CacheClusterID

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -222,7 +222,7 @@ def resource_format(resource, resource_type):
     elif resource_type == 'cache-snapshot':
         return "name: %s cluster: %s source: %s" % (
             resource['SnapshotName'],
-            resource['CacheClusterId'],
+            resource.get('CacheClusterId'),
             resource['SnapshotSource'])
     elif resource_type == 'redshift-snapshot':
         return "name: %s db: %s" % (

--- a/tools/c7n_mailer/c7n_mailer/utils.py
+++ b/tools/c7n_mailer/c7n_mailer/utils.py
@@ -220,9 +220,13 @@ def resource_format(resource, resource_type):
             resource['CacheClusterCreateTime'],
             resource['CacheClusterStatus'])
     elif resource_type == 'cache-snapshot':
+        cid = resource.get('CacheClusterId')
+        if cid is None:
+            cid = ', '.join([
+                ns['CacheClusterId'] for ns in resource['NodeSnapshots']])
         return "name: %s cluster: %s source: %s" % (
             resource['SnapshotName'],
-            resource.get('CacheClusterId'),
+            cid,
             resource['SnapshotSource'])
     elif resource_type == 'redshift-snapshot':
         return "name: %s db: %s" % (


### PR DESCRIPTION
I wrote a policy to delete elasticache snapshots but the notification was causing exceptions in c7n-mailer. It appears that not all backups have a CacheClusterID set.