### PR TITLE
tools/omnissm - some refactoring, add request validation test, use initctl if systemctl is not available

### DIFF
--- a/tools/omnissm/api/register/register_test.go
+++ b/tools/omnissm/api/register/register_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+func TestValidateRequest(t *testing.T) {
+	type errorResponse struct {
+		Error   string `json:"error"`
+		Message string `json:"message"`
+	}
+
+	failureCases := []struct {
+		name string
+		body string
+		err  errorResponse
+	}{
+		{
+			name: "empty request",
+			body: "",
+			err:  errorResponse{"invalid-request", "malformed json"},
+		},
+		{
+			name: "malformed json",
+			body: "{",
+			err:  errorResponse{"invalid-request", "malformed json"},
+		},
+		{
+			name: "unknown provider",
+			body: `{"identity":"","signature":"","provider":"unknown","managed-id":""}`,
+			err:  errorResponse{"invalid-request", "unknown provider"},
+		},
+		{
+			name: "signature not base64",
+			body: `{"identity":"identity","signature":"not%%base64","provider":"aws","managed-id":""}`,
+			err:  errorResponse{"invalid-request", "malformed rsa signature"},
+		},
+		{
+			name: "signature blank",
+			body: `{"identity":"identity","signature":"","provider":"aws","managed-id":""}`,
+			err:  errorResponse{"invalid-signature", "invalid identity"},
+		},
+		{
+			name: "signature not valid",
+			body: `{"identity":"identity","signature":"aWRlbnRpdHkK","provider":"aws","managed-id":""}`,
+			err:  errorResponse{"invalid-signature", "invalid identity"},
+		},
+	}
+
+	for _, c := range failureCases {
+		t.Run(c.name, func(t *testing.T) {
+			_, resp := validateRequest(c.body)
+			if resp.StatusCode != 400 {
+				t.Errorf("response status code was %d, expected 400", resp.StatusCode)
+			}
+			var errResp errorResponse
+			if err := json.Unmarshal([]byte(resp.Body), &errResp); err != nil {
+				t.Errorf("error unmarshaling reponse body: %v", err)
+			}
+			if errResp != c.err {
+				t.Errorf("\n\texpected '%+v'\n\tgot      '%+v'", c.err, errResp)
+			}
+		})
+	}
+}

