### PR TITLE
azure - prevent tagging arm resources directly

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -38,6 +38,9 @@ def update_resource_tags(self, resource, tags):
         )
     # other Azure resources
     else:
+        if self.manager.type == 'armresource':
+            raise NotImplementedError('Can not tag generic ARM resources.')
+
         az_resource = GenericResource.deserialize(resource)
         api_version = self.session.resource_api_version(az_resource.id)
         az_resource.tags = tags

--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -39,7 +39,7 @@ def update_resource_tags(self, resource, tags):
     # other Azure resources
     else:
         if self.manager.type == 'armresource':
-            raise NotImplementedError('Can not tag generic ARM resources.')
+            raise NotImplementedError('Cannot tag generic ARM resources.')
 
         az_resource = GenericResource.deserialize(resource)
         api_version = self.session.resource_api_version(az_resource.id)


### PR DESCRIPTION
The generic arm base class is cool - but if you use its incomplete generic resource representation to call an `Update` on a resource like the tag actions do, terrible things can happen to your resources :: sigh :: 

Blocking people from doing this while we investigate other options.