### PR TITLE
iam-user - add ability to pick what parts of the iam-user to delete

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1165,15 +1165,15 @@ class UserDelete(BaseAction):
         client.delete_user(UserName=r['UserName'])
 
     OPTIONS = {
-        'console-access':delete_console_access,
-        'access-keys':delete_access_keys,
-        'user-policies':delete_user_policies,
-        'mfa-devices':delete_hw_mfa_devices,
-        'groups':delete_groups,
-        'ssh-keys':delete_ssh_keys,
-        'signing-certificates':delete_signing_certificates,
-        'services-specific-credentials':delete_service_specific_credentials,
-        'user':delete_user,
+        'console-access': delete_console_access,
+        'access-keys': delete_access_keys,
+        'user-policies': delete_user_policies,
+        'mfa-devices': delete_hw_mfa_devices,
+        'groups': delete_groups,
+        'ssh-keys': delete_ssh_keys,
+        'signing-certificates': delete_signing_certificates,
+        'services-specific-credentials': delete_service_specific_credentials,
+        'user': delete_user,
     }
 
     schema = type_schema(

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -957,7 +957,7 @@ class GroupMembership(ValueFilter):
 
         matched = []
         for r in resources:
-            for p in r['c7n:Groups']:
+            for p in r.get('c7n:Groups', []):
                 if self.match(p) and r not in matched:
                     matched.append(r)
         return matched

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1151,7 +1151,7 @@ class UserDelete(BaseAction):
                   options:
                     - mfa-devices
                     - access-keys
-                - ssh-keys
+                    - ssh-keys
     """
 
     ORDERED_OPTIONS = OrderedDict([

--- a/tests/data/placebo/test_iam_user_delete_options/iam.DeleteAccessKey_1.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.DeleteAccessKey_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3a0255e5-652f-11e8-a7cd-9bf8f79cb856", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3a0255e5-652f-11e8-a7cd-9bf8f79cb856", 
+                "date": "Fri, 01 Jun 2018 00:03:33 GMT", 
+                "content-length": "210", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.DeleteLoginProfile_1.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.DeleteLoginProfile_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "39f3897e-652f-11e8-a7cd-9bf8f79cb856", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "39f3897e-652f-11e8-a7cd-9bf8f79cb856", 
+                "date": "Fri, 01 Jun 2018 00:03:33 GMT", 
+                "content-length": "216", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.GenerateCredentialReport_1.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.GenerateCredentialReport_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "State": "STARTED", 
+        "Description": "No report exists. Starting a new report generation task", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "33c53360-652f-11e8-bcd0-e9452080145d", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "33c53360-652f-11e8-bcd0-e9452080145d", 
+                "date": "Fri, 01 Jun 2018 00:03:23 GMT", 
+                "content-length": "413", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.GetCredentialReport_1.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.GetCredentialReport_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 410, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 410, 
+            "RequestId": "33bf18bf-652f-11e8-bcd0-e9452080145d", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "33bf18bf-652f-11e8-bcd0-e9452080145d", 
+                "date": "Fri, 01 Jun 2018 00:03:23 GMT", 
+                "content-length": "224", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "Error": {
+            "Code": "ReportNotPresent", 
+            "Type": "Sender"
+        }
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.GetCredentialReport_2.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.GetCredentialReport_2.json
@@ -1,0 +1,29 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Content": "user,arn,user_creation_time,password_enabled,password_last_used,password_last_changed,password_next_rotation,mfa_active,access_key_1_active,access_key_1_last_rotated,access_key_1_last_used_date,access_key_1_last_used_region,access_key_1_last_used_service,access_key_2_active,access_key_2_last_rotated,access_key_2_last_used_date,access_key_2_last_used_region,access_key_2_last_used_service,cert_1_active,cert_1_last_rotated,cert_2_active,cert_2_last_rotated\ntest_user,arn:aws:iam::644160558196:user/test_user,2018-05-30T19:46:19+00:00,true,no_information,2018-06-01T00:02:54+00:00,2018-08-30T00:02:54+00:00,false,true,2018-06-01T00:02:57+00:00,N/A,N/A,N/A,false,N/A,N/A,N/A,N/A,false,N/A,false,N/A", 
+        "GeneratedTime": {
+            "hour": 0, 
+            "__class__": "datetime", 
+            "month": 6, 
+            "second": 25, 
+            "microsecond": 0, 
+            "year": 2018, 
+            "day": 1, 
+            "minute": 3
+        }, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "39ccc738-652f-11e8-bcd0-e9452080145d", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "39ccc738-652f-11e8-bcd0-e9452080145d", 
+                "vary": "Accept-Encoding", 
+                "content-length": "9257", 
+                "content-type": "text/xml", 
+                "date": "Fri, 01 Jun 2018 00:03:33 GMT"
+            }
+        }, 
+        "ReportFormat": "text/csv"
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.ListAccessKeys_1.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.ListAccessKeys_1.json
@@ -1,0 +1,34 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccessKeyMetadata": [
+            {
+                "UserName": "test_user", 
+                "Status": "Active", 
+                "CreateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2018, 
+                    "day": 1, 
+                    "minute": 2
+                }, 
+                "AccessKeyId": "AKIAJT7FGC7KLSEDVDIQ"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3392d904-652f-11e8-a7cd-9bf8f79cb856", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3392d904-652f-11e8-a7cd-9bf8f79cb856", 
+                "date": "Fri, 01 Jun 2018 00:03:22 GMT", 
+                "content-length": "557", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.ListAccessKeys_2.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.ListAccessKeys_2.json
@@ -1,0 +1,34 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccessKeyMetadata": [
+            {
+                "UserName": "test_user", 
+                "Status": "Active", 
+                "CreateDate": {
+                    "hour": 0, 
+                    "__class__": "datetime", 
+                    "month": 6, 
+                    "second": 57, 
+                    "microsecond": 0, 
+                    "year": 2018, 
+                    "day": 1, 
+                    "minute": 2
+                }, 
+                "AccessKeyId": "AKIAJT7FGC7KLSEDVDIQ"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "39fb78e9-652f-11e8-a7cd-9bf8f79cb856", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "39fb78e9-652f-11e8-a7cd-9bf8f79cb856", 
+                "date": "Fri, 01 Jun 2018 00:03:33 GMT", 
+                "content-length": "557", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.ListAccessKeys_3.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.ListAccessKeys_3.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "AccessKeyMetadata": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3a4fb2b5-652f-11e8-ae43-51ef87f2196b", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3a4fb2b5-652f-11e8-ae43-51ef87f2196b", 
+                "date": "Fri, 01 Jun 2018 00:03:34 GMT", 
+                "content-length": "321", 
+                "content-type": "text/xml"
+            }
+        }, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.ListUsers_1.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.ListUsers_1.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Users": [
+            {
+                "UserName": "test_user", 
+                "Path": "/", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2018, 
+                    "day": 30, 
+                    "minute": 46
+                }, 
+                "UserId": "AIDAJORTU4WKRHGEOSI5U", 
+                "Arn": "arn:aws:iam::644160558196:user/test_user"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3369a57a-652f-11e8-a7cd-9bf8f79cb856", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3369a57a-652f-11e8-a7cd-9bf8f79cb856", 
+                "vary": "Accept-Encoding", 
+                "content-length": "6895", 
+                "content-type": "text/xml", 
+                "date": "Fri, 01 Jun 2018 00:03:22 GMT"
+            }
+        }, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.ListUsers_2.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.ListUsers_2.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Users": [
+            {
+                "UserName": "test_user", 
+                "Path": "/", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2018, 
+                    "day": 30, 
+                    "minute": 46
+                }, 
+                "UserId": "AIDAJORTU4WKRHGEOSI5U", 
+                "Arn": "arn:aws:iam::644160558196:user/test_user"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3a26594c-652f-11e8-8a14-65705c3116c1", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3a26594c-652f-11e8-8a14-65705c3116c1", 
+                "vary": "Accept-Encoding", 
+                "content-length": "6895", 
+                "content-type": "text/xml", 
+                "date": "Fri, 01 Jun 2018 00:03:34 GMT"
+            }
+        }, 
+        "IsTruncated": false
+    }
+}

--- a/tests/data/placebo/test_iam_user_delete_options/iam.ListUsers_3.json
+++ b/tests/data/placebo/test_iam_user_delete_options/iam.ListUsers_3.json
@@ -1,0 +1,36 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Users": [
+            {
+                "UserName": "test_user", 
+                "Path": "/", 
+                "CreateDate": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 5, 
+                    "second": 19, 
+                    "microsecond": 0, 
+                    "year": 2018, 
+                    "day": 30, 
+                    "minute": 46
+                }, 
+                "UserId": "AIDAJORTU4WKRHGEOSI5U", 
+                "Arn": "arn:aws:iam::644160558196:user/test_user"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3a758a62-652f-11e8-aeca-27ae8882579a", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3a758a62-652f-11e8-aeca-27ae8882579a", 
+                "vary": "Accept-Encoding", 
+                "content-length": "6895", 
+                "content-type": "text/xml", 
+                "date": "Fri, 01 Jun 2018 00:03:34 GMT"
+            }
+        }, 
+        "IsTruncated": false
+    }
+}


### PR DESCRIPTION
related to: https://github.com/capitalone/cloud-custodian/issues/2450

New Functionality:
- Specify parts of an iam-user to delete using `options`
  - console-access
  - access-keys
  - user-policies
  - mfa-devices
  - groups
  - ssh-keys
  - signing-certificates
  - service-specific-credentials
```yaml
policies:
  - name: delete-user-console-access
    resource: iam-user
    filters:
      - UserName: test_user
    actions:
      - type: delete
        options:
          - console-access
```

- To delete the user itself, use `delete` with no options (previous implementation):

```yaml
policies:
  - name: delete-user
    resource: iam-user
    filters:
      - UserName: test_user
    actions:
      - type: delete
```