### PR TITLE
dynamodb - mark-for-op test wasn't actually testing the mark-for-op action + mark-for-op defaults fix

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -555,21 +555,21 @@ class TagDelayedAction(Action):
     The optional 'tz' parameter can be used to adjust the clock to align
     with a given timezone. The default value is 'utc'.
 
+    If neither 'days' nor 'hours' is specified, Cloud Custodian will default
+    to marking the resource for action 4 days in the future.
+
     .. code-block :: yaml
 
       - policies:
-        - name: ec2-stop-marked
+        - name: ec2-mark-for-stop-in-future
           resource: ec2
           filters:
-            - type: marked-for-op
-              # The default tag used is custodian_status
-              # but that is configurable
-              tag: custodian_status
-              op: stop
-              # Another optional tag is skew
-              tz: utc
+            - type: value
+              key: Name
+              value: instance-to-stop-in-four-days
           actions:
-            - stop
+            - type: mark-for-op
+              op: stop
     """
 
     schema = utils.type_schema(
@@ -605,7 +605,7 @@ class TagDelayedAction(Action):
 
     def generate_timestamp(self, days, hours):
         n = datetime.now(tz=self.tz)
-        if days == hours == 0:
+        if days is None or hours is None:
             # maintains default value of days being 4 if nothing is provided
             days = 4
         action_date = (n + timedelta(days=days, hours=hours))

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.DescribeTable_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.DescribeTable_1.json
@@ -2,10 +2,10 @@
     "status_code": 200, 
     "data": {
         "Table": {
-            "TableArn": "arn:aws:dynamodb:us-west-2:644160558196:table/rolltop", 
+            "TableArn": "arn:aws:dynamodb:us-east-1:644160558196:table/c7n-test", 
             "AttributeDefinitions": [
                 {
-                    "AttributeName": "customer_id", 
+                    "AttributeName": "test", 
                     "AttributeType": "S"
                 }
             ], 
@@ -15,29 +15,40 @@
                 "ReadCapacityUnits": 5
             }, 
             "TableSizeBytes": 0, 
-            "TableName": "rolltop", 
+            "TableName": "c7n-test", 
             "TableStatus": "ACTIVE", 
+            "TableId": "192b379a-ecc4-4bd9-8619-916aa281b3e7", 
             "KeySchema": [
                 {
                     "KeyType": "HASH", 
-                    "AttributeName": "customer_id"
+                    "AttributeName": "test"
                 }
             ], 
             "ItemCount": 0, 
             "CreationDateTime": {
-                "hour": 7, 
+                "hour": 9, 
                 "__class__": "datetime", 
-                "month": 6, 
-                "second": 39, 
-                "microsecond": 637000, 
-                "year": 2016, 
-                "day": 26, 
-                "minute": 20
+                "month": 2, 
+                "second": 11, 
+                "microsecond": 50000, 
+                "year": 2018, 
+                "day": 16, 
+                "minute": 7
             }
         }, 
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "JJVG5SPOKF7HD096BRKVUVNIBFVV4KQNSO5AEMVJF66Q9ASUAAJG"
+            "RequestId": "FVT99228ISSGFB7P4DD0QG4F8JVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "FVT99228ISSGFB7P4DD0QG4F8JVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "content-length": "466", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "x-amz-crc32": "3001339236", 
+                "date": "Fri, 08 Jun 2018 22:50:32 GMT", 
+                "content-type": "application/x-amz-json-1.0"
+            }
         }
     }
 }

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.DescribeTable_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.DescribeTable_1.json
@@ -39,14 +39,14 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "FVT99228ISSGFB7P4DD0QG4F8JVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "RequestId": "7GB3UBR2FHP4TAU27100TCKC07VV4KQNSO5AEMVJF66Q9ASUAAJG", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "FVT99228ISSGFB7P4DD0QG4F8JVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "x-amzn-requestid": "7GB3UBR2FHP4TAU27100TCKC07VV4KQNSO5AEMVJF66Q9ASUAAJG", 
                 "content-length": "466", 
                 "server": "Server", 
                 "connection": "keep-alive", 
                 "x-amz-crc32": "3001339236", 
-                "date": "Fri, 08 Jun 2018 22:50:32 GMT", 
+                "date": "Fri, 08 Jun 2018 23:17:24 GMT", 
                 "content-type": "application/x-amz-json-1.0"
             }
         }

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTables_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTables_1.json
@@ -4,14 +4,14 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "2A9GSSSDHU8CLMB4JM54UML6C3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "RequestId": "GOQ5TJ3H3EJ9KQ005NST3J4IPFVV4KQNSO5AEMVJF66Q9ASUAAJG", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "2A9GSSSDHU8CLMB4JM54UML6C3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "x-amzn-requestid": "GOQ5TJ3H3EJ9KQ005NST3J4IPFVV4KQNSO5AEMVJF66Q9ASUAAJG", 
                 "content-length": "51", 
                 "server": "Server", 
                 "connection": "keep-alive", 
                 "x-amz-crc32": "650458758", 
-                "date": "Fri, 08 Jun 2018 22:50:31 GMT", 
+                "date": "Fri, 08 Jun 2018 23:17:24 GMT", 
                 "content-type": "application/x-amz-json-1.0"
             }
         }, 

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTables_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTables_1.json
@@ -2,11 +2,21 @@
     "status_code": 200, 
     "data": {
         "ResponseMetadata": {
+            "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "1K86DP6MB03RQURBT2423496GNVV4KQNSO5AEMVJF66Q9ASUAAJG"
+            "RequestId": "2A9GSSSDHU8CLMB4JM54UML6C3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "2A9GSSSDHU8CLMB4JM54UML6C3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "content-length": "51", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "x-amz-crc32": "650458758", 
+                "date": "Fri, 08 Jun 2018 22:50:31 GMT", 
+                "content-type": "application/x-amz-json-1.0"
+            }
         }, 
         "TableNames": [
-            "rolltop"
+            "c7n-test"
         ]
     }
 }

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_1.json
@@ -4,14 +4,14 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "9BM82VV03362IBBFICNL36GDP3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "RequestId": "IF5IL5I0JQA7E3HIL0CA6F27ERVV4KQNSO5AEMVJF66Q9ASUAAJG", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "9BM82VV03362IBBFICNL36GDP3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "x-amzn-requestid": "IF5IL5I0JQA7E3HIL0CA6F27ERVV4KQNSO5AEMVJF66Q9ASUAAJG", 
                 "content-length": "11", 
                 "server": "Server", 
                 "connection": "keep-alive", 
                 "x-amz-crc32": "1756070277", 
-                "date": "Fri, 08 Jun 2018 22:50:32 GMT", 
+                "date": "Fri, 08 Jun 2018 23:17:25 GMT", 
                 "content-type": "application/x-amz-json-1.0"
             }
         }, 

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_1.json
@@ -4,20 +4,17 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "57BIJH9PBVC3ERAISL5M6I2DBNVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "RequestId": "9BM82VV03362IBBFICNL36GDP3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "57BIJH9PBVC3ERAISL5M6I2DBNVV4KQNSO5AEMVJF66Q9ASUAAJG", 
-                "date": "Tue, 31 Jan 2017 19:34:51 GMT", 
-                "content-length": "160", 
-                "content-type": "application/x-amz-json-1.0", 
-                "x-amz-crc32": "2210834338"
+                "x-amzn-requestid": "9BM82VV03362IBBFICNL36GDP3VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "content-length": "11", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "x-amz-crc32": "1756070277", 
+                "date": "Fri, 08 Jun 2018 22:50:32 GMT", 
+                "content-type": "application/x-amz-json-1.0"
             }
         }, 
-        "Tags": [
-            {
-                "Value": "test_value", 
-                "Key": "test_key"
-            }
-        ]
+        "Tags": []
     }
 }

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_2.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_2.json
@@ -4,20 +4,20 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "3J8JU0PJ73TOS4DKKPKHUJ0QANVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "RequestId": "V1QVBPF0LUUBBM9MQIDKSNM13NVV4KQNSO5AEMVJF66Q9ASUAAJG", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "3J8JU0PJ73TOS4DKKPKHUJ0QANVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "x-amzn-requestid": "V1QVBPF0LUUBBM9MQIDKSNM13NVV4KQNSO5AEMVJF66Q9ASUAAJG", 
                 "content-length": "88", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "x-amz-crc32": "2705876837", 
-                "date": "Fri, 08 Jun 2018 22:50:33 GMT", 
+                "x-amz-crc32": "547662945", 
+                "date": "Fri, 08 Jun 2018 23:17:26 GMT", 
                 "content-type": "application/x-amz-json-1.0"
             }
         }, 
         "Tags": [
             {
-                "Value": "Resource does not meet policy: delete@2018/06/12", 
+                "Value": "Resource does not meet policy: delete@2018/06/08", 
                 "Key": "test_tag"
             }
         ]

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_2.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.ListTagsOfResource_2.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3J8JU0PJ73TOS4DKKPKHUJ0QANVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "3J8JU0PJ73TOS4DKKPKHUJ0QANVV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "content-length": "88", 
+                "server": "Server", 
+                "connection": "keep-alive", 
+                "x-amz-crc32": "2705876837", 
+                "date": "Fri, 08 Jun 2018 22:50:33 GMT", 
+                "content-type": "application/x-amz-json-1.0"
+            }
+        }, 
+        "Tags": [
+            {
+                "Value": "Resource does not meet policy: delete@2018/06/12", 
+                "Key": "test_tag"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.TagResource_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.TagResource_1.json
@@ -4,13 +4,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "TMR3Q9FEPUDRD44T0IKB9A5AH7VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "RequestId": "1VO5LDRJPIQDUOJELT6TLTLR37VV4KQNSO5AEMVJF66Q9ASUAAJG", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "TMR3Q9FEPUDRD44T0IKB9A5AH7VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "x-amzn-requestid": "1VO5LDRJPIQDUOJELT6TLTLR37VV4KQNSO5AEMVJF66Q9ASUAAJG", 
                 "content-length": "0", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Tue, 31 Jan 2017 21:19:35 GMT", 
+                "date": "Fri, 08 Jun 2018 22:50:32 GMT", 
                 "content-type": "application/x-amz-json-1.0"
             }
         }

--- a/tests/data/placebo/test_dynamodb_mark/dynamodb.TagResource_1.json
+++ b/tests/data/placebo/test_dynamodb_mark/dynamodb.TagResource_1.json
@@ -4,13 +4,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "1VO5LDRJPIQDUOJELT6TLTLR37VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+            "RequestId": "AT4A2KUKQ46RKDCU4RBRCQ6TD7VV4KQNSO5AEMVJF66Q9ASUAAJG", 
             "HTTPHeaders": {
-                "x-amzn-requestid": "1VO5LDRJPIQDUOJELT6TLTLR37VV4KQNSO5AEMVJF66Q9ASUAAJG", 
+                "x-amzn-requestid": "AT4A2KUKQ46RKDCU4RBRCQ6TD7VV4KQNSO5AEMVJF66Q9ASUAAJG", 
                 "content-length": "0", 
                 "server": "Server", 
                 "connection": "keep-alive", 
-                "date": "Fri, 08 Jun 2018 22:50:32 GMT", 
+                "date": "Fri, 08 Jun 2018 23:17:26 GMT", 
                 "content-type": "application/x-amz-json-1.0"
             }
         }


### PR DESCRIPTION
Resolves: https://github.com/capitalone/cloud-custodian/issues/2489

Was looking into a tagging issue regarding dynamodb and found that the previous test asserted that `test_key` existed on the resource, but the resource contained the tag prior to the actual test so the assert wasn't actually testing the mark-for-op functionality.

This PR also fixes the default behavior of missing a days/hours option in mark-for-op. Previously, c7n defaulted to 4 days if `days == None`. The PR https://github.com/capitalone/cloud-custodian/pull/2012 checked for 0 rather than None, even though 0 is a valid input for mark-for-op days/hours.