### PR TITLE
Ipv6 cidr filter

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -846,10 +846,10 @@ class SGPermission(Filter):
           value: x.y.z
 
     `Cidr` can match ipv4 and ipv6 rules.  In this example we are blocking
-    global inbound connections to SSH or RDP. 
+    global inbound connections to SSH or RDP.
 
     .. code-block:: yaml
-    
+
       - type: ingress
         Ports: [22, 3389]
         Cidr:
@@ -912,13 +912,14 @@ class SGPermission(Filter):
         found = None
         if 'Cidr' in self.data:
             # Looping over CidrIp and CidrIpv6 will allow Cidr to match both.
-            for type in [['CidrIp', 'IpRanges'],['CidrIpv6', 'Ipv6Ranges']]:
-                ip_perms = perm.get(type[1], [])
+            for cidr_type, range_type in [['CidrIp', 'IpRanges'], ['CidrIpv6', 'Ipv6Ranges']]:
+                ip_perms = perm.get(range_type, [])
                 if not ip_perms:
+                    found = False
                     break
 
                 match_range = self.data['Cidr']
-                match_range['key'] = type[0] 
+                match_range['key'] = cidr_type
 
                 vf = ValueFilter(match_range)
                 vf.annotate = False

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -845,8 +845,9 @@ class SGPermission(Filter):
           op: in
           value: x.y.z
 
-    `Cidr` can match ipv4 and ipv6 rules.  In this example we are blocking
-    global inbound connections to SSH or RDP.
+    `Cidr` can match ipv4 rules and `CidrV6` can match ipv6 rules.  In
+    this example we are blocking global inbound connections to SSH or
+    RDP.
 
     .. code-block:: yaml
 

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -1561,6 +1561,7 @@ class SecurityGroupTest(BaseTest):
             }
         )
         manager = p.get_resource_manager()
+
         self.assertEqual(len(manager.filter_resources(resources)), 0)
 
         resources = [
@@ -1662,6 +1663,56 @@ class SecurityGroupTest(BaseTest):
                 ],
             }
         )
+        manager = p.get_resource_manager()
+        self.assertEqual(len(manager.filter_resources(resources)), 1)
+
+    def test_egress_ipv6(self):
+        p = self.load_policy({
+            "name": "ipv6-test",
+            "resource": "security-group",
+            "filters": [{
+                "type": "egress", "CidrV6": {
+                    "value": "::/0"}}]
+        })
+
+        resources = [{
+            "IpPermissionsEgress": [
+                {
+                    "IpProtocol": "-1",
+                    "PrefixListIds": [],
+                    "IpRanges": [
+                        {
+                            "CidrIp": "0.0.0.0/0"
+                        }
+                    ],
+                    "UserIdGroupPairs": [],
+                    "Ipv6Ranges": [
+                        {
+                            "CidrIpv6": "::/0"
+                        }
+                    ]
+                }
+            ],
+            "Description": "default VPC security group",
+            "IpPermissions": [
+                {
+                    "IpProtocol": "-1",
+                    "PrefixListIds": [],
+                    "IpRanges": [],
+                    "UserIdGroupPairs": [
+                        {
+                            "UserId": "644160558196",
+                            "GroupId": "sg-b744bafc"
+                        }
+                    ],
+                    "Ipv6Ranges": []
+                }
+            ],
+            "GroupName": "default",
+            "VpcId": "vpc-f8c6d983",
+            "OwnerId": "644160558196",
+            "GroupId": "sg-b744bafc"
+        }]
         manager = p.get_resource_manager()
         self.assertEqual(len(manager.filter_resources(resources)), 1)
 


### PR DESCRIPTION
Take Two for a potential solution for #2313 

I'm trying to decide if `Cidr` should magically match both IpRange and Ipv6Range items.  On the one hand I like that I can create one list for Cidr that will disallow any matching rule.  I can also see that it maybe better to create a `Cidrv6` or some such and have it be explicit.