### PR TITLE
iam-user - Delete in-line user policies

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1158,6 +1158,7 @@ class UserDelete(BaseAction):
     ORDERED_OPTIONS = OrderedDict([
         ('console-access', 'delete_console_access'),
         ('access-keys', 'delete_access_keys'),
+        ('user-policies', 'delete_attached_user_policies'),
         ('attached-user-policies', 'delete_attached_user_policies'),
         ('inline-user-policies', 'delete_inline_user_policies'),
         ('mfa-devices', 'delete_hw_mfa_devices'),

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1157,6 +1157,7 @@ class UserDelete(BaseAction):
     ORDERED_OPTIONS = OrderedDict([
         ('console-access', 'delete_console_access'),
         ('access-keys', 'delete_access_keys'),
+        ('attached-user-policies', 'delete_attached_user_policies'),
         ('user-policies', 'delete_user_policies'),
         ('mfa-devices', 'delete_hw_mfa_devices'),
         ('groups', 'delete_groups'),
@@ -1189,6 +1190,7 @@ class UserDelete(BaseAction):
         'iam:DeleteSigningCertificate',
         'iam:DeleteSSHPublicKey',
         'iam:DeleteUser',
+        'iam:DeleteUserPolicy',
         'iam:DetachUserPolicy',
         'iam:RemoveUserFromGroup')
 
@@ -1209,11 +1211,18 @@ class UserDelete(BaseAction):
                                      AccessKeyId=access_key['AccessKeyId'])
 
     @staticmethod
-    def delete_user_policies(client, r):
+    def delete_attached_user_policies(client, r):
         response = client.list_attached_user_policies(UserName=r['UserName'])
         for user_policy in response['AttachedPolicies']:
             client.detach_user_policy(
                 UserName=r['UserName'], PolicyArn=user_policy['PolicyArn'])
+
+    @staticmethod
+    def delete_user_policies(client, r):
+        response = client.list_user_policies(UserName=r['UserName'])
+        for user_policy_name in response['PolicyNames']:
+            client.delete_user_policy(
+                UserName=r['UserName'], PolicyName=user_policy_name)
 
     @staticmethod
     def delete_hw_mfa_devices(client, r):

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1109,7 +1109,8 @@ class UserDelete(BaseAction):
             - delete
 
     Additionally, you can specify the options to delete properties of an iam-user,
-    including console-access, access-keys, user-policies, mfa-devices, groups,
+    including console-access, access-keys, attached-user-policies,
+    inline-user-policies, mfa-devices, groups,
     ssh-keys, signing-certificates, and service-specific-credentials.
 
     Note: using options will _not_ delete the user itself, only the items specified
@@ -1158,7 +1159,7 @@ class UserDelete(BaseAction):
         ('console-access', 'delete_console_access'),
         ('access-keys', 'delete_access_keys'),
         ('attached-user-policies', 'delete_attached_user_policies'),
-        ('user-policies', 'delete_user_policies'),
+        ('inline-user-policies', 'delete_inline_user_policies'),
         ('mfa-devices', 'delete_hw_mfa_devices'),
         ('groups', 'delete_groups'),
         ('ssh-keys', 'delete_ssh_keys'),
@@ -1218,7 +1219,7 @@ class UserDelete(BaseAction):
                 UserName=r['UserName'], PolicyArn=user_policy['PolicyArn'])
 
     @staticmethod
-    def delete_user_policies(client, r):
+    def delete_inline_user_policies(client, r):
         response = client.list_user_policies(UserName=r['UserName'])
         for user_policy_name in response['PolicyNames']:
             client.delete_user_policy(

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1158,7 +1158,7 @@ class UserDelete(BaseAction):
     ORDERED_OPTIONS = OrderedDict([
         ('console-access', 'delete_console_access'),
         ('access-keys', 'delete_access_keys'),
-        ('user-policies', 'delete_attached_user_policies'),
+        ('user-policies', 'delete_attached_user_policies'), # keep this for backwards-compatibility
         ('attached-user-policies', 'delete_attached_user_policies'),
         ('inline-user-policies', 'delete_inline_user_policies'),
         ('mfa-devices', 'delete_hw_mfa_devices'),
@@ -1275,7 +1275,11 @@ class UserDelete(BaseAction):
             self.process_user(client, r)
 
     def process_user(self, client, r):
-        user_options = self.data.get('options', list(self.ORDERED_OPTIONS.keys()))
+        # filter out options that yield the same operation,
+        # see definition of ORDERED_OPTIONS above
+        default_options = {v: k for k, v in self.ORDERED_OPTIONS.items()}.values()
+
+        user_options = self.data.get('options', list(default_options))
         for cmd in self.ORDERED_OPTIONS:
             if cmd in user_options:
                 op = getattr(self, self.ORDERED_OPTIONS[cmd])

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1158,7 +1158,8 @@ class UserDelete(BaseAction):
     ORDERED_OPTIONS = OrderedDict([
         ('console-access', 'delete_console_access'),
         ('access-keys', 'delete_access_keys'),
-        ('user-policies', 'delete_attached_user_policies'), # keep this for backwards-compatibility
+        # keep 'user-policies' for backwards-compatibility
+        ('user-policies', 'delete_attached_user_policies'),
         ('attached-user-policies', 'delete_attached_user_policies'),
         ('inline-user-policies', 'delete_inline_user_policies'),
         ('mfa-devices', 'delete_hw_mfa_devices'),

--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -1176,7 +1176,7 @@ class UserDelete(BaseAction):
             'type': 'array',
             'items': {
                 'type': 'string',
-                'enum': list(ORDERED_OPTIONS.keys() + COMPOUND_OPTIONS.keys()),
+                'enum': list(ORDERED_OPTIONS.keys()) + list(COMPOUND_OPTIONS.keys()),
             }
         })
 

--- a/tests/data/placebo/test_iam_user_delete/iam.ListUserPolicies_1.json
+++ b/tests/data/placebo/test_iam_user_delete/iam.ListUserPolicies_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "PolicyNames": [], 
+        "IsTruncated": false, 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "8845c98a-b414-11e7-bd64-7d523ade9cf4", 
+            "HTTPHeaders": {
+                "x-amzn-requestid": "8845c98a-b414-11e7-bd64-7d523ade9cf4", 
+                "date": "Wed, 18 Oct 2017 14:56:33 GMT", 
+                "content-length": "360", 
+                "content-type": "text/xml"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Currently delete_user only detaches managed user policies, but not inline policies belonging to the user. When deleting a user, user policies must be deleted as well.
Otherwise it will fail with:
```[ERROR]	2018-06-13T08:43:34.435Z	d7de5b44-6ee5-11e8-b1ce-c53830de9f18	Error while executing policy
Traceback (most recent call last):
File "/var/task/c7n/policy.py", line 261, in run
results = a.process(resources)
File "/var/task/c7n/resources/iam.py", line 1264, in process
self.process_user(client, r)
File "/var/task/c7n/resources/iam.py", line 1275, in process_user
self.delete_user(client, r)
File "/var/task/c7n/resources/iam.py", line 1257, in delete_user
client.delete_user(UserName=r['UserName'])
File "/var/runtime/botocore/client.py", line 314, in _api_call
return self._make_api_call(operation_name, kwargs)
File "/var/runtime/botocore/client.py", line 612, in _make_api_call
raise error_class(parsed_response, operation_name)
DeleteConflictException: An error occurred (DeleteConflict) when calling the DeleteUser operation: Cannot delete entity, must delete policies first.
```