### PR TITLE
aws.shield - elastic ip type fix, error handling if shield is not enabled

### DIFF
--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -57,8 +57,15 @@ def get_protections_paginator(client):
 
 
 def get_type_protections(client, model):
-    protections = get_protections_paginator(
-        client).paginate().build_full_result().get('Protections')
+    try:
+        protections = get_protections_paginator(
+            client).paginate().build_full_result().get('Protections')
+    except ClientError as e:
+        # shield is not enabled in the account, so all resources are not protected
+        if e.response['Error']['Code'] == 'ResourceNotFoundException':
+            return []
+        else:
+            raise
     return [p for p in protections if model.type in p['ResourceArn']]
 
 

--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -60,12 +60,9 @@ def get_type_protections(client, model):
     try:
         protections = get_protections_paginator(
             client).paginate().build_full_result().get('Protections')
-    except ClientError as e:
+    except client.exceptions.ResourceNotFoundException:
         # shield is not enabled in the account, so all resources are not protected
-        if e.response['Error']['Code'] == 'ResourceNotFoundException':
-            return []
-        else:
-            raise
+        return []
     return [p for p in protections if model.type in p['ResourceArn']]
 
 

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1492,7 +1492,7 @@ class NetworkAddress(query.QueryResourceManager):
 
     class resource_type(object):
         service = 'ec2'
-        type = 'network-addr'
+        type = 'eip-allocation'
         enum_spec = ('describe_addresses', 'Addresses', None)
         name = 'PublicIp'
         id = 'AllocationId'
@@ -1510,7 +1510,7 @@ class NetworkAddress(query.QueryResourceManager):
                 self.get_model().service,
                 region=self.config.region,
                 account_id=self.account_id,
-                resource_type='eip-allocation',
+                resource_type=self.type,
                 separator='/')
         return self._generate_arn
 


### PR DESCRIPTION
addresses: https://github.com/capitalone/cloud-custodian/issues/2529
adds error handling if shield is not enabled in the account

Didn't want to snowflake out elastic ip's specifically when resolving resources from `list_protections`, I don't see any regressions from running the test suite locally