### PR TITLE
Fallback to non-enterprise Slack user id

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -137,14 +137,16 @@ class SlackDelivery(object):
                     self.caching.set(address, {})
                 continue
             else:
+                slack_user_id = response['user']['id']
+                if 'enterprise_user' in response['user'].keys():
+                    slack_user_id = response['user']['enterprise_user']['id']
                 self.logger.debug(
-                    "Slack account %s found for user %s",
-                    response['user']['enterprise_user']['id'])
+                    "Slack account %s found for user %s", slack_user_id)
                 if self.caching:
                     self.logger.debug('Writing user: %s metadata to cache.', address)
-                    self.caching.set(address, response['user']['enterprise_user']['id'])
+                    self.caching.set(address, slack_user_id)
 
-                list[address] = response['user']['enterprise_user']['id']
+                list[address] = slack_user_id
 
         return list
 


### PR DESCRIPTION
This allows notifications to work for non-paid Slack communities.