### PR TITLE
support for Trusted IP set and resigned member accounts 

### DIFF
--- a/tools/c7n_guardian/c7n_guardian/cli.py
+++ b/tools/c7n_guardian/c7n_guardian/cli.py
@@ -240,10 +240,10 @@ def enable_region(master_info, accounts_config, executor, message, region):
 
     # Find extant members not currently enabled
     suspended_ids = {m['AccountId'] for m in extant_members
-                     if m['RelationshipStatus'] == 'Disabled'}
+        if m['RelationshipStatus'] == 'Disabled'}
     # Filter by accounts under consideration per config and cli flags
     suspended_ids = {a['account_id'] for a in accounts_config['accounts']
-                     if a['account_id'] in suspended_ids}
+        if a['account_id'] in suspended_ids}
 
     if suspended_ids:
         unprocessed = master_client.start_monitoring_members(
@@ -331,7 +331,7 @@ def enable_account(account, master_account_id, region):
         profile=account.get('profile'),
         region=region)
     member_client = member_session.client('guardduty')
-    m_detector_id = get_or_create_detector_id(member_client)    
+    m_detector_id = get_or_create_detector_id(member_client)
     all_invitations = member_client.list_invitations().get('Invitations', [])
     invitations = [
         i for i in all_invitations

--- a/tools/c7n_guardian/c7n_guardian/cli.py
+++ b/tools/c7n_guardian/c7n_guardian/cli.py
@@ -222,16 +222,15 @@ def enable_region(master_info, accounts_config, executor, message, region):
 
     # Find active members
     active_ids = {m['AccountId'] for m in extant_members
-                      if m['RelationshipStatus'] == 'Enabled'}
+        if m['RelationshipStatus'] == 'Enabled'}
     # Find invited members
     invited_ids = {m['AccountId'] for m in extant_members
-                       if m['RelationshipStatus'] == 'Invited'}
+        if m['RelationshipStatus'] == 'Invited'}
     # Find extant members who currently have guardduty disabled(not suspended)
     resigned_ids = {m['AccountId'] for m in extant_members
-                       if m['RelationshipStatus'] == 'Resigned'}
-
+        if m['RelationshipStatus'] == 'Resigned'}
     resigned_ids = {a['account_id'] for a in accounts_config['accounts']
-                     if a['account_id'] in resigned_ids}    
+        if a['account_id'] in resigned_ids}    
     
     if resigned_ids:
         master_client.delete_members(DetectorId=detector_id, AccountIds=list(resigned_ids))


### PR DESCRIPTION
1. Option to create/update trusted IP list in GuardDuty (Only if the ipset s3 url is present in the policy file for master account, see below)
2. Re-enable guardduty on resigned member accounts (disabled not suspended) by diassociating from master and then re-invite and add
3. Fixed the issue with get_or_create_detector_id method in which the created detectors are in disabled due to Enabled=true missing
4. Added a time.sleep before enable_account call to fix the race condition issue in which c7n-guardian is returning no invite found message while trying to accept invites in member accounts right after sending invites


accounts:
  - name: master
    email: xxxxxxxxxx
    account_id: "xxxxxxx"
    role: "arn:aws:iam::xxxxx:role/xxxxxxx"
    trustedIP: "https://s3.amazonaws.com/<bucket-name>/Ipset.txt"
    tags:
      - master
