### PR TITLE
add support for setting minimum requested units in limit increase policy

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -534,7 +534,9 @@ class RequestLimitIncrease(BaseAction):
         percent_increase = self.data.get('percent-increase')
         amount_increase = self.data.get('amount-increase')
         minimum_increase = self.data.get('minimum-increase')
-
+            if not mimimum_increase:
+                mimimum_increase = 1
+                
         for s in limit_exceeded:
             current_limit = int(s['limit'])
             if percent_increase:

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -534,7 +534,7 @@ class RequestLimitIncrease(BaseAction):
         percent_increase = self.data.get('percent-increase')
         amount_increase = self.data.get('amount-increase')
         minimum_increase = self.data.get('minimum-increase',1)
-                
+
         for s in limit_exceeded:
             current_limit = int(s['limit'])
             if percent_increase:

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -534,8 +534,8 @@ class RequestLimitIncrease(BaseAction):
         percent_increase = self.data.get('percent-increase')
         amount_increase = self.data.get('amount-increase')
         minimum_increase = self.data.get('minimum-increase')
-            if not mimimum_increase:
-                mimimum_increase = 1
+            if not minimum_increase:
+                minimum_increase = 1
                 
         for s in limit_exceeded:
             current_limit = int(s['limit'])

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -533,9 +533,7 @@ class RequestLimitIncrease(BaseAction):
         limit_exceeded = resources[0].get('c7n:ServiceLimitsExceeded', [])
         percent_increase = self.data.get('percent-increase')
         amount_increase = self.data.get('amount-increase')
-        minimum_increase = self.data.get('minimum-increase')
-            if not minimum_increase:
-                minimum_increase = 1
+        minimum_increase = self.data.get('minimum-increase',1)
                 
         for s in limit_exceeded:
             current_limit = int(s['limit'])

--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -496,6 +496,7 @@ class RequestLimitIncrease(BaseAction):
             'type': {'enum': ['request-limit-increase']},
             'percent-increase': {'type': 'number', 'minimum': 1},
             'amount-increase': {'type': 'number', 'minimum': 1},
+            'minimum-increase': {'type': 'number', 'minimum': 1},
             'subject': {'type': 'string'},
             'message': {'type': 'string'},
             'severity': {'type': 'string', 'enum': ['urgent', 'high', 'normal', 'low']}
@@ -532,12 +533,13 @@ class RequestLimitIncrease(BaseAction):
         limit_exceeded = resources[0].get('c7n:ServiceLimitsExceeded', [])
         percent_increase = self.data.get('percent-increase')
         amount_increase = self.data.get('amount-increase')
+        minimum_increase = self.data.get('minimum-increase')
 
         for s in limit_exceeded:
             current_limit = int(s['limit'])
             if percent_increase:
                 increase_by = current_limit * float(percent_increase) / 100
-                increase_by = max(increase_by, 1)
+                increase_by = max(increase_by, minimum_increase)
             else:
                 increase_by = amount_increase
             increase_by = round(increase_by)


### PR DESCRIPTION
```
└─<cwb>$ git diff --minimal -U0  master
diff --git a/c7n/resources/account.py b/c7n/resources/account.py
index e71d9d81..a88df652 100644
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -498,0 +499 @@ class RequestLimitIncrease(BaseAction):
+            'minimum-increase': {'type': 'number', 'minimum': 1},
@@ -534,0 +536 @@ class RequestLimitIncrease(BaseAction):
+        minimum_increase = self.data.get('minimum-increase')
@@ -540 +542 @@ class RequestLimitIncrease(BaseAction):
-                increase_by = max(increase_by, 1)
+                increase_by = max(increase_by, minimum_increase)
```