### PR TITLE
Add an age filter for EBS Volume

### DIFF
--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -540,6 +540,38 @@ class HealthFilter(HealthEventFilter):
         return {"VolumeId": rid}
 
 
+@filters.register('age')
+class VolumeAgeFilter(AgeFilter):
+    """EBS Volume Age Filter
+
+    Filters an EBS volume based on the age of the volume (in days/hours/minutes)
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: ebs-volumes-recent-but-not-too-old
+                resource: ebs
+                filters:
+                  - type: age
+                    days: 1
+                    op: le
+                  - type: age
+                    minutes: 10
+                    op: ge
+    """
+
+    date_attribute = 'CreateTime'
+
+    schema = type_schema(
+        'age',
+        op={'type': 'string', 'enum': list(OPERATORS.keys())},
+        days={'type': 'number'},
+        hours={'type': 'number'},
+        minutes={'type': 'number'})
+
+
 @actions.register('copy-instance-tags')
 class CopyInstanceTags(BaseAction):
     """Copy instance tags to its attached volume.

--- a/docs/source/policy/resources/ebs.rst
+++ b/docs/source/policy/resources/ebs.rst
@@ -14,6 +14,12 @@ Filters
   .. c7n-schema:: AttachedInstanceFilter
       :module: c7n.resources.ebs
 
+``age``
+  Filter volumes based on their age (source: ``CreateTime``) in days, and/or hours, and/or minutes
+
+  .. c7n-schema:: VolumeAgeFilter
+      :module: c7n.resources.ebs
+
 Actions
 -------
 


### PR DESCRIPTION
This filter (age) is based on the CreateTime of the EBS volume,
which you can express in days / hours / minutes.