### PR TITLE
Pin futures to 3.1.1

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -5,3 +5,4 @@ jsonschema>=2.5.1
 PyYAML>=3.12
 tabulate>=0.7.7
 jsonpatch>=1.2.1
+futures==3.1.1


### PR DESCRIPTION
The most recent version doesn't let itself get installed  on py3,
Pinning to 3.2.1 allow the package to create the test harness for python3.