### PR TITLE
Add code for expansion of variables for the dead_letter_config

### DIFF
--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -456,6 +456,9 @@ class LambdaMode(PolicyExecutionMode):
                 if 'output_dir' in p['mode']['execution-options']:
                     p['mode']['execution-options']['output_dir'] = utils.format_string_values(
                         p['mode']['execution-options']['output_dir'], **variables)
+            if 'dead_letter_config' in p['mode']:
+                p['mode']['dead_letter_config'] = utils.format_string_values(
+                    p['mode']['dead_letter_config'], **variables)
         return p
 
     def provision(self):


### PR DESCRIPTION
I found in the code that the dead_letter_config setting was available to configure in the policy definition, which is very helpful for capturing Lambda errors (I recommend this be added to the doc).  I realized however that the variables for account_id and region weren't expanded, so I added this logic in.  I now have this defined on every policy I deploy.

```
 mode:
      type: periodic
      schedule: "rate(24 hours)"
      role: arn:aws:iam::{account_id}:role/cloud-custodian
      execution-options:
        output_dir: s3://ellucian-cloudcustodian-{account_id}
      dead_letter_config:
        TargetArn: arn:aws:sns:{region}:{account_id}:CustodianLambdaError
```