### PR TITLE
UniversalTagDelayedAction mark-for-op support for hours

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -26,7 +26,6 @@ from concurrent.futures import as_completed
 from datetime import datetime, timedelta
 from dateutil import zoneinfo
 from dateutil.parser import parse
-from dateutil.tz import tzutc
 
 import itertools
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -888,7 +888,38 @@ class UniversalTagDelayedAction(TagDelayedAction):
     concurrency = 2
     permissions = ('resourcegroupstaggingapi:TagResources',)
 
+    # def process(self, resources):
+    #     self.id_key = self.manager.get_model().id
+    #
+    #     # Move this to policy? / no resources bypasses actions?
+    #     if not len(resources):
+    #         return
+    #
+    #     msg_tmpl = self.data.get('msg', self.default_template)
+    #
+    #     op = self.data.get('op', 'stop')
+    #     tag = self.data.get('tag', DEFAULT_TAG)
+    #     date = self.data.get('days', 4)
+    #
+    #     n = datetime.now(tz=tzutc())
+    #     action_date = n + timedelta(days=date)
+    #     msg = msg_tmpl.format(
+    #         op=op, action_date=action_date.strftime('%Y/%m/%d'))
+    #
+    #     self.log.info("Tagging %d resources for %s on %s" % (
+    #         len(resources), op, action_date.strftime('%Y/%m/%d')))
+    #
+    #     tags = {tag: msg}
+    #
+    #     batch_size = self.data.get('batch_size', self.batch_size)
+    #
+    #     _common_tag_processer(
+    #         self.executor_factory, batch_size, self.concurrency,
+    #         self.process_resource_set, self.id_key, resources, tags, self.log)
+
     def process(self, resources):
+        self.tz = zoneinfo.gettz(
+            Time.TZ_ALIASES.get(self.data.get('tz', 'utc')))
         self.id_key = self.manager.get_model().id
 
         # Move this to policy? / no resources bypasses actions?
@@ -899,15 +930,15 @@ class UniversalTagDelayedAction(TagDelayedAction):
 
         op = self.data.get('op', 'stop')
         tag = self.data.get('tag', DEFAULT_TAG)
-        date = self.data.get('days', 4)
+        days = self.data.get('days', 0)
+        hours = self.data.get('hours', 0)
+        action_date = self.generate_timestamp(days, hours)
 
-        n = datetime.now(tz=tzutc())
-        action_date = n + timedelta(days=date)
         msg = msg_tmpl.format(
-            op=op, action_date=action_date.strftime('%Y/%m/%d'))
+            op=op, action_date=action_date)
 
         self.log.info("Tagging %d resources for %s on %s" % (
-            len(resources), op, action_date.strftime('%Y/%m/%d')))
+            len(resources), op, action_date))
 
         tags = {tag: msg}
 

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -888,35 +888,6 @@ class UniversalTagDelayedAction(TagDelayedAction):
     concurrency = 2
     permissions = ('resourcegroupstaggingapi:TagResources',)
 
-    # def process(self, resources):
-    #     self.id_key = self.manager.get_model().id
-    #
-    #     # Move this to policy? / no resources bypasses actions?
-    #     if not len(resources):
-    #         return
-    #
-    #     msg_tmpl = self.data.get('msg', self.default_template)
-    #
-    #     op = self.data.get('op', 'stop')
-    #     tag = self.data.get('tag', DEFAULT_TAG)
-    #     date = self.data.get('days', 4)
-    #
-    #     n = datetime.now(tz=tzutc())
-    #     action_date = n + timedelta(days=date)
-    #     msg = msg_tmpl.format(
-    #         op=op, action_date=action_date.strftime('%Y/%m/%d'))
-    #
-    #     self.log.info("Tagging %d resources for %s on %s" % (
-    #         len(resources), op, action_date.strftime('%Y/%m/%d')))
-    #
-    #     tags = {tag: msg}
-    #
-    #     batch_size = self.data.get('batch_size', self.batch_size)
-    #
-    #     _common_tag_processer(
-    #         self.executor_factory, batch_size, self.concurrency,
-    #         self.process_resource_set, self.id_key, resources, tags, self.log)
-
     def process(self, resources):
         self.tz = zoneinfo.gettz(
             Time.TZ_ALIASES.get(self.data.get('tz', 'utc')))

