### PR TITLE
asg - not-encrypted filter: only get snapshots from provided snap_ids

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -539,6 +539,7 @@ class NotEncryptedFilter(Filter, LaunchConfigFilterBase):
                 raise
             else:
                 return result.get('Snapshots', ())
+        return ()
 
     @staticmethod
     def get_bad_snapshot(e):

--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -528,7 +528,7 @@ class NotEncryptedFilter(Filter, LaunchConfigFilterBase):
 
     def get_snapshots(self, ec2, snap_ids):
         """get snapshots corresponding to id, but tolerant of invalid id's."""
-        while True:
+        while snap_ids:
             try:
                 result = ec2.describe_snapshots(SnapshotIds=snap_ids)
             except ClientError as e:


### PR DESCRIPTION
Related to: https://github.com/capitalone/cloud-custodian/issues/2467

Passing in an empty list when describing snapshots returns all snapshots, causing KeyErrors when the resulting list is passed back. 