### PR TITLE
azure - fix future dep installation issue

### DIFF
--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -31,5 +31,5 @@ setup(
         "custodian.resources": [
             'azure = c7n_azure.entry:initialize_azure']
     },
-    install_requires=["c7n", "click", "azure", "azure-cli-core", "adal"]
+    install_requires=["azure", "c7n", "click", "azure-cli-core", "adal", "futures==3.1.1"],
 )


### PR DESCRIPTION
Do not install futures for python 3.6