### PR TITLE
s3 - toggle-versioning: add error handling for put_bucket_versioning

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1187,7 +1187,6 @@ class ToggleVersioning(BucketActionBase):
             log.warning(
                 "Access Denied Bucket:%s while put bucket versioning" % resource['Name'])
 
-
     # mfa delete enablement looks like it needs the serial and a current token.
     def process(self, resources):
         enabled = self.data.get('enabled', True)

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1171,26 +1171,34 @@ class ToggleVersioning(BucketActionBase):
         enabled={'type': 'boolean'})
     permissions = ("s3:PutBucketVersioning",)
 
+    def process_versioning(self, resource, state):
+        client = bucket_client(
+            local_session(self.manager.session_factory), r)
+        try:
+            client.put_bucket_versioning(
+                Bucket=resource['Name'],
+                VersioningConfiguration={
+                    'Status': state})
+        except ClientError as e:
+            if e.response['Error']['Code'] != 'AccessDenied':
+                log.error(
+                    "Unable to put bucket versioning on bucket %s: %s" % resource['Name'], e)
+                raise
+            log.warning(
+                "Access Denied Bucket:%s while put bucket versioning" % resource['Name'])
+
+
     # mfa delete enablement looks like it needs the serial and a current token.
     def process(self, resources):
         enabled = self.data.get('enabled', True)
-
         for r in resources:
-            client = bucket_client(
-                local_session(self.manager.session_factory), r)
             if 'Versioning' not in r or not r['Versioning']:
                 r['Versioning'] = {'Status': 'Suspended'}
             if enabled and (
                     r['Versioning']['Status'] == 'Suspended'):
-                client.put_bucket_versioning(
-                    Bucket=r['Name'],
-                    VersioningConfiguration={
-                        'Status': 'Enabled'})
-                continue
+                self.process_versioning(r, 'Enabled')
             if not enabled and r['Versioning']['Status'] == 'Enabled':
-                client.put_bucket_versioning(
-                    Bucket=r['Name'],
-                    VersioningConfiguration={'Status': 'Suspended'})
+                self.process_versioning(r, 'Suspended')
 
 
 @actions.register('toggle-logging')

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -1173,7 +1173,7 @@ class ToggleVersioning(BucketActionBase):
 
     def process_versioning(self, resource, state):
         client = bucket_client(
-            local_session(self.manager.session_factory), r)
+            local_session(self.manager.session_factory), resource)
         try:
             client.put_bucket_versioning(
                 Bucket=resource['Name'],


### PR DESCRIPTION
Related to: https://github.com/capitalone/cloud-custodian/issues/2460
- moved some repeated code into its own function, `process_versioning`
- moved client instantiation out of the for loop and only instantiate a new client when we need to actually set versioning
- add error handling, continue processing if `AccessDenied` on a bucket