--- a/tests/data/placebo/test_rds_mark_hours/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_mark_hours/rds.DescribeDBInstances_1.json
@@ -1,0 +1,112 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBInstances": [
+            {
+                "PubliclyAccessible": false, 
+                "MasterUsername": "admin", 
+                "MonitoringInterval": 0, 
+                "LicenseModel": "general-public-license", 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-05d3a670a5842a0a8"
+                    }
+                ], 
+                "InstanceCreateTime": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 42, 
+                    "microsecond": 180000, 
+                    "year": 2018, 
+                    "day": 9, 
+                    "minute": 47
+                }, 
+                "CopyTagsToSnapshot": true, 
+                "OptionGroupMemberships": [
+                    {
+                        "Status": "in-sync", 
+                        "OptionGroupName": "default:mysql-5-6"
+                    }
+                ], 
+                "PendingModifiedValues": {}, 
+                "Engine": "mysql", 
+                "MultiAZ": false, 
+                "DBSecurityGroups": [], 
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.mysql5.6", 
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ], 
+                "PerformanceInsightsEnabled": false, 
+                "AutoMinorVersionUpgrade": true, 
+                "PreferredBackupWindow": "08:32-09:02", 
+                "DBSubnetGroup": {
+                    "Subnets": [
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-19bfcb7f", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2a"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-f5c054bd", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2b"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-4097a11b", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2c"
+                            }
+                        }
+                    ], 
+                    "DBSubnetGroupName": "default", 
+                    "VpcId": "vpc-172f0c71", 
+                    "DBSubnetGroupDescription": "default", 
+                    "SubnetGroupStatus": "Complete"
+                }, 
+                "ReadReplicaDBInstanceIdentifiers": [], 
+                "AllocatedStorage": 20, 
+                "DBInstanceArn": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "BackupRetentionPeriod": 0, 
+                "PreferredMaintenanceWindow": "sun:09:32-sun:10:02", 
+                "Endpoint": {
+                    "HostedZoneId": "Z1PVIF0B656C1W", 
+                    "Port": 3306, 
+                    "Address": "db1.camx4omr69zr.us-west-2.rds.amazonaws.com"
+                }, 
+                "DBInstanceStatus": "available", 
+                "IAMDatabaseAuthenticationEnabled": false, 
+                "EngineVersion": "5.6.39", 
+                "AvailabilityZone": "us-west-2c", 
+                "DomainMemberships": [], 
+                "StorageType": "gp2", 
+                "DbiResourceId": "db-IAMMMJGR7VZFVOVL5SHAYO4HKY", 
+                "CACertificateIdentifier": "rds-ca-2015", 
+                "StorageEncrypted": false, 
+                "DBInstanceClass": "db.t2.micro", 
+                "DbInstancePort": 0, 
+                "DBInstanceIdentifier": "db1"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "89df140b-dca5-49a4-8b5d-d3a0b28f0696", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "89df140b-dca5-49a4-8b5d-d3a0b28f0696", 
+                "vary": "Accept-Encoding", 
+                "content-length": "4076", 
+                "content-type": "text/xml", 
+                "date": "Wed, 09 May 2018 16:20:17 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_mark_hours/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_mark_hours/rds.DescribeDBInstances_1.json
@@ -74,13 +74,13 @@
                 }, 
                 "ReadReplicaDBInstanceIdentifiers": [], 
                 "AllocatedStorage": 20, 
-                "DBInstanceArn": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:db:db1",
                 "BackupRetentionPeriod": 0, 
                 "PreferredMaintenanceWindow": "sun:09:32-sun:10:02", 
                 "Endpoint": {
                     "HostedZoneId": "Z1PVIF0B656C1W", 
                     "Port": 3306, 
-                    "Address": "db1.camx4omr69zr.us-west-2.rds.amazonaws.com"
+                    "Address": "db1.camx4omr69zr.us-east-1.rds.amazonaws.com"
                 }, 
                 "DBInstanceStatus": "available", 
                 "IAMDatabaseAuthenticationEnabled": false, 

