### PR TITLE
Mail delivery with sendgrid for notify actions though Azure Storage Queue

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -387,7 +387,7 @@ class Notify(BaseNotify):
         message = {
             'event': event,
             'account_id': session.subscription_id,
-            'account': 'subscription',
+            'account': session.subscription_id,
             'region': 'all',
             'policy': self.manager.data}
 

--- a/tools/c7n_azure/c7n_azure/storage_utils.py
+++ b/tools/c7n_azure/c7n_azure/storage_utils.py
@@ -52,11 +52,11 @@ class StorageUtilities(object):
         return queue_service.put_message(queue_name, content)
 
     @staticmethod
-    def get_queue_messages(queue_service, queue_name):
+    def get_queue_messages(queue_service, queue_name, num_messages=None):
         # Default message visibility timeout is 30 seconds
         # so you are expected to delete message within 30 seconds
         # if you have successfully processed it
-        return queue_service.get_messages(queue_name)
+        return queue_service.get_messages(queue_name, num_messages)
 
     @staticmethod
     def delete_queue_message(queue_service, queue_name, message):

--- a/tools/c7n_mailer/c7n_mailer/azure_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_queue_processor.py
@@ -1,0 +1,77 @@
+# Copyright 2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+"""
+Azure Queue Message Processing
+==============================
+
+"""
+import base64
+import json
+import traceback
+import zlib
+
+from c7n_azure.storage_utils import StorageUtilities
+
+from .sendgrid_delivery import SendGridDelivery
+
+
+class MailerAzureQueueProcessor(object):
+
+    def __init__(self, config, logger, max_num_processes=16):
+        self.max_num_processes = max_num_processes
+        self.config = config
+        self.logger = logger
+        self.receive_queue = self.config['queue_url'].split("asq:")[1]
+        self.max_num_of_messages_in_queue_batch = 32
+
+    def run(self, parallel=False):
+        if parallel:
+            print("Parallel processing with Azure Queue is not yet implemented")
+
+        self.logger.info("Downloading messages from the Azure Storage queue.")
+        queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(self.receive_queue)
+        queue_messages = StorageUtilities.get_queue_messages(
+            queue_service, queue_name, self.max_num_of_messages_in_queue_batch)
+
+        while len(queue_messages) > 0:
+            for queue_message in queue_messages:
+                self.logger.debug("Message id: %s received" % queue_message.id)
+                self.process_azure_queue_message(queue_message)
+                StorageUtilities.delete_queue_message(queue_service, queue_name, queue_message)
+
+            queue_messages = StorageUtilities.get_queue_messages(
+                queue_service, queue_name, self.max_num_of_messages_in_queue_batch)
+
+        self.logger.info('No messages left on the azure storage queue, exiting c7n_mailer.')
+        return
+
+    def process_azure_queue_message(self, encoded_azure_queue_message):
+        queue_message = json.loads(
+            zlib.decompress(base64.b64decode(encoded_azure_queue_message.content)))
+
+        self.logger.debug("Got account:%s message:%s %s:%d policy:%s recipients:%s" % (
+            queue_message.get('account', 'na'),
+            encoded_azure_queue_message.id,
+            queue_message['policy']['resource'],
+            len(queue_message['resources']),
+            queue_message['policy']['name'],
+            ', '.join(queue_message['action'].get('to'))))
+
+        # this section sends a notification to the resource owner via SendGrid
+        try:
+            sendgrid_delivery = SendGridDelivery(self.config, self.logger)
+            sendgrid_messages = sendgrid_delivery.get_to_addrs_sendgrid_messages_map(queue_message)
+            sendgrid_delivery.sendgrid_handler(queue_message, sendgrid_messages)
+        except Exception:
+            traceback.print_exc()

--- a/tools/c7n_mailer/c7n_mailer/azure_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/azure_queue_processor.py
@@ -37,7 +37,7 @@ class MailerAzureQueueProcessor(object):
 
     def run(self, parallel=False):
         if parallel:
-            print("Parallel processing with Azure Queue is not yet implemented")
+            self.logger.info("Parallel processing with Azure Queue is not yet implemented")
 
         self.logger.info("Downloading messages from the Azure Storage queue.")
         queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(self.receive_queue)

--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -141,7 +141,8 @@ def main():
     session = session_factory(mailer_config)
     if args_dict.get('update_lambda'):
         if azure(mailer_config):
-            print('not yet implemented')
+            print('\n** Azure functions support not yet implemented. **\n')
+            return
         if args_dict.get('debug'):
             print('\n** --debug is only supported with --run, not --update-lambda **\n')
             return

--- a/tools/c7n_mailer/c7n_mailer/sendgrid_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/sendgrid_delivery.py
@@ -1,0 +1,85 @@
+# Copyright 2018 Capital One Services, LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+# http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+import os
+
+import sendgrid
+import six
+from sendgrid.helpers.mail import Email, Content, Mail
+
+from .utils import (
+    get_message_subject, get_rendered_jinja)
+
+
+class SendGridDelivery(object):
+
+    def __init__(self, config, logger):
+        self.config = config
+        self.logger = logger
+        self.sendgrid_client = sendgrid.SendGridAPIClient(apikey=os.environ.get('SENDGRID_API_KEY'))
+
+    def get_to_addrs_sendgrid_messages_map(self, queue_message):
+        targets = queue_message['action']['to']
+
+        # eg: { ('milton@initech.com', 'peter@initech.com'): [resource1, resource2, etc] }
+        to_addrs_to_resources_map = {tuple(sorted(set(targets))): queue_message['resources']}
+
+        to_addrs_to_content_map = {}
+        for to_addrs, resources in six.iteritems(to_addrs_to_resources_map):
+            to_addrs_to_content_map[to_addrs] = self.get_message_content(
+                queue_message,
+                resources,
+                list(to_addrs)
+            )
+        # eg: { ('milton@initech.com', 'peter@initech.com'): message }
+        return to_addrs_to_content_map
+
+    def get_message_content(self, queue_message, resources, to_addrs):
+        return get_rendered_jinja(
+            to_addrs, queue_message, resources, self.logger, 'template', 'default')
+
+    def sendgrid_handler(self, queue_message, to_addrs_to_email_messages_map):
+        self.logger.info("Sending account:%s policy:%s %s:%s email:%s to %s" % (
+            queue_message.get('account', ''),
+            queue_message['policy']['name'],
+            queue_message['policy']['resource'],
+            str(len(queue_message['resources'])),
+            queue_message['action'].get('template', 'default'),
+            to_addrs_to_email_messages_map))
+
+        from_email = Email(self.config['from_address'])
+        subject = get_message_subject(queue_message)
+        email_format = queue_message['action'].get('template_format', None)
+        if not email_format:
+            email_format = queue_message['action'].get(
+                'template', 'default').endswith('html') and 'html' or 'plain'
+
+        for email_to_addrs, email_content in six.iteritems(to_addrs_to_email_messages_map):
+            for to_address in email_to_addrs:
+                to_email = Email(to_address)
+                content = Content("text/" + email_format, email_content)
+                mail = Mail(from_email, subject, to_email, content)
+                try:
+                    self.sendgrid_client.client.mail.send.post(request_body=mail.get())
+                except Exception as error:
+                    self.logger.warning(
+                        "Error policy:%s account:%s sending to:%s \n\n error:"
+                        " %s\n\n mailer.yml: %s" % (
+                            queue_message['policy'],
+                            queue_message.get('account', ''),
+                            email_to_addrs,
+                            error,
+                            self.config
+                        )
+                    )

--- a/tools/c7n_mailer/requirements.txt
+++ b/tools/c7n_mailer/requirements.txt
@@ -15,3 +15,4 @@ six==1.11.0
 redis
 datadog
 slackclient
+sendgrid


### PR DESCRIPTION
Example of command to run:
c7n-mailer --config samples/mailer.yml --run

Example of policy to put notification message to Azure Storage Queue:
policies:
 - name: test-notify
    resource: azure.resourcegroup
    filters:
      - type: empty-group
    actions:
      - type: notify
        template: default
        subject: Testing the mailer with sendgrid
        to:
          - anzoloch@microsoft.com
          - ana.kaplin@gmail.com
        transport:
          type: asq
          queue: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc

Example of mailer config:
queue_url: asq:https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc
from_address: anastasiia.zolocheska@gmail.com