--- a/tools/omnissm/api/register/register_test.go
+++ b/tools/omnissm/api/register/register_test.go
@@ -1,3 +1,18 @@
+/*
+Copyright 2018 Capital One Services, LLC
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+
+You may obtain a copy of the License at
+	http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
 package main
 
 import (

--- a/tools/omnissm/host/register/Makefile
+++ b/tools/omnissm/host/register/Makefile
@@ -2,6 +2,6 @@ bucket=c7n-ssm-build
 
 publish:
 	GOOS=linux go build -o ssm-initialize initialize.go
-	bzip2 ssm-initialize
-	aws s3 cp --sse AES256 --acl public-read ssm-initialize.bz2 s3://$(bucket)/assets/ssm-initialize-linux-amd64.bz2
-	rm ssm-initialize.bz2
+	gzip ssm-initialize
+	aws s3 cp --sse AES256 --acl public-read ssm-initialize.gz s3://$(bucket)/assets/ssm-initialize-linux-amd64.gz
+	rm ssm-initialize.gz

--- a/tools/omnissm/host/register/initialize.go
+++ b/tools/omnissm/host/register/initialize.go
@@ -18,7 +18,6 @@ package main
 import (
 	"bytes"
 	"encoding/json"
-	"errors"
 	"fmt"
 	"io/ioutil"
 	"log"
@@ -27,13 +26,9 @@ import (
 	"os/exec"
 	"strings"
 	"time"
-)
 
-// SSMAgentRegistration Sourced from /var/lib/amazon/ssm/registration
-type SSMAgentRegistration struct {
-	ManagedInstanceID string
-	Region            string
-}
+	"github.com/pkg/errors"
+)
 
 const (
 	// LinuxSSMRegistrationPath Linux Path to Agent Registration State
@@ -45,6 +40,12 @@ const (
 	// SignatureURL RSA SHA256 Signature of identity document
 	SignatureURL = "http://169.254.169.254/latest/dynamic/instance-identity/signature"
 )
+
+// SSMAgentRegistration Sourced from /var/lib/amazon/ssm/registration
+type SSMAgentRegistration struct {
+	ManagedInstanceID string
+	Region            string
+}
 
 // SSMHostInfo output of ssm-cli get-ubstabce-information
 type SSMHostInfo struct {
@@ -67,7 +68,6 @@ type NodeInfo struct {
 
 // NewNodeInfo Constructor for SSM Node Info
 func NewNodeInfo() (*NodeInfo, error) {
-
 	ssmCmdPath, err := exec.LookPath("amazon-ssm-agent")
 	if err != nil {
 		return nil, errors.New("Package Missing - Error finding amazon-ssm-agent")
@@ -88,37 +88,40 @@ func NewNodeInfo() (*NodeInfo, error) {
 		return nil, errors.New("Missing Registration Endpoint Env Var (OMNISSM_URI)")
 	}
 
-	identity, err := FetchContents(IdentityURL)
-	if err != nil {
-		return nil, err
-	}
-	signature, err := FetchContents(SignatureURL)
-	if err != nil {
-		return nil, err
-	}
-
-	return &NodeInfo{
+	n := NodeInfo{
 		BinSSMAgent:     ssmCmdPath,
 		BinSSMInfo:      ssmInfoPath,
 		BinService:      svcCmdPath,
 		RegistrationURL: registrationURL,
-		Identity:        string(identity),
-		Signature:       string(signature),
-		netClient:       &http.Client{Timeout: time.Second * 10},
-	}, nil
+		netClient:       &http.Client{Timeout: 10 * time.Second},
+	}
 
+	// EC2 Metadata request for identity document
+	b, err := readResponse(n.netClient.Get(IdentityURL))
+	if err != nil {
+		return nil, errors.Wrap(err, "instance identity request failed")
+	}
+	n.Identity = string(b)
+
+	// EC2 Metadata request for signature
+	b, err = readResponse(n.netClient.Get(SignatureURL))
+	if err != nil {
+		return nil, errors.Wrap(err, "instance signature request failed")
+	}
+	n.Signature = string(b)
+
+	return &n, nil
 }
 
 // IsRegistered Is the node registered with SSM
 func (n *NodeInfo) IsRegistered() bool {
 	// If we have a current registration for hybrid mode, exit
-	agentRaw, err := ioutil.ReadFile(LinuxSSMRegistrationPath)
+	raw, err := ioutil.ReadFile(LinuxSSMRegistrationPath)
 	if err == nil {
-		agentReg := SSMAgentRegistration{}
-		err = json.Unmarshal(agentRaw, &agentReg)
-		if err == nil {
-			if strings.HasPrefix(agentReg.ManagedInstanceID, "mi-") {
-				n.ManagedID = agentReg.ManagedInstanceID
+		var r SSMAgentRegistration
+		if err := json.Unmarshal(raw, &r); err == nil {
+			if strings.HasPrefix(r.ManagedInstanceID, "mi-") {
+				n.ManagedID = r.ManagedInstanceID
 				return true
 
 			}
@@ -129,147 +132,114 @@ func (n *NodeInfo) IsRegistered() bool {
 
 // GetSSMInfo Return ssm agent node information
 func (n *NodeInfo) GetSSMInfo() (*SSMHostInfo, error) {
-	ssmInfoCmd := exec.Command(n.BinSSMInfo, "get-instance-information")
-	ssmInfoOut, err := ssmInfoCmd.Output()
+	cmd := exec.Command(n.BinSSMInfo, "get-instance-information")
+	out, err := cmd.Output()
 	if err != nil {
 		return nil, err
 	}
 
-	ssmInfo := SSMHostInfo{}
-	err = json.Unmarshal(ssmInfoOut, &ssmInfo)
+	info := SSMHostInfo{}
+	err = json.Unmarshal(out, &info)
 	if err != nil {
 		return nil, err
 	}
-	n.ManagedID = ssmInfo.InstanceID
-	return &ssmInfo, nil
+	if strings.HasPrefix(info.InstanceID, "mi-") {
+		n.ManagedID = info.InstanceID
+	}
+	return &info, nil
 }
 
 // Register Node with SSM via registration API
 func (n *NodeInfo) Register() error {
-
-	regSerial, err := json.Marshal(
-		map[string]string{
-			"provider":  "aws",
-			"identity":  n.Identity,
-			"signature": n.Signature,
-		})
-
+	regSerial, err := json.Marshal(map[string]string{
+		"provider":  "aws",
+		"identity":  n.Identity,
+		"signature": n.Signature,
+	})
 	if err != nil {
 		return err
 	}
 
 	fmt.Println("Registration Request", string(regSerial))
 
-	response, err := n.netClient.Post(
-		n.RegistrationURL, "application/json", bytes.NewReader(regSerial))
+	b, err := readResponse(n.netClient.Post(n.RegistrationURL, "application/json", bytes.NewReader(regSerial)))
 	if err != nil {
 		return err
 	}
-	regResultBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
+
+	result := make(map[string]string)
+	if err := json.Unmarshal(b, &result); err != nil {
 		return err
 	}
-	defer response.Body.Close()
-
-	if response.StatusCode != 200 {
-		return fmt.Errorf("Registration Error %s", regResultBody)
+	if code, ok := result["error"]; ok {
+		return errors.Errorf("%s: %s", code, result["message"])
 	}
 
-	regResult := map[string]string{}
-
-	err = json.Unmarshal(regResultBody, &regResult)
-	if err != nil {
-		return err
-	}
-	errCode, ok := regResult["error"]
-	if ok {
-		return fmt.Errorf("Registration Error %s %s", errCode, regResult["message"])
-	}
-
-	ssmCmd := exec.Command(
-		n.BinSSMAgent, "-register", "-y",
-		"-id", regResult["activation-id"],
-		"-code", regResult["activation-code"],
-		"-i", regResult["managed-id"],
-		"--region", regResult["region"])
+	ssmCmd := exec.Command(n.BinSSMAgent,
+		"-register", "-y",
+		"-id", result["activation-id"],
+		"-code", result["activation-code"],
+		"-i", result["managed-id"],
+		"--region", result["region"])
 	ssmOut, err := ssmCmd.CombinedOutput()
-
 	if err != nil {
-		return fmt.Errorf("SSM Register Error %s %s", err, string(ssmOut))
+		return errors.Errorf("SSM agent command failed: %v - %s", err, string(ssmOut))
 	}
 
 	svcCmd := exec.Command(n.BinService, "amazon-ssm-agent", "restart")
 	svcOut, err := svcCmd.CombinedOutput()
-
 	if err != nil {
-		return fmt.Errorf("SSM agent restart error %s %s", err, svcOut)
+		return errors.Errorf("SSM agent restart failed: %v - %s", err, string(svcOut))
 	}
-
 	return nil
-
 }
 
 // UpdateSSMID Record host SSM Id via the registration API
 func (n *NodeInfo) UpdateSSMID() error {
-	ssmInfo, err := n.GetSSMInfo()
+	info, err := n.GetSSMInfo()
 	if err != nil {
 		return err
 	}
 
-	idSerial, err := json.Marshal(map[string]string{
+	b, err := json.Marshal(map[string]string{
 		"provider":   "aws",
 		"identity":   n.Identity,
 		"signature":  n.Signature,
-		"managed-id": ssmInfo.InstanceID,
+		"managed-id": info.InstanceID,
 	})
-
 	if err != nil {
 		return err
 	}
 
-	idReq, err := http.NewRequest("PATCH", n.RegistrationURL, bytes.NewReader(idSerial))
+	req, err := http.NewRequest("PATCH", n.RegistrationURL, bytes.NewReader(b))
 	if err != nil {
 		return err
 	}
-
-	idReq.Header.Set("Content-Type", "application/json")
-	response, err := n.netClient.Do(idReq)
-	if err != nil {
-		return err
-	}
-	defer response.Body.Close()
-
-	idResultBody, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return err
-	}
-
-	if response.StatusCode != 200 {
-		return fmt.Errorf("Error recording SSM Instance Id %s %s", err, idResultBody)
-	}
-
-	return nil
+	req.Header.Set("Content-Type", "application/json")
+	_, err = readResponse(n.netClient.Do(req))
+	return err
 }
 
-// FetchContents Retrieve contents of URL
-func FetchContents(uri string) ([]byte, error) {
-	response, err := http.Get(uri)
+func readResponse(resp *http.Response, err error) ([]byte, error) {
+	if err != nil {
+		// network error sending request
+		return nil, err
+	}
+	defer resp.Body.Close()
+	b, err := ioutil.ReadAll(resp.Body)
 	if err != nil {
 		return nil, err
 	}
-	defer response.Body.Close()
-	body, err := ioutil.ReadAll(response.Body)
-	if err != nil {
-		return nil, err
+	if resp.StatusCode != 200 {
+		return nil, errors.Errorf("%d: %s", resp.StatusCode, string(b))
 	}
-	return body, nil
+	return b, nil
 }
 
 func main() {
-
 	node, err := NewNodeInfo()
 	if err != nil {
-		log.Fatalf("Error initializing node %s", err)
+		log.Fatalf("Error initializing node: %v", err)
 	}
 
 	if node.IsRegistered() {
@@ -280,12 +250,12 @@ func main() {
 	log.Println("Registering Instance")
 	err = node.Register()
 	if err != nil {
-		log.Fatalf("Error registering node %s", err)
+		log.Fatalf("Error registering node: %v", err)
 	}
 
 	err = node.UpdateSSMID()
 	if err != nil {
-		log.Fatalf("Error recording node ssm id %s", err)
+		log.Fatalf("Error recording node ssm id: %v", err)
 	}
 
 	log.Printf("Instance Registered - ManagedId: %s\n", node.ManagedID)

--- a/tools/omnissm/inventory/process/Makefile
+++ b/tools/omnissm/inventory/process/Makefile
@@ -2,6 +2,6 @@ bucket=c7n-ssm-build
 
 publish:
 	GOOS=linux go build -o inventory-process process.go
-	bzip2 inventory-process
-	aws s3 cp --sse AES256 --acl public-read inventory-process.bz2 s3://$(bucket)/assets/inventory-process-linux-amd64.bz2
-	rm inventory-process.bz2
+	gzip inventory-process
+	aws s3 cp --sse AES256 --acl public-read inventory-process.gz s3://$(bucket)/assets/inventory-process-linux-amd64.gz
+	rm inventory-process.gz


### PR DESCRIPTION
On Ubuntu14.04/Ubuntu16.04, `service` will act on systemd, upstart, or sys V services - but the version `service` on RHEL 6 will only interact with sys V services/scripts. One of the changes made will check for `initctl` if `systemctl` is not available, in order to restart the amazon-ssm-agent upstart service.

A simple test of request validation was added to `api/register/`, and can be built upon in future commits.

Makefiles for the agent binaries were updated to use gzip, as bzip2 was not available by default on all target platforms.