--- a/tests/data/placebo/test_rds_mark_hours/rds.ListTagsForResource_1.json
+++ b/tests/data/placebo/test_rds_mark_hours/rds.ListTagsForResource_1.json
@@ -1,0 +1,26 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "7d554f3f-8110-4bbf-aef9-eda44d357515", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "7d554f3f-8110-4bbf-aef9-eda44d357515", 
+                "date": "Wed, 09 May 2018 16:20:17 GMT", 
+                "content-length": "531", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "TagList": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/05/09 2120 UTC", 
+                "Key": "maid_status"
+            }, 
+            {
+                "Value": "other", 
+                "Key": "workload-type"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_rds_mark_hours/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_mark_hours/tagging.GetResources_1.json
@@ -4,7 +4,7 @@
         "PaginationToken": "", 
         "ResourceTagMappingList": [
             {
-                "ResourceARN": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "ResourceARN": "arn:aws:rds:us-east-1:123456789012:db:db1",
                 "Tags": [
                     {
                         "Value": "other", 

--- a/tests/data/placebo/test_rds_mark_hours/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_mark_hours/tagging.GetResources_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PaginationToken": "", 
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "Tags": [
+                    {
+                        "Value": "other", 
+                        "Key": "workload-type"
+                    }
+                ]
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "dcb03f4b-53a4-11e8-861e-2dfce93af58e", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "dcb03f4b-53a4-11e8-861e-2dfce93af58e", 
+                "date": "Wed, 09 May 2018 16:20:17 GMT", 
+                "content-length": "158", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_mark_hours/tagging.TagResources_1.json
+++ b/tests/data/placebo/test_rds_mark_hours/tagging.TagResources_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "dccf602e-53a4-11e8-aa81-375f542e9c8f", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "dccf602e-53a4-11e8-aa81-375f542e9c8f", 
+                "date": "Wed, 09 May 2018 16:20:18 GMT", 
+                "content-length": "25", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }, 
+        "FailedResourcesMap": {}
+    }
+}

--- a/tests/data/placebo/test_rds_marked_hours/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_marked_hours/rds.DescribeDBInstances_1.json
@@ -74,13 +74,13 @@
                 }, 
                 "ReadReplicaDBInstanceIdentifiers": [], 
                 "AllocatedStorage": 20, 
-                "DBInstanceArn": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "DBInstanceArn": "arn:aws:rds:us-east-1:123456789012:db:db1",
                 "BackupRetentionPeriod": 0, 
                 "PreferredMaintenanceWindow": "sun:09:32-sun:10:02", 
                 "Endpoint": {
                     "HostedZoneId": "Z1PVIF0B656C1W", 
                     "Port": 3306, 
-                    "Address": "db1.camx4omr69zr.us-west-2.rds.amazonaws.com"
+                    "Address": "db1.camx4omr69zr.us-east-1.rds.amazonaws.com"
                 }, 
                 "DBInstanceStatus": "available", 
                 "IAMDatabaseAuthenticationEnabled": false, 

--- a/tests/data/placebo/test_rds_marked_hours/rds.DescribeDBInstances_1.json
+++ b/tests/data/placebo/test_rds_marked_hours/rds.DescribeDBInstances_1.json
@@ -1,0 +1,112 @@
+{
+    "status_code": 200, 
+    "data": {
+        "DBInstances": [
+            {
+                "PubliclyAccessible": false, 
+                "MasterUsername": "admin", 
+                "MonitoringInterval": 0, 
+                "LicenseModel": "general-public-license", 
+                "VpcSecurityGroups": [
+                    {
+                        "Status": "active", 
+                        "VpcSecurityGroupId": "sg-05d3a670a5842a0a8"
+                    }
+                ], 
+                "InstanceCreateTime": {
+                    "hour": 14, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 42, 
+                    "microsecond": 180000, 
+                    "year": 2018, 
+                    "day": 9, 
+                    "minute": 47
+                }, 
+                "CopyTagsToSnapshot": true, 
+                "OptionGroupMemberships": [
+                    {
+                        "Status": "in-sync", 
+                        "OptionGroupName": "default:mysql-5-6"
+                    }
+                ], 
+                "PendingModifiedValues": {}, 
+                "Engine": "mysql", 
+                "MultiAZ": false, 
+                "DBSecurityGroups": [], 
+                "DBParameterGroups": [
+                    {
+                        "DBParameterGroupName": "default.mysql5.6", 
+                        "ParameterApplyStatus": "in-sync"
+                    }
+                ], 
+                "PerformanceInsightsEnabled": false, 
+                "AutoMinorVersionUpgrade": true, 
+                "PreferredBackupWindow": "08:32-09:02", 
+                "DBSubnetGroup": {
+                    "Subnets": [
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-19bfcb7f", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2a"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-f5c054bd", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2b"
+                            }
+                        }, 
+                        {
+                            "SubnetStatus": "Active", 
+                            "SubnetIdentifier": "subnet-4097a11b", 
+                            "SubnetAvailabilityZone": {
+                                "Name": "us-west-2c"
+                            }
+                        }
+                    ], 
+                    "DBSubnetGroupName": "default", 
+                    "VpcId": "vpc-172f0c71", 
+                    "DBSubnetGroupDescription": "default", 
+                    "SubnetGroupStatus": "Complete"
+                }, 
+                "ReadReplicaDBInstanceIdentifiers": [], 
+                "AllocatedStorage": 20, 
+                "DBInstanceArn": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "BackupRetentionPeriod": 0, 
+                "PreferredMaintenanceWindow": "sun:09:32-sun:10:02", 
+                "Endpoint": {
+                    "HostedZoneId": "Z1PVIF0B656C1W", 
+                    "Port": 3306, 
+                    "Address": "db1.camx4omr69zr.us-west-2.rds.amazonaws.com"
+                }, 
+                "DBInstanceStatus": "available", 
+                "IAMDatabaseAuthenticationEnabled": false, 
+                "EngineVersion": "5.6.39", 
+                "AvailabilityZone": "us-west-2c", 
+                "DomainMemberships": [], 
+                "StorageType": "gp2", 
+                "DbiResourceId": "db-IAMMMJGR7VZFVOVL5SHAYO4HKY", 
+                "CACertificateIdentifier": "rds-ca-2015", 
+                "StorageEncrypted": false, 
+                "DBInstanceClass": "db.t2.micro", 
+                "DbInstancePort": 0, 
+                "DBInstanceIdentifier": "db1"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ed771476-17ff-4217-9110-f69f834e8775", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "ed771476-17ff-4217-9110-f69f834e8775", 
+                "vary": "Accept-Encoding", 
+                "content-length": "4076", 
+                "content-type": "text/xml", 
+                "date": "Wed, 09 May 2018 16:54:05 GMT"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_marked_hours/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_marked_hours/tagging.GetResources_1.json
@@ -1,0 +1,32 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PaginationToken": "", 
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "Tags": [
+                    {
+                        "Value": "Resource does not meet policy: delete@2018/05/09 1520 UTC", 
+                        "Key": "maid_status"
+                    }, 
+                    {
+                        "Value": "other", 
+                        "Key": "workload-type"
+                    }
+                ]
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "95af44b7-53a9-11e8-9f0a-9da08d4dc7eb", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "95af44b7-53a9-11e8-9f0a-9da08d4dc7eb", 
+                "date": "Wed, 09 May 2018 16:54:05 GMT", 
+                "content-length": "248", 
+                "content-type": "application/x-amz-json-1.1"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_rds_marked_hours/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_rds_marked_hours/tagging.GetResources_1.json
@@ -4,7 +4,7 @@
         "PaginationToken": "", 
         "ResourceTagMappingList": [
             {
-                "ResourceARN": "arn:aws:rds:us-west-2:123456789012:db:db1",
+                "ResourceARN": "arn:aws:rds:us-east-1:123456789012:db:db1",
                 "Tags": [
                     {
                         "Value": "Resource does not meet policy: delete@2018/05/09 1520 UTC", 

--- a/tests/test_asg.py
+++ b/tests/test_asg.py
@@ -237,7 +237,8 @@ class AutoScalingTest(BaseTest):
         asg = session.client('autoscaling')
         localtz = zoneinfo.gettz('America/New_York')
         dt = datetime.now(localtz)
-        dt = dt.replace(year=2018, month=2, day=20, hour=8, minute=42)
+        dt = dt.replace(year=2018, month=2, day=20, hour=12, minute=42,
+                        second=0, microsecond=0)
 
         policy = self.load_policy({
             'name': 'asg-mark-for-op-hours',
@@ -263,7 +264,7 @@ class AutoScalingTest(BaseTest):
         result = datetime.strptime(
             tags[0].strip().split('@', 1)[-1], '%Y/%m/%d %H%M %Z').replace(
             tzinfo=localtz)
-        self.assertEqual(result.date(), dt.date())
+        self.assertEqual(result, dt)
 
     def test_asg_marked_for_op_hours(self):
         session_factory = self.replay_flight_data('test_asg_marked_for_op_hours')

--- a/tests/test_ec2.py
+++ b/tests/test_ec2.py
@@ -638,7 +638,8 @@ class TestTag(BaseTest):
     def test_ec2_mark_hours(self):
         localtz = zoneinfo.gettz('America/New_York')
         dt = datetime.now(localtz)
-        dt = dt.replace(year=2018, month=2, day=20, hour=18, minute=00)
+        dt = dt.replace(year=2018, month=2, day=20, hour=18, minute=00,
+                        second=0, microsecond=0)
         session_factory = self.replay_flight_data('test_ec2_mark_hours')
         session = session_factory(region='us-east-1')
         ec2 = session.client('ec2')
@@ -666,7 +667,7 @@ class TestTag(BaseTest):
         result = datetime.strptime(
             tags[0].strip().split('@', 1)[-1], '%Y/%m/%d %H%M %Z').replace(
             tzinfo=localtz)
-        self.assertEqual(result.date(), dt.date())
+        self.assertEqual(result, dt)
 
     def test_ec2_marked_hours(self):
         session_factory = self.replay_flight_data('test_ec2_marked_hours')

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -224,7 +224,7 @@ class RDSTest(BaseTest):
         dt = dt.replace(year=2018, month=5, day=9, hour=21, minute=20,
                         second=0, microsecond=0)
         session_factory = self.replay_flight_data('test_rds_mark_hours')
-        session = session_factory(region='us-west-2')
+        session = session_factory(region='us-east-1')
         rds = session.client('rds')
 
         policy = self.load_policy({

--- a/tests/test_rds.py
+++ b/tests/test_rds.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import datetime
+from dateutil import tz, zoneinfo
 import json
 import logging
 import os
@@ -216,6 +217,61 @@ class RDSTest(BaseTest):
             session_factory=session_factory)
         resources = policy.run()
         self.assertEqual(len(resources), 1)
+
+    def test_rds_mark_hours(self):
+        localtz = zoneinfo.gettz('Etc/UTC')
+        dt = datetime.datetime.now(localtz)
+        dt = dt.replace(year=2018, month=5, day=9, hour=21, minute=20,
+                        second=0, microsecond=0)
+        session_factory = self.replay_flight_data('test_rds_mark_hours')
+        session = session_factory(region='us-west-2')
+        rds = session.client('rds')
+
+        policy = self.load_policy({
+            'name': 'rds-mark-5-hours',
+            'resource': 'rds',
+            'filters': [
+                {'tag:CreatorName': 'absent'}
+            ],
+            'actions': [
+                {'type': 'mark-for-op',
+                 'hours': 5,
+                 'op': 'delete'}]
+        },
+            config={'account_id': '123456789012'},
+            session_factory=session_factory
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+
+        resource = rds.list_tags_for_resource(
+            ResourceName=resources[0]['DBInstanceArn']
+        )
+        tags = [
+            t['Value'] for t in resource['TagList']
+            if t['Key'] == 'maid_status'
+        ]
+        result = datetime.datetime.strptime(
+            tags[0].strip().split('@', 1)[-1], '%Y/%m/%d %H%M %Z'
+        ).replace(tzinfo=localtz)
+        self.assertEqual(result, dt)
+
+    def test_rds_marked_hours(self):
+        session_factory = self.replay_flight_data('test_rds_marked_hours')
+        policy = self.load_policy(
+            {'name': 'rds-marked-for-op-hours',
+             'resource': 'rds',
+             'filters': [
+                 {'type': 'marked-for-op',
+                  'op': 'delete'}
+             ]
+             },
+            config={'account_id': '123456789012'},
+            session_factory=session_factory
+        )
+        resources = policy.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]['DBInstanceIdentifier'], 'db1')
 
     def test_rds_default_vpc(self):
         session_factory = self.replay_flight_data('test_rds_default_vpc')


### PR DESCRIPTION
* Makes updates discussed in #2006 for the `UniversalTagDelayedAction` class
* Changes hour support so that it includes the minutes as well. Prior the minutes were replaced with `0` leading to unexpected behavior.
* `UniversalTagDelayedAction` is used for rds, so this adds support for rds
* Added `test_rds_mark_hours` & `test_rds_marked_hours` unit test
* Realized that unittests `test_ec2_mark_hours` & `test_asg_mark_for_op_hours` were only comparing the tag data, vs comparing hours and minutes, so these have been updated to be better tests.