### PR TITLE
filters - lookup for value_from once instead of per resource in case where jmespath returns None

### DIFF
--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -422,7 +422,7 @@ class ValueFilter(Filter):
     def match(self, i):
         if self.v is None and len(self.data) == 1:
             [(self.k, self.v)] = self.data.items()
-        elif self.v is None and not hasattr(self, 'content_semaphore'):
+        elif self.v is None and not hasattr(self, 'content_initialized'):
             self.k = self.data.get('key')
             self.op = self.data.get('op')
             if 'value_from' in self.data:
@@ -430,7 +430,7 @@ class ValueFilter(Filter):
                 self.v = values.get_values()
             else:
                 self.v = self.data.get('value')
-            self.content_semaphore = True
+            self.content_initialized = True
             self.vtype = self.data.get('value_type')
 
         if i is None:

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -422,7 +422,7 @@ class ValueFilter(Filter):
     def match(self, i):
         if self.v is None and len(self.data) == 1:
             [(self.k, self.v)] = self.data.items()
-        elif self.v is None:
+        elif self.v is None and not hasattr(self, 'content_semaphore'):
             self.k = self.data.get('key')
             self.op = self.data.get('op')
             if 'value_from' in self.data:
@@ -430,6 +430,7 @@ class ValueFilter(Filter):
                 self.v = values.get_values()
             else:
                 self.v = self.data.get('value')
+            self.content_semaphore = True
             self.vtype = self.data.get('value_type')
 
         if i is None:

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -18,11 +18,14 @@ import io
 import jmespath
 import json
 import os.path
+import logging
 from six import text_type
 from six.moves.urllib.request import urlopen
 from six.moves.urllib.parse import parse_qsl, urlparse
 
 from c7n.utils import format_string_values
+
+log = logging.getLogger('custodian.resolver')
 
 
 class URIResolver(object):
@@ -134,7 +137,10 @@ class ValuesFrom(object):
         if format == 'json':
             data = json.loads(contents)
             if 'expr' in self.data:
-                return jmespath.search(self.data['expr'], data)
+                res = jmespath.search(self.data['expr'], data)
+                if res is None:
+                    log.warning('ValueFilter: %s key returned None' % self.data['expr'])
+                return res
         elif format == 'csv' or format == 'csv2dict':
             data = csv.reader(io.StringIO(contents))
             if format == 'csv2dict':
@@ -144,7 +150,10 @@ class ValuesFrom(object):
                     return [d[self.data['expr']] for d in data]
                 data = list(data)
             if 'expr' in self.data:
-                return jmespath.search(self.data['expr'], data)
+                res = jmespath.search(self.data['expr'], data)
+                if res is None:
+                    log.warning('ValueFilter: %s key returned None' % self.data['expr'])
+                return res
             return data
         elif format == 'txt':
             return [s.strip() for s in io.StringIO(contents).readlines()]

--- a/c7n/resolver.py
+++ b/c7n/resolver.py
@@ -139,7 +139,7 @@ class ValuesFrom(object):
             if 'expr' in self.data:
                 res = jmespath.search(self.data['expr'], data)
                 if res is None:
-                    log.warning('ValueFilter: %s key returned None' % self.data['expr'])
+                    log.warning('ValueFrom filter: %s key returned None' % self.data['expr'])
                 return res
         elif format == 'csv' or format == 'csv2dict':
             data = csv.reader(io.StringIO(contents))
@@ -152,7 +152,7 @@ class ValuesFrom(object):
             if 'expr' in self.data:
                 res = jmespath.search(self.data['expr'], data)
                 if res is None:
-                    log.warning('ValueFilter: %s key returned None' % self.data['expr'])
+                    log.warning('ValueFrom filter: %s key returned None' % self.data['expr'])
                 return res
             return data
         elif format == 'txt':

--- a/tests/test_filters.py
+++ b/tests/test_filters.py
@@ -145,6 +145,18 @@ class TestValueFilter(unittest.TestCase):
         res = vf.process_value_type(sentinel, value, resource)
         self.assertEqual(res, (None, 4))
 
+    def test_value_match(self):
+        resource = {"a": 1, "Tags": [{"Key": "xtra", "Value": "hello"}]}
+        vf = filters.factory({"type": "value", "value": None, "key": "tag:xtra"})
+        self.assertFalse(hasattr(vf, "content_initialized"))
+        self.assertEqual(vf.v, None)
+
+        res = vf.match(resource)
+
+        self.assertTrue(vf.content_initialized)
+        self.assertEqual(vf.v, None)
+        self.assertFalse(res)
+
 
 class TestAgeFilter(unittest.TestCase):
 


### PR DESCRIPTION
When executing a policy with a value from filter, if the value returned by a jmespath search is null/None, the policy will attempt to retrieve the contents from the file for each resource. This can result in inconsistent behavior: 
- if the value of the jmespath search is None and later becomes a value during the policy execution, there is inconsistency on how the resources in an account are evaluated. In this case, `self.v` should be static during the evaluation of the filter.
- Results in long executions if the value of a lookup is supposed to be "null" as each lookup will open the file (remotely in s3 or on disk) and do the jmespath search.
- None is a often-used value when doing things like tag-compliance policies, in the current case this would also save a few additional calls as `self.v = self.data.get('value')` would only be called once per value filter instead of once per resource.

This PR introduces a content_semaphore attr in the Filter object to prevent multiple lookups of a value during runtime and logging when the jmespath search returns None as it is not a typical use-case and is likely a result of an error on the path or in the file used in the `value_from` filter.