### PR TITLE
Fix build with new Azure Storage package

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,6 +3,9 @@ install:
 	python -m virtualenv --python python2.7 .
 	. bin/activate && pip install -r requirements-dev.txt
 	. bin/activate && pip install -e .
+	. bin/activate && pip install -r tools/c7n_mailer/requirements.txt
+    . bin/activate && pip install -r tools/c7n_azure/requirements.txt
+    . bin/activate && pip install -r tools/c7n_gcp/requirements.txt
 
 coverage:
 	rm -Rf .coverage

--- a/Makefile
+++ b/Makefile
@@ -4,8 +4,8 @@ install:
 	. bin/activate && pip install -r requirements-dev.txt
 	. bin/activate && pip install -e .
 	. bin/activate && pip install -r tools/c7n_mailer/requirements.txt
-    . bin/activate && pip install -r tools/c7n_azure/requirements.txt
-    . bin/activate && pip install -r tools/c7n_gcp/requirements.txt
+	. bin/activate && pip install -r tools/c7n_azure/requirements.txt
+	. bin/activate && pip install -r tools/c7n_gcp/requirements.txt
 
 coverage:
 	rm -Rf .coverage

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -32,9 +32,10 @@ setup(
         "custodian.resources": [
             'azure = c7n_azure.entry:initialize_azure']
     },
-    install_requires=["azure",
+    install_requires=["azure-mgmt",
+                      "azure-storage-blob",
+                      "azure-storage-queue",
                       "c7n",
-                      "click",
                       "azure-cli-core",
                       "adal~=0.5.0",
                       "backports.functools_lru_cache",

--- a/tools/c7n_azure/tests/cassettes/NotifyTest.test_notify_though_storage_queue.yaml
+++ b/tools/c7n_azure/tests/cassettes/NotifyTest.test_notify_though_storage_queue.yaml
@@ -6,8 +6,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.27 msrest_azure/0.4.24 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -18,41 +18,63 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
         alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
-        epp/XlfrVXO3zZv2928E7N1VXV0Ws7xu7n5RTOuqqc7bsXZ5V9scT6fVetk2d6fTVj+6/jR7e/2L
-        VtnFrL1XEWo6qOEG7fUKDW7sg5qW1TTD4Kg5od3Op/myrbNyje/a7KIBEd/QKy+yRf4pNaLffzIj
-        In9K39Pv/PmB9/mBfI6Pd72Pd72Pd/zPd9wXe97ne+7je97H99zH+97H++7j+97H993HD7yPH7iP
-        H3ofPwQb0ASt8pr4gwe+zNurqn57PC35z8n1Kmvot4+Of7Cu89d5fVlMqeHoo8uibtdZ+UKav1qX
-        9Omj732fmGjl/THLz7N12R5Pld7HZVldodO2XjdtPnta1PmUJog7/95HD/bOHx4cTM63Dz49393e
-        383Otx/uZpPtvdmD6Wxnd3c22X/wEYFt1qtVVbfNt9t21byps/PzYvrlsrz+6NF5Vjb56KN8Oa2v
-        mYMxiMagTb+fFyXxyS+mFtmkzInhCRN6ocya9lQ+elMwq+3t7B5s79zf3tl/s/vpo92DR/fuj+/f
-        //Te7qcPfgojmJTV5BsARJDe5tevWXyocY9/0RXN0GXR0GCK5QUJcIuGr9fTaZ7PqOPRR9M6Z4be
-        0OH+QxLYB7s/Ra1XdbHI6uvT5WxVFZAIGoQM5qM56Pno7pAcjtFsPK3qfHxFuqO6asbELncJ5i9a
-        51BCNwLgdlEILUh2CwjcLgpBZvZGAGgWeZ/JzIR5vkE9NET9dfPl+UtpSk2yy6wogROmkljt/y06
-        OFv+oCJFN9+GMt6+XLyXHjYv493LxazILh7ehzrTYQ19/SMdzB//SAd/szp4f3v3wZu93Ud7Dx7t
-        3Rvf39+/t7ezQ6rzvXXwECCC9LOjg8MO9w92HzzcuX9LHRwVsttr4Pjr3Cr6fgty3fg+t4q+L3N6
-        w+toFHmbycsE+f+H7sWgf//3VLn79xe/aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv/NKl0iC2H9I120
-        QYU8fLP78NHO3qPd/fGn+wfEB/ukQr6OLooCIkg/a7rI73Bn9/7Op7dURXHeu70uGnifm0UBtKDX
-        zQC4WRSAzOpN76NV5HWmMBPl/x/qiLq43l5dt/NquX2+Xk7fSy/hZXkXrxJWOp7e519PD12Rqlw3
-        cLtUAcEvYu/uR17fz29Ny/Hrzs6j+58+2j8Y39vZu7dznxQWjQB65xsARJB+djRt2OHe3v7uwwcH
-        t1S1oVjdXsV23uOvoy+2INDwi/x19EWZvqH38G3kNSYhD9pTpU7mf17qUDjDBw+ho3RYQ19/QxqV
-        yELI/kjRDOuH3ftvdu9RhPbo/sPx3r2H+/f2H5J++BqKJg6IIP1sKRq/w90Hnz68t0/xLKCxPN1e
-        0SjTfV19Y17nVtH3W5Drxve5VfR9mdMbXkejyNtMXibI11BC3/8l/w/yBbS3YxkAAA==
+        epp/XlfrFb2znF1vl8Vy/W57Wi3brFjm9e7dVV1dFrO8bu5+UUzrqqnO27H2fbeRn8fTabVets1d
+        ftm9S7jpqPpftNcrfHEjTGpaVtMMo6LmV3nTrvFZm100RDUiB+G3ymuiE/7+aJm3V1X99nha8p+T
+        61XW0G8fHf9gXeev8/qymFLD0UeXRd2us/KFNH+1LunTR9/7PhFz5f0xy8+zddkeT7X747KsrjAH
+        bb1u2nz2tKjzKeHLnX/vowd75w8PDibn2wefnu9u7+9m59sPd7PJ9t7swXS2s7s7m+w/+IjANuvV
+        qqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zyTGERj0Kbfz4uSyPaLqUU2KXOaeMKEXiiz
+        pj2Vj94UTPG9nd2D7Z1Pt3fvv9nbfbT34NG9++MHOw93H+x8+lMYwaSsJt8AIIL0Nr9+zWxEjXvT
+        ia5ohi6LhgZTLC+IkVs0fL2eTvN8Rh2PPprWOc/vhg7v33twb+fezk9R61VdLLL6+nQ5W1UFGIQG
+        IYP5aA56PrrbZcMxvh5PqzofX5HsVFfNmNjkLsH6RescQjj4In8ffbMFiTa8yd9H35QZHHwRX0fe
+        YzLywJ9HpKEhqq6bL89fShP6KrvMihI4YIqIhf5fpWOmJDzVrMiW995Lu+Bd9+rBXv4pIaZDin73
+        Ix3zw9Exe7tvdg8e7ew+2r8/3tn59P79/YekGr6GjokDIkg/WzrGdbg/frC/8/DevQe31DF9hru9
+        mom8y02iL7cg1OaXuUn0ZZnKTe+iReRVJikT4f/b+oYk6Dxbnq+XLF4tDeC9VE7/dcJNRxX97kcq
+        54ekcu6/2f300f2Hj3Yfjvd3P93Z24M38nVUThQQQfpZUzleh3sPd3ce7uzfUuXQ1HQY7vYqJ/Iu
+        N4m+3IJQm1/mJtGXZSo3vYsWkVeZpEyE/2+rHIzx91dxfy9lM522+tH1p9nb61+0yi5m7b2KUNNB
+        DTf4emqH0G7n03zZ1lnJRFb189Gb7OJFtsh3qQ39+pMZhaqI2eh3fLznfbznPr7nfXzPfbzvfbzv
+        Pr7vfXxfPs7x+afe5/Dh6Hd8/MD7+IF8zM0PvM8P5HN8/ND7+KH7eHfH+5z+IDagCfqRnh1Sj/e3
+        d/ahrchHQhB2/9N7u5+Sg0QjgOL5BgARpJ8dPRt2uP+QBJb0OoCx+tikZgek7Pa6dggAt4tCaEGx
+        W0DgdlEIMrE3AkCzyPtMZSaMp3p72uH/Oyo4W/6gIj0334Yu3r5cvJcaNi/j3csFecoXD+9D++mw
+        hr7+kQqmz3+kgr9pFby/vftA82B798b39/fv7e1QHoxGAH30DQAiSD87KjjscP9g9wEF84DF2mOT
+        Bo6K2O31b/x1bhV9vwWxbnyfW0Xflxm94XU0irzNxGWC/P9D82LQv/97Ktz9+4tfNL3IHqzeNldF
+        k3FG9HJBSOlwBr//kcqlz3+kcn8WVO7DN7sPH+3sPdrdH3+6f0AMTzE6jQAq6BsARJB+1lSu3+HO
+        7n0s0gAY641NOjcuZLdXugPvc7MogBb0uhkAN4sCkFm96X20irzOFGai/P9E72YX29lsJg5vXl/l
+        5XT+XkqYAND7eF3fJuR0WLGvvp7q9WlLUMGHRBRC8+ebMiKeuaUOoXXQgzd7O4/2dx/de0iR84OD
+        B3u7pEPeWxkNASJIPzvKKOxwf+fB/t6De7fURsQcIcvdXhH1X+UW0XdbkGnju9wi+i4Uy8ZX0SDy
+        JpOTCeBpHl8w/r+jdKZltZ651dz30jf8rn2VkNLh9D7/eppG8sbw02hiwGFEB0LvR3pmg3og1+EA
+        0dr9nfHDvft7+5/ukXr4OnomCogg/azpGa/Dg0/3Du49vK3XE3Lb7ZVM5z3+OvpiCwINv8hfR1+U
+        6Rt6D99GXmMS8qA93eJE4f87moW9tymtF2XFMq/vvZdm6bz7cGcXoZOOKf7lN6RjEGRxwEVf0q8S
+        b9HX9Ds+/lEE+fNIme6/2bv3aHf30f09pL52DvaRa/s6yjQKiCD9rClTr0NS3Z8+vH9LXRoRrdsr
+        1NjL3Cb6dgtK3fA2t4m+LZO58WU0ibzLVGVC/H9cv1IX11/TccOr9s3dg7170EI6ouh335ByJXIQ
+        mj/SORtUxf03e3uP7h88IgY+2Nv5dBeiSyOAEH4DgAjSz5rO8Tp8sPfpwcHe7ZcKuhx3e50TeZeb
+        RF9uQajNL3OT6MsylZveRYvIq0xSJsL/HxTO6rqdV8vt8/Vy+t4qR97Fq4SVjqf3+TekauDqsNtD
+        X9Kv4vXQ1/Q7Pv6RH/fzRafe397Zf7Oz8+j+p4/2D8b3dvbu7dyn0JJGACXzDQAiSD87OjXscG9v
+        f/fhvYf2OXgP7eoE7P00q/cefx19sQWphl/kr6MvykQOvYdvI68xMXnQP9KmeBevkgm6OHgI7abD
+        Gvr6R7qVfsfHP9Kt35BuJa9v994jCjbvPxzv3Xu4f2+fvD4aAdTMNwCIIP1s6Va/w90Hnz68t0tK
+        VZ+vp1tVzr6uijWvc6vo+y0Id+P73Cr6vszuDa+jUeRtJjQT5P/jeneSNcV0W5l+e1W+Z+jMr+vb
+        3koRIahDG27wDWlfIg4h/COlNKRLPt3e232z++DRvU8f7XC+7T5l3EiXvLdSGgJEkH52lFKnw517
+        93ZvHUQPsN3tldEQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMmJ8VlXSTSiK5IRb6JlQSLwx9zVTe
+        Mr/i5uA1j2ZEXNVHww1+pI9+WPpoh9Px+492Px3vPdjdfbCPuPHr6KMoIIL0s6aPvA4p+tx5sEMr
+        F4DGYrdJHw2w3e310RAAbheF0IJkt4DA7aIQZGZvBIBmkfeZzEyY/4/rI+rCW1nYey99hHfdq9mn
+        M8R0OqTodz/SQj8kLbR7gGTSvYckzuOHB/cf7DzcI+XxNbRQHBBB+tnSQkGHOw8+3d0lNwzQWJA2
+        aaE+x91eAUXe5SbRl1sQavPL3CT6skzlpnfRIvIqk5SJ8DU0zvd/yf8DoFf+RcJIAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1303']
+      content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 29 May 2018 19:56:25 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [a521ab01-1154-4121-82da-46be4ddd8463]
-      x-ms-original-request-ids: [4cf60509-0889-40da-8b2c-3f6c430b45dd, 80c13615-2bce-4dfd-abce-2d34cc209f53]
+      x-ms-correlation-request-id: [4838f0b5-aefa-41fa-89b2-8d54ea018576]
+      x-ms-original-request-ids: [abe9efc7-87b6-4d51-8465-e999952e9e5f, a4a49f76-6a4c-485d-a322-a8b85dcd9dbd,
+        999c4516-0034-4a0b-9993-aaf2e562cf46, f009ff26-1e94-4a4d-bf63-3e8f5ce3625b]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [a521ab01-1154-4121-82da-46be4ddd8463]
-      x-ms-routing-request-id: ['WESTUS2:20180529T195626Z:a521ab01-1154-4121-82da-46be4ddd8463']
+      x-ms-request-id: [4838f0b5-aefa-41fa-89b2-8d54ea018576]
+      x-ms-routing-request-id: ['WESTUS2:20180627T141911Z:4838f0b5-aefa-41fa-89b2-8d54ea018576']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -61,8 +83,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.27 msrest_azure/0.4.24 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 keyvaultmanagementclient/0.40.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
@@ -80,16 +102,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['295']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 29 May 2018 19:56:26 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [0d1defc1-9579-43f9-80d4-0cf1661937a9]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [0d1defc1-9579-43f9-80d4-0cf1661937a9]
-      x-ms-routing-request-id: ['WESTUS2:20180529T195626Z:0d1defc1-9579-43f9-80d4-0cf1661937a9']
+      x-ms-correlation-request-id: [7f3f4939-e6a3-441f-a998-4989b8dec867]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [7f3f4939-e6a3-441f-a998-4989b8dec867]
+      x-ms-routing-request-id: ['WESTUS2:20180627T141912Z:7f3f4939-e6a3-441f-a998-4989b8dec867']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -98,8 +120,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.27 msrest_azure/0.4.24 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -110,41 +132,63 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
         alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
-        epp/XlfrVXO3zZv2928E7N1VXV0Ws7xu7n5RTOuqqc7bsXZ5V9scT6fVetk2d6fTVj+6/jR7e/2L
-        VtnFrL1XEWo6qOEG7fUKDW7sg5qW1TTD4Kg5od3Op/myrbNyje/a7KIBEd/QKy+yRf4pNaLffzIj
-        In9K39Pv/PmB9/mBfI6Pd72Pd72Pd/zPd9wXe97ne+7je97H99zH+97H++7j+97H993HD7yPH7iP
-        H3ofPwQb0ASt8pr4gwe+zNurqn57PC35z8n1Kmvot4+Of7Cu89d5fVlMqeHoo8uibtdZ+UKav1qX
-        9Omj732fmGjl/THLz7N12R5Pld7HZVldodO2XjdtPnta1PmUJog7/95HD/bOHx4cTM63Dz49393e
-        383Otx/uZpPtvdmD6Wxnd3c22X/wEYFt1qtVVbfNt9t21byps/PzYvrlsrz+6NF5Vjb56KN8Oa2v
-        mYMxiMagTb+fFyXxyS+mFtmkzInhCRN6ocya9lQ+elMwq+3t7B5s79zf3tl/s/vpo92DR/fuj+/f
-        //Te7qcPfgojmJTV5BsARJDe5tevWXyocY9/0RXN0GXR0GCK5QUJcIuGr9fTaZ7PqOPRR9M6Z4be
-        0OH+QxLYB7s/Ra1XdbHI6uvT5WxVFZAIGoQM5qM56Pno7pAcjtFsPK3qfHxFuqO6asbELncJ5i9a
-        51BCNwLgdlEILUh2CwjcLgpBZvZGAGgWeZ/JzIR5vkE9NET9dfPl+UtpSk2yy6wogROmkljt/y06
-        OFv+oCJFN9+GMt6+XLyXHjYv493LxazILh7ehzrTYQ19/SMdzB//SAd/szp4f3v3wZu93Ud7Dx7t
-        3Rvf39+/t7ezQ6rzvXXwECCC9LOjg8MO9w92HzzcuX9LHRwVsttr4Pjr3Cr6fgty3fg+t4q+L3N6
-        w+toFHmbycsE+f+H7sWgf//3VLn79xe/aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv/NKl0iC2H9I120
-        QYU8fLP78NHO3qPd/fGn+wfEB/ukQr6OLooCIkg/a7rI73Bn9/7Op7dURXHeu70uGnifm0UBtKDX
-        zQC4WRSAzOpN76NV5HWmMBPl/x/qiLq43l5dt/NquX2+Xk7fSy/hZXkXrxJWOp7e519PD12Rqlw3
-        cLtUAcEvYu/uR17fz29Ny/Hrzs6j+58+2j8Y39vZu7dznxQWjQB65xsARJB+djRt2OHe3v7uwwcH
-        t1S1oVjdXsV23uOvoy+2INDwi/x19EWZvqH38G3kNSYhD9pTpU7mf17qUDjDBw+ho3RYQ19/QxqV
-        yELI/kjRDOuH3ftvdu9RhPbo/sPx3r2H+/f2H5J++BqKJg6IIP1sKRq/w90Hnz68t0/xLKCxPN1e
-        0SjTfV19Y17nVtH3W5Drxve5VfR9mdMbXkejyNtMXibI11BC3/8l/w/yBbS3YxkAAA==
+        epp/XlfrFb2znF1vl8Vy/W57Wi3brFjm9e7dVV1dFrO8bu5+UUzrqqnO27H2fbeRn8fTabVets1d
+        ftm9S7jpqPpftNcrfHEjTGpaVtMMo6LmV3nTrvFZm100RDUiB+G3ymuiE/7+aJm3V1X99nha8p+T
+        61XW0G8fHf9gXeev8/qymFLD0UeXRd2us/KFNH+1LunTR9/7PhFz5f0xy8+zddkeT7X747KsrjAH
+        bb1u2nz2tKjzKeHLnX/vowd75w8PDibn2wefnu9u7+9m59sPd7PJ9t7swXS2s7s7m+w/+IjANuvV
+        qqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zyTGERj0Kbfz4uSyPaLqUU2KXOaeMKEXiiz
+        pj2Vj94UTPG9nd2D7Z1Pt3fvv9nbfbT34NG9++MHOw93H+x8+lMYwaSsJt8AIIL0Nr9+zWxEjXvT
+        ia5ohi6LhgZTLC+IkVs0fL2eTvN8Rh2PPprWOc/vhg7v33twb+fezk9R61VdLLL6+nQ5W1UFGIQG
+        IYP5aA56PrrbZcMxvh5PqzofX5HsVFfNmNjkLsH6RescQjj4In8ffbMFiTa8yd9H35QZHHwRX0fe
+        YzLywJ9HpKEhqq6bL89fShP6KrvMihI4YIqIhf5fpWOmJDzVrMiW995Lu+Bd9+rBXv4pIaZDin73
+        Ix3zw9Exe7tvdg8e7ew+2r8/3tn59P79/YekGr6GjokDIkg/WzrGdbg/frC/8/DevQe31DF9hru9
+        mom8y02iL7cg1OaXuUn0ZZnKTe+iReRVJikT4f/b+oYk6Dxbnq+XLF4tDeC9VE7/dcJNRxX97kcq
+        54ekcu6/2f300f2Hj3Yfjvd3P93Z24M38nVUThQQQfpZUzleh3sPd3ce7uzfUuXQ1HQY7vYqJ/Iu
+        N4m+3IJQm1/mJtGXZSo3vYsWkVeZpEyE/2+rHIzx91dxfy9lM522+tH1p9nb61+0yi5m7b2KUNNB
+        DTf4emqH0G7n03zZ1lnJRFb189Gb7OJFtsh3qQ39+pMZhaqI2eh3fLznfbznPr7nfXzPfbzvfbzv
+        Pr7vfXxfPs7x+afe5/Dh6Hd8/MD7+IF8zM0PvM8P5HN8/ND7+KH7eHfH+5z+IDagCfqRnh1Sj/e3
+        d/ahrchHQhB2/9N7u5+Sg0QjgOL5BgARpJ8dPRt2uP+QBJb0OoCx+tikZgek7Pa6dggAt4tCaEGx
+        W0DgdlEIMrE3AkCzyPtMZSaMp3p72uH/Oyo4W/6gIj0334Yu3r5cvJcaNi/j3csFecoXD+9D++mw
+        hr7+kQqmz3+kgr9pFby/vftA82B798b39/fv7e1QHoxGAH30DQAiSD87KjjscP9g9wEF84DF2mOT
+        Bo6K2O31b/x1bhV9vwWxbnyfW0Xflxm94XU0irzNxGWC/P9D82LQv/97Ktz9+4tfNL3IHqzeNldF
+        k3FG9HJBSOlwBr//kcqlz3+kcn8WVO7DN7sPH+3sPdrdH3+6f0AMTzE6jQAq6BsARJB+1lSu3+HO
+        7n0s0gAY641NOjcuZLdXugPvc7MogBb0uhkAN4sCkFm96X20irzOFGai/P9E72YX29lsJg5vXl/l
+        5XT+XkqYAND7eF3fJuR0WLGvvp7q9WlLUMGHRBRC8+ebMiKeuaUOoXXQgzd7O4/2dx/de0iR84OD
+        B3u7pEPeWxkNASJIPzvKKOxwf+fB/t6De7fURsQcIcvdXhH1X+UW0XdbkGnju9wi+i4Uy8ZX0SDy
+        JpOTCeBpHl8w/r+jdKZltZ651dz30jf8rn2VkNLh9D7/eppG8sbw02hiwGFEB0LvR3pmg3og1+EA
+        0dr9nfHDvft7+5/ukXr4OnomCogg/azpGa/Dg0/3Du49vK3XE3Lb7ZVM5z3+OvpiCwINv8hfR1+U
+        6Rt6D99GXmMS8qA93eJE4f87moW9tymtF2XFMq/vvZdm6bz7cGcXoZOOKf7lN6RjEGRxwEVf0q8S
+        b9HX9Ds+/lEE+fNIme6/2bv3aHf30f09pL52DvaRa/s6yjQKiCD9rClTr0NS3Z8+vH9LXRoRrdsr
+        1NjL3Cb6dgtK3fA2t4m+LZO58WU0ibzLVGVC/H9cv1IX11/TccOr9s3dg7170EI6ouh335ByJXIQ
+        mj/SORtUxf03e3uP7h88IgY+2Nv5dBeiSyOAEH4DgAjSz5rO8Tp8sPfpwcHe7ZcKuhx3e50TeZeb
+        RF9uQajNL3OT6MsylZveRYvIq0xSJsL/HxTO6rqdV8vt8/Vy+t4qR97Fq4SVjqf3+TekauDqsNtD
+        X9Kv4vXQ1/Q7Pv6RH/fzRafe397Zf7Oz8+j+p4/2D8b3dvbu7dyn0JJGACXzDQAiSD87OjXscG9v
+        f/fhvYf2OXgP7eoE7P00q/cefx19sQWphl/kr6MvykQOvYdvI68xMXnQP9KmeBevkgm6OHgI7abD
+        Gvr6R7qVfsfHP9Kt35BuJa9v994jCjbvPxzv3Xu4f2+fvD4aAdTMNwCIIP1s6Va/w90Hnz68t0tK
+        VZ+vp1tVzr6uijWvc6vo+y0Id+P73Cr6vszuDa+jUeRtJjQT5P/jeneSNcV0W5l+e1W+Z+jMr+vb
+        3koRIahDG27wDWlfIg4h/COlNKRLPt3e232z++DRvU8f7XC+7T5l3EiXvLdSGgJEkH52lFKnw517
+        93ZvHUQPsN3tldEQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMmJ8VlXSTSiK5IRb6JlQSLwx9zVTe
+        Mr/i5uA1j2ZEXNVHww1+pI9+WPpoh9Px+492Px3vPdjdfbCPuPHr6KMoIIL0s6aPvA4p+tx5sEMr
+        F4DGYrdJHw2w3e310RAAbheF0IJkt4DA7aIQZGZvBIBmkfeZzEyY/4/rI+rCW1nYey99hHfdq9mn
+        M8R0OqTodz/SQj8kLbR7gGTSvYckzuOHB/cf7DzcI+XxNbRQHBBB+tnSQkGHOw8+3d0lNwzQWJA2
+        aaE+x91eAUXe5SbRl1sQavPL3CT6skzlpnfRIvIqk5SJ8DU0zvd/yf8DoFf+RcJIAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1303']
+      content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Tue, 29 May 2018 19:56:26 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:11 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [664aea4b-6602-4be7-a1a7-30484f0d330a]
-      x-ms-original-request-ids: [36fd19de-d20a-4861-b96f-6e32e162c4f8, 53804b45-c562-4d0d-b1f7-dcacf6586bc0]
+      x-ms-correlation-request-id: [a886496d-dc43-44a6-927a-f5aea3c66720]
+      x-ms-original-request-ids: [31bf3a87-83dd-47a7-9e66-0e1e0112c200, 4bcfd37d-ed88-4768-b80d-a6f84842e1e4,
+        b3eed3f8-a0e8-4332-81a3-1801384f28c9, 4810a377-3881-4bdb-8103-37ac654cd3d2]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [664aea4b-6602-4be7-a1a7-30484f0d330a]
-      x-ms-routing-request-id: ['WESTUS2:20180529T195627Z:664aea4b-6602-4be7-a1a7-30484f0d330a']
+      x-ms-request-id: [a886496d-dc43-44a6-927a-f5aea3c66720]
+      x-ms-routing-request-id: ['WESTUS2:20180627T141912Z:a886496d-dc43-44a6-927a-f5aea3c66720']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -154,8 +198,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.27 msrest_azure/0.4.24 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o/listKeys?api-version=2017-10-01
@@ -173,7 +217,7 @@ interactions:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json]
-      date: ['Tue, 29 May 2018 19:56:27 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:12 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -181,52 +225,52 @@ interactions:
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [d8d82c50-6bfc-40cd-88c7-ee9b2c1c1563]
+      x-ms-correlation-request-id: [347a56f9-1756-4572-8a79-a4838f072533]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-id: [ead10662-c2eb-4640-884d-5098f79ba2de]
-      x-ms-routing-request-id: ['WESTUS2:20180529T195627Z:d8d82c50-6bfc-40cd-88c7-ee9b2c1c1563']
+      x-ms-request-id: [4f7b49ef-b153-4abd-8952-be3b7b0ab366]
+      x-ms-routing-request-id: ['WESTUS2:20180627T141912Z:347a56f9-1756-4572-8a79-a4838f072533']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.1.0-1.1.0 (Python CPython 2.7.10; Darwin 17.5.0)]
-      x-ms-date: ['Tue, 29 May 2018 19:56:27 GMT']
-      x-ms-version: ['2017-07-29']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:19:12 GMT']
+      x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Tue, 29 May 2018 19:56:27 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:12 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [0e1dbbad-4003-00ab-2987-f78e11000000]
-      x-ms-version: ['2017-07-29']
+      x-ms-request-id: [73a9f318-9003-00ed-7f21-0e5087000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
     body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
 
-      <QueueMessage><MessageText>eJzlU7Fu4zAM3f0VgefaapP2knS6rcPh1luKImAl2tFVERWJSuEG/fezpCSIhwO6dxJAPr5HPpHHqgYpKVquH2d1iK9Beu1Yk61vZpfcRquUBliv1sv71+ZBzaG5V+tVA8sVNIvVvFss7x7U7RJzmcc+MaQSY05EXCLHqmYa3+eqjgH9T0U70LaVtKurl4Rk3DkDjKlaYQfRcGZwXpPXPGy2CAp9Ss9zggeXwZZYd0MJebDBkeciuI8YM2TL7MKjEFJyYPLQ4/AD3oa9g17xgtoMHHvx2L5rq+g9tBZZMAaWciIGYV9XnykyevYXZbYv4bTtZ6WT2WnmAnNktBxKPx4DRS8L0Ucc1d5wOFwmtbDDM11TuJqOfDMBFfKQnfyOnlYvBYoHzLtrozFl9Yq3F2fObkp59u+uqEKfMMfP66onT9GdZTcTww1JOO1wPYJ5K0dhDyaGyRC/tfQUqOP2Fw5/UrXIHAVV7khc31kQXzkrMekwiEl/wnk66PEDg/ivvLiev9j3DzaGSag=</MessageText></QueueMessage>'
+      <QueueMessage><MessageText>eJzlUz1PIzEQ7fdXRK7Z9ZEASajoKE7XXnNC0WDPbgyOx7HHQXsR/51dO4nY4iSor7I0fh8zz+NjJUApSo7F/UwArFfr5c1zfavnUN/o9aqG5QrqxWreLpbXt/rHEsXV7MLZGP0tWsDOkMsUa09CXCrHSjAN559KpIjhQdMOjGsU7UT1NCIZd94C48jW2EKynBV8MBQM95stgsYwXs/zBfc+gx2xaftSCuCip8DFcJ8wZciW2cd7KZXiyBSgw/4OXvu9h07zgpoMHHoJ2LwZp+ktNg5ZMkZWamIGcS+q97ES0/MLqhzriDOum5VOZqeZC8yTNaov/QSMlIIqQn/T4PaK/eEyqYMdnuXqolW3FOoJqIjHnOT/mGn1VKB4wLzTLllbVq9ke0nmnKZS5/yuiyt0I+b4/pn1GCj5s+1mErglBacdFgOYt2owDmBTnAzxy6hAkVpufmL/e2TLrFFQ5R/JYb6ogvH5CeVXvpWcdBjlpD/pAx3M8IBR/tNefp6/xPcBcDFN2Q==</MessageText></QueueMessage>'
     headers:
       Connection: [keep-alive]
-      Content-Length: ['623']
-      User-Agent: [Azure-Storage/1.1.0-1.1.0 (Python CPython 2.7.10; Darwin 17.5.0)]
-      x-ms-date: ['Tue, 29 May 2018 19:56:27 GMT']
-      x-ms-version: ['2017-07-29']
+      Content-Length: ['619']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:19:12 GMT']
+      x-ms-version: ['2018-03-28']
     method: POST
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>a3b23791-5975-4787-a81a-5348dfee6ff2</MessageId><InsertionTime>Tue,\
-        \ 29 May 2018 19:56:27 GMT</InsertionTime><ExpirationTime>Tue, 05 Jun 2018\
-        \ 19:56:27 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAwk6FIYf30wE=</PopReceipt><TimeNextVisible>Tue,\
-        \ 29 May 2018 19:56:27 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>1a376396-739a-4739-a28c-2c7811d3e179</MessageId><InsertionTime>Wed,\
+        \ 27 Jun 2018 14:19:13 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
+        \ 14:19:13 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAxCms0iEO1AE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 27 Jun 2018 14:19:13 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
     headers:
       content-type: [application/xml]
-      date: ['Tue, 29 May 2018 19:56:27 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:12 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [0e1dbbc1-4003-00ab-3887-f78e11000000]
-      x-ms-version: ['2017-07-29']
+      x-ms-request-id: [73a9f332-9003-00ed-1521-0e5087000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 201, message: Created}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/NotifyTest.test_notify_though_storage_queue.yaml
+++ b/tools/c7n_azure/tests/cassettes/NotifyTest.test_notify_though_storage_queue.yaml
@@ -63,18 +63,18 @@ interactions:
       content-encoding: [gzip]
       content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:19:11 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [4838f0b5-aefa-41fa-89b2-8d54ea018576]
-      x-ms-original-request-ids: [abe9efc7-87b6-4d51-8465-e999952e9e5f, a4a49f76-6a4c-485d-a322-a8b85dcd9dbd,
-        999c4516-0034-4a0b-9993-aaf2e562cf46, f009ff26-1e94-4a4d-bf63-3e8f5ce3625b]
+      x-ms-correlation-request-id: [5f3ef420-5fec-4d2a-8d03-71ccff27e22f]
+      x-ms-original-request-ids: [292fa6c5-4d7b-416e-8095-abc6604bd77f, c9ef87d7-a36d-485b-993a-c7fb57ff7824,
+        473c5c8c-d133-474f-903c-5d774f476403, d9731f05-1c10-4072-b341-7bbc770b4288]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [4838f0b5-aefa-41fa-89b2-8d54ea018576]
-      x-ms-routing-request-id: ['WESTUS2:20180627T141911Z:4838f0b5-aefa-41fa-89b2-8d54ea018576']
+      x-ms-request-id: [5f3ef420-5fec-4d2a-8d03-71ccff27e22f]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162255Z:5f3ef420-5fec-4d2a-8d03-71ccff27e22f']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -102,16 +102,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['295']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:19:11 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:55 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [7f3f4939-e6a3-441f-a998-4989b8dec867]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [7f3f4939-e6a3-441f-a998-4989b8dec867]
-      x-ms-routing-request-id: ['WESTUS2:20180627T141912Z:7f3f4939-e6a3-441f-a998-4989b8dec867']
+      x-ms-correlation-request-id: [3d63fa73-abf5-4a05-b4be-47965f519d2c]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [3d63fa73-abf5-4a05-b4be-47965f519d2c]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162255Z:3d63fa73-abf5-4a05-b4be-47965f519d2c']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -177,18 +177,18 @@ interactions:
       content-encoding: [gzip]
       content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:19:11 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [a886496d-dc43-44a6-927a-f5aea3c66720]
-      x-ms-original-request-ids: [31bf3a87-83dd-47a7-9e66-0e1e0112c200, 4bcfd37d-ed88-4768-b80d-a6f84842e1e4,
-        b3eed3f8-a0e8-4332-81a3-1801384f28c9, 4810a377-3881-4bdb-8103-37ac654cd3d2]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [a886496d-dc43-44a6-927a-f5aea3c66720]
-      x-ms-routing-request-id: ['WESTUS2:20180627T141912Z:a886496d-dc43-44a6-927a-f5aea3c66720']
+      x-ms-correlation-request-id: [9d5a2f43-c684-42dc-bc4f-0ab5e0ee5027]
+      x-ms-original-request-ids: [d01e4816-5ab8-4fa6-b3dc-7d9254182c05, 9656409e-9a43-478b-a5bd-6d707d3a494f,
+        70045e11-7c17-44bd-a456-c36ea8683b88, f57e8f8f-e27e-4679-b62d-90b3049bde08]
+      x-ms-ratelimit-remaining-subscription-reads: ['14997']
+      x-ms-request-id: [9d5a2f43-c684-42dc-bc4f-0ab5e0ee5027]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162256Z:9d5a2f43-c684-42dc-bc4f-0ab5e0ee5027']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -217,7 +217,7 @@ interactions:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json]
-      date: ['Wed, 27 Jun 2018 14:19:12 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:56 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -225,10 +225,10 @@ interactions:
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [347a56f9-1756-4572-8a79-a4838f072533]
+      x-ms-correlation-request-id: [62c2a1cf-f473-42df-a352-1e2081cdcc98]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-id: [4f7b49ef-b153-4abd-8952-be3b7b0ab366]
-      x-ms-routing-request-id: ['WESTUS2:20180627T141912Z:347a56f9-1756-4572-8a79-a4838f072533']
+      x-ms-request-id: [7a57f108-2851-40f3-bf90-1156fe79c16a]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162257Z:62c2a1cf-f473-42df-a352-1e2081cdcc98']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -236,41 +236,41 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:19:12 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:22:56 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 27 Jun 2018 14:19:12 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:57 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [73a9f318-9003-00ed-7f21-0e5087000000]
+      x-ms-request-id: [acb475cc-2003-0115-7d33-0eddcf000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
-    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
 
       <QueueMessage><MessageText>eJzlUz1PIzEQ7fdXRK7Z9ZEASajoKE7XXnNC0WDPbgyOx7HHQXsR/51dO4nY4iSor7I0fh8zz+NjJUApSo7F/UwArFfr5c1zfavnUN/o9aqG5QrqxWreLpbXt/rHEsXV7MLZGP0tWsDOkMsUa09CXCrHSjAN559KpIjhQdMOjGsU7UT1NCIZd94C48jW2EKynBV8MBQM95stgsYwXs/zBfc+gx2xaftSCuCip8DFcJ8wZciW2cd7KZXiyBSgw/4OXvu9h07zgpoMHHoJ2LwZp+ktNg5ZMkZWamIGcS+q97ES0/MLqhzriDOum5VOZqeZC8yTNaov/QSMlIIqQn/T4PaK/eEyqYMdnuXqolW3FOoJqIjHnOT/mGn1VKB4wLzTLllbVq9ke0nmnKZS5/yuiyt0I+b4/pn1GCj5s+1mErglBacdFgOYt2owDmBTnAzxy6hAkVpufmL/e2TLrFFQ5R/JYb6ogvH5CeVXvpWcdBjlpD/pAx3M8IBR/tNefp6/xPcBcDFN2Q==</MessageText></QueueMessage>'
     headers:
       Connection: [keep-alive]
       Content-Length: ['619']
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:19:12 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:22:57 GMT']
       x-ms-version: ['2018-03-28']
     method: POST
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>1a376396-739a-4739-a28c-2c7811d3e179</MessageId><InsertionTime>Wed,\
-        \ 27 Jun 2018 14:19:13 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
-        \ 14:19:13 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAxCms0iEO1AE=</PopReceipt><TimeNextVisible>Wed,\
-        \ 27 Jun 2018 14:19:13 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>a5690bbd-61a8-4f7e-b311-ec4aea3d54e6</MessageId><InsertionTime>Wed,\
+        \ 27 Jun 2018 16:22:57 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
+        \ 16:22:57 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAbh4RHDMO1AE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 27 Jun 2018 16:22:57 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 27 Jun 2018 14:19:12 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:57 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [73a9f332-9003-00ed-1521-0e5087000000]
+      x-ms-request-id: [acb475ed-2003-0115-1a33-0eddcf000000]
       x-ms-version: ['2018-03-28']
     status: {code: 201, message: Created}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/ResourceGroupTest.test_delete_empty_group.yaml
+++ b/tools/c7n_azure/tests/cassettes/ResourceGroupTest.test_delete_empty_group.yaml
@@ -6,8 +6,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups?api-version=2017-05-10
@@ -17,28 +17,34 @@ interactions:
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
-        7892HuR367yp1vU0/7yu1it6Z/mDqqym8+02b9rtbFV8NPpomS2ok49iX9HfGTqjr6f5sq2zct3Q
-        x6u6WuV1W+TNR49+Mf66LBpqVSwvXrdZC2Cv19Npns/y2Ue/5JeMfrbQn1bNogI+0RHYb+kjMwgC
-        1s7/XziSt/n1ZbYuW8IoOhbve/rw/+2jKatstj3Jymw5zWtCKzqkbiP65v/t47pcEC7RwfA39Of/
-        +0YwKbM59a9Y618epleE/rrZow/b7IKRO6nzrK3q00VWlNQgW5brannxey6KaV011Xk7nlYYrd9s
-        b7DdL/k5HDrPDI/Kjt//aCMRVnW+nb8rmpbQ3Mbw1stFNSvOC0ISQ/K+3aVvve98utA3cbJwR3iR
-        Nfwu/e2/hv7i7/1ck/P3zxer9rq+IIQ9inqfekSll/9fIgOMY0tIltQNMPFx9z//fy/2rGB8tPmD
-        bw7f7/+S/wfojJjNbggAAA==
+        7892HuR367yp1vU0/7yu1it6Zzm73p6um7aaFdnyo9FHy2xBPXzU+7ysphm6oe+u8qZdN3v04aqu
+        VnndFnnz0aNfjL8ui4baFMuL123WAs7r9XSa57N89tEv+SWjny20gUoUb3zx/2bE7xEqUcTxRQ9x
+        +oww/TnEuyyW63fb02rZZsUyr3cJIR/7yNe9MfzcE3913c6r5fb5ejklXHz8w2/+34b6DyrCaL49
+        Lav1bLsljAgdi33sS/rEDGCaL9s6K3+uWUixBH7b2aogZLoD8L6iv2Pot9kFI366vCzqarmgr6jF
+        G3qPvjyp86yt6tNFVpT0qQH7ey6KaV011Xk7nlaLj37J/2uIMK2aRYVRRelgv6WPDCkIWDv//y09
+        LheEdJQW/A39+f93OjT5cnZRE9QeHbxv6E9DhwgJfi6HMcmaYrrd5PVlMc23VyW7DjqQ6HfeUP5f
+        oGVFf1orTKgo7v0v/t+FOJvewPIq4v0vPMR95iFk/9+AOhyfKOr4wkP9/3U0f1q1L3Lomij29ltv
+        CP+voH7T5ufZEi4PYEDVEjY6hOh33gBkDugzwvfnBnvSeNvZTDye7by+ysvpnPBR/Ae+7Y3g55SL
+        GLk2WxKTEBoG8+BDD+H/V/AMsPv9xTmZTQgRD2n/Yw9tev3/V9aah5ovVu11fUEI+wRwnxLOg+Mn
+        XH8OMX+bX19m6xK09lH3Pt6E+/8f5q6sstn2JCMfZMoi5pOh+x3h//9rWqgn5pNAPyJszcj9QROC
+        P4fokgtWZxc54eFj7D71kKaXw+kiXH8OMecYxkeaP9iEr2GvVZ1v5++KpiVMt3epZVttv83zFTUJ
+        vtoLvqK30ZaThvD8Ovw4q7aXVbu9II/2/Prnng2v8km2Ato+heyHt6FSZ3z/L5U36iX8sbsH39Yb
+        NX0W/pAWNBZDgq/rt3z/l/w/MOBaD0QWAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['529']
+      content-length: ['881']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:28 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:25 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [ec0ba137-64bc-4108-96d4-13c2e2fa3071]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [ec0ba137-64bc-4108-96d4-13c2e2fa3071]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141028Z:ec0ba137-64bc-4108-96d4-13c2e2fa3071']
+      x-ms-correlation-request-id: [61a853a3-cbff-4aae-855c-0c6da3859ff7]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [61a853a3-cbff-4aae-855c-0c6da3859ff7]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142126Z:61a853a3-cbff-4aae-855c-0c6da3859ff7']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -47,8 +53,258 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/andy-custodian/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1it6Zzm73p6um7aaFdny7qquLotZXjd3F8W0rprqvB0Xy6a4mLfN3Wm1
+        WFXLfEm/hq/tfjT6aJktCLOP+l+01yt8sREeNXtbLDGkq3xCf5TVNMOY+IOmXTd79GGbXTQfPfrF
+        H82L2SxfbpfF8u2juz+LFPjCYvzdfHK3Kdq823iX8Hul0D76Jb9k9EOYFofU67aqs4v8LrXBz+Pp
+        tFoTKflV++buwd69+0Q7b3Z63+kE3QiZmjZv15gBhfa6JXhZPfv9n796TV+2RV57n370S+ykKkBq
+        s2lif8kv+f4v+X8AGp2rsuMCAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['419']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [7237137c-529a-4858-ae3a-4ef4be18092a]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [7237137c-529a-4858-ae3a-4ef4be18092a]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142126Z:7237137c-529a-4858-ae3a-4ef4be18092a']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/andy-custodian2/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1it6Zzm73p6um7aaFdly7+6qri6LWV43dxfFtK6a6rwdF8umuJi3zd1p
+        tVhVy3xJv3be+2j00TJbEGof9b9or1f4YiM8ava2WGJMV/mE/iiraYZB8QdNu24YUHbRfPToF380
+        L2azfLldFsu3j+7+bJLgC4vyd/PJ3aZo815rQvCVgvvol/yS0Q9jYhxWr9uqzi7yu9QIP4+n02pN
+        xOR33avZp7N9op43P73vdIpuhExNm7drzIFCe90SvKye/f7PX72mL9sir71PP/oldloVILXZNLU/
+        dAoOz2tAsPCLHrUsFPpSx3u+Xk6BerZajYhR1+9G02rZZsWSCLSZBoa967zM2nz2QRx+4VFidd3O
+        q+U2EBsmRV5f5vV5Vi+au6/p92Kavyyz5TN6h1DNF6v2mrj8+7/k/wExVLO5igQAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['505']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [a889b083-eaa8-4482-bf70-dca95c795e24]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [a889b083-eaa8-4482-bf70-dca95c795e24]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:a889b083-eaa8-4482-bf70-dca95c795e24']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/andy-custodian3/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1it6Zzm73p6um7aaFdny3t1VXV0Ws7xu7i6KaV011Xk7LpZNcTFvm7vT
+        arGqlvmSfu2899Hoo2W2INQ+6n/RXq/wxUZ41OxtscSYrvIJ/VFW0wyDog/yrGnXaNBmF81Hj37x
+        R/NiNsuX22WxfPvo7s8mBb6wGH83n9xtijbvtSb8Xim4j37JLxn9MObFYfW6rersIr9LjfDzeDqt
+        1kRLfte9erCXf0rU86an953O0I2QqWnzdo05UGivW4KX1bPf//mr1/RlW+S19+lHv8TOqgKkNt7M
+        XuXhzP7QCTg8rQG9wi96xLJQ6Esd7vl6OQXq2Wo1Ij5dvxtNq2WbFUuiz0YSGOau8zJr89kH8feF
+        RwhGYtsisTtMjry+zOvzrF40d/kl9w6hmy9W7TUx+vd/yf8DjHQZDIwEAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['500']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [ef375e83-515e-4560-a85c-410313924c6b]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [ef375e83-515e-4560-a85c-410313924c6b]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:ef375e83-515e-4560-a85c-410313924c6b']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/andy-linux-container1/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1it6Zzm73i6L5frd9rRatlmxzOvdu6u6uixmed3c/aKY1lVTnbfj121V
+        Zxf53UZ+Hk+n1XrZNnf5ZffuR6OPltmCkPyo/0V7vcIXN8Kkps3b9UePfrEB9bolPLN69vs/f/Wa
+        vmyLvPY+/eiXjD56WyxBEQVIbcpqmoEs9OFV3rRrAG2zi4ag/pJfMvq5IOB388ndJq8v8/pZVi8+
+        jHAdWNSkQzB+q0MmalT8wH57ni2K8hp/0R/TbJVNi5b+3HXEZDzoyz4pfw4JWLT5N0A6QKEvdaDn
+        6+UUA8hWqxFDGFkQ1Cgy/O//kv8H4qgvNYwDAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['428']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [68569d4e-6c94-4867-93ee-5442db4a3a88]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [68569d4e-6c94-4867-93ee-5442db4a3a88]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:68569d4e-6c94-4867-93ee-5442db4a3a88']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/andy-python-func/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvm7vGLp7/P9svf5823v3yx/eyrFyd3V3V1Wczyurn7RTGtq6Y6b8cn
+        1WK1bvO7s6J529w9Xy+n6HC7zZt2e1417e//ZfOUvvr9d3//bJrtHuxk0wf5eba/m+09fJBnOzuf
+        5rP72cPd2afTj0YfLbMFDeGjD4TSXq8AZQBHatC8XX/06Beb3l7W+aJYL37/569e03dtkdfuw49+
+        yeijRbbMLvLZk2v6+O6HUzVbzq63V9ftnMaHgW6k6mVRt+us/CKbzotlHqMvoVxW0wwfEn5X9PG6
+        2SO0f47Y4FYIK+Gj3w1OXgcyNY2Me0Sjzpdt0dJk/eKPVnWxnBarrDwDKbKH59lsej7Znu5Odrb3
+        d7K97YOHNPb97OH984OHs/OH9wCgzZfZsuU3HuydPzw4mJxvH3x6vrtN3Ha+/XA3m2zvzR5MZzu7
+        u7PJ/gO8ISi/vm7afHHcNMXFMp/RFHzUZhcN4fFLvsnZ+IbZ527+jgbc0Gc00cdPn1cXxfJZVT8v
+        lut3NLTBmYo1VjrcjIbrk96KzOL/R+j1hSiGM+W4U/ONR5Jh+t3i5f+v0XNhES0Im4t5S63LvG7r
+        dUlIPsuKcl3n6fGyWmRlkTfpdlpipNNq2WY0jhrSpwS7XWMl0MZ+qZlHkTwDRegzFc2P5sWMZmCb
+        YL99dPcDqHPxdagzpfmslsQAzV1CIBjco49eKeSPfljqYzOC2Q9oPvgV7nx7Vk3f5rUB1WSLVZnr
+        h0Rencb3e2l4Oh0e1OxtsQQxrvIJ/fHDmNubSedE9Lv55G5TkJi/F8H+XzfbRDOPHYmmOqG9zz9w
+        zoyGIkD/r5g06tYf3//L5wV0i04MvvjAmfl/mTRRt8H4/t85M6FUh5PT/e4D5+f/lZITjvH/dXO0
+        uBbMigW5XgZLO0sD337gPP2/TI6ig/w5mCiH24u8varqt3eX8vNs2eb1eTYlXPEKOnde86e7D4mS
+        Ol9DX+uE3aIHauzNlJGon2sKvM6n65pCAgWB14CAG+b2srkg1AfJoN/fRIewH3rh/020WK0nZTE9
+        e3k8mxGYJsoN28WKsB4mA389SIVeD9Q4TAw9yZqC80mSEnqVXxD8rCSi/L+KVBoN6p/9l7cvacJp
+        GDqqoa8HCdWBT03/3zD6121Vkwq728jP4+m0WpMm5pflXbxKyHrDDj7vjXcAIjUN2eJ1S7CyehYm
+        DM2nRAljCxQgtYkQjF5Ug/Amu3hBkHfpS/r1JzNK4+7S1/Q7PoarQ7/yx3iLfsfH97yP77mP972P
+        993H972P78vHOT7/1Pv8U/kcHz/wPkaCi37n5gfe5wfyOT5+6H0MBUy/4+PdHe9z+uOHb1p0Aroz
+        yi/Lu3h1VmQXBw9Bcp3goa9/xDH/v+cYdpTy+jKvn2X1orn7mn4vpvnLMls+o3cIVTOlvS963NGB
+        RU1Crni5d4npUW7QBYefxEdN8QOvwXm2KErKZ3/0kv+cZqtsSmb7o0e7jnHIm+SUYYRtfm5o2Hc2
+        L8GiOvT+F3HqAQp9qYNEj8A9W61Gmwb8/V/y/wDywT6hDhsAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['1348']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [1424dc59-18a8-4a74-b785-c37c32e0d1ed]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [1424dc59-18a8-4a74-b785-c37c32e0d1ed]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:1424dc59-18a8-4a74-b785-c37c32e0d1ed']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/anzoloch-cloud-test/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1it6Z/mDqqym8+1pWa1n223etHdXdXVZzPK6uftFMa2rpjpvxydl1jTF
+        9KRarNZtfndWLbJi+SJb5FEQH40+WtJ3hGL8y/Z6hS9vA55a0/sZRkhvTPNlW2fluvnol3z/l/w/
+        xINIchABAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['293']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [71a0029c-3424-4f8b-b680-2b3fe0a5bcf7]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [71a0029c-3424-4f8b-b680-2b3fe0a5bcf7]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:71a0029c-3424-4f8b-b680-2b3fe0a5bcf7']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/anzoloch-test-api/resources?api-version=2017-05-10
@@ -69,16 +325,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['503']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:28 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [e6956216-0f89-45df-a1b1-fcf744dfc993]
+      x-ms-correlation-request-id: [e37bb897-80c3-4b50-9f6b-dec1e2d93f2b]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [e6956216-0f89-45df-a1b1-fcf744dfc993]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141028Z:e6956216-0f89-45df-a1b1-fcf744dfc993']
+      x-ms-request-id: [e37bb897-80c3-4b50-9f6b-dec1e2d93f2b]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:e37bb897-80c3-4b50-9f6b-dec1e2d93f2b']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -87,8 +343,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/anzoloch-test-cosmos/resources?api-version=2017-05-10
@@ -106,16 +362,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['339']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:28 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [d0eb1a16-df9f-4b32-a9bc-893adf9cebe7]
+      x-ms-correlation-request-id: [31b606e4-2a06-429d-b1f6-c634b63588f2]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [d0eb1a16-df9f-4b32-a9bc-893adf9cebe7]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141029Z:d0eb1a16-df9f-4b32-a9bc-893adf9cebe7']
+      x-ms-request-id: [31b606e4-2a06-429d-b1f6-c634b63588f2]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:31b606e4-2a06-429d-b1f6-c634b63588f2']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -124,83 +380,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/anzoloch-test-keyvault/resources?api-version=2017-05-10
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
-        7892HuR367yp1vU0/7yu1it6Z/mDqqym8+02b9rtt/n1ZbYu27ururosZnnd3P2imNZVU523498r
-        v/5J/pKbDL360eijZbYgJD8a/L69XuH7QcjUhN7LMChqRui282m+bOusXOO7NrtoPnr0i3/JL/n+
-        L/l/AA3cXz0SAQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['297']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:29 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [78fb3901-2be1-4711-984c-6c10c6d514d6]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [78fb3901-2be1-4711-984c-6c10c6d514d6]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141029Z:78fb3901-2be1-4711-984c-6c10c6d514d6']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/anzoloch-test-load-balancer/resources?api-version=2017-05-10
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
-        7892HuR367yp1vU0/7yu1it6Z/mDqqym8+02b9rtsspm25OszJbTvL67qqvLYpbXzd0vimldNdV5
-        O36Rt1dV/fYuWj7RhhuhfDT6aJktCOmPNjdqr1dodENP1LB5u/7o0S82QJ9kTTGlT9uCoDz66FV+
-        QaTIyo9+yegj6isDYehjGnI7n+bLts7KdUNf/twTcLWelMX07OXxbEYQm3wjpO1iRWPUId/YbpCU
-        vT6p8TdBzu//kv8Htb7MnpsCAAA=
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['362']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:28 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [4bec66a8-557b-4d55-b134-d5a7f825ea82]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [4bec66a8-557b-4d55-b134-d5a7f825ea82]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141029Z:4bec66a8-557b-4d55-b134-d5a7f825ea82']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/anzoloch-test-vm/resources?api-version=2017-05-10
@@ -213,27 +394,29 @@ interactions:
         7892HuR367yp1vU0/7yu1qvm7vGLn/ry+Zcn395+c/r6zfZPfnF3VVeXxSyvm7tfFNO6aqrzdnxS
         LVbrNr87K5q31M3yB1VZTefbbd6025eL3//L5il98fvv/v75/Z383mx38mByPtk/OLg3ub/34NM8
         v3cv392Z3d9/+NHoo2W2oAF89EEw2usVYAzgRw2at+uPHv1i09fLOl8U68Xv//zVa/quLfLaffjR
-        Lxl9tMiW2UU+e3JNH9/9cIp2h7aRopdF3a6z8otsOi+Wef9lQpj+zIANYUf9tPNpvmzrrFw3hPs3
-        xwfdjj8Ua6V95JvB2etApab05v9bhv4ib6+q+u3dpfw8W7Z5fZ5NI4Pfvb9LqA+MX77skWAQOjWm
-        1/9fSoTX+XRdF+31AIjtZXNB+A9QQr+9iRRhH/QCwfh/GzlW60lZTM9eHs9mBKaJ8MR2sSLUhyjB
-        Xw4SogedGocK7knWFFP6VFXbq/yCxp2VRJD/N1JLxVz/7L+8fUlTT6PRwQ19PUivDnxqSq//v4UI
-        r9uqJmNzt5Gfx9NptV627mW8e7mYFdnFQ9YUHSJ0v+4RYQA+NQ1Z5nWbLWdZPQuNovmU6PLR22IJ
-        wihAakP9D1CR3s8uGoL+S37J93/J/wO35xf3pQgAAA==
+        Lxl9tMiW2UU+e3JNH9/9cIp2h7aRopdF3a6z8otsOi+Wef9lQpj+zIANYUf9tPNpvmzrrFw3hPvP
+        ER/cAmulfeSbwdnrQKWm9ObA0AlMdtHQJP+Sb5IIXWyjRHiRt1dV/fbuUn6eLdu8Ps+mETLs3t8l
+        RAcoIV/2iDEInRrT6wPk+Lkmwut8uq6L9noAxPayuSD8Byih395EirAPeoFgDJCDgAl3fHTy6vT4
+        zenT7Se/D7UyHf+eC9vHtCIV8HNGvdV6UhbTs5fHsxmBaSIstF2saDRDhOMvB+nWg06NQ834JGuK
+        KX2qOvFVfkHjzkpip/8fEFfVif7Zf3n7khiLRqO0GPp6kLwd+NSUXh+g2Q+dCK/bqiajdreRn8fT
+        abVetu5lvHu5mBXZxUPWQx0idL/uEWEAPjUNOex1my1nWT0Lja/5lOjy0dtiCcIoQGpD/Q9Qkd5X
+        znuTXbzIFvkutaFffzIjrwho0u/4eM/7eM99fM/7+J77eN/7eN99fN/7+L58nOPzT73PP5XP8fED
+        7+MH8jE3P/A+P5DP8fFD72O4NPQ7Pt7d8T6nP37JL/n+L/l/AOXbZiP2CQAA
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['658']
+      content-length: ['786']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:29 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [5175e4d0-0c8c-4a16-b9dd-ff02cc5bd948]
+      x-ms-correlation-request-id: [3d790120-95b3-4276-85e8-11b2fca3c1d0]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [5175e4d0-0c8c-4a16-b9dd-ff02cc5bd948]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141029Z:5175e4d0-0c8c-4a16-b9dd-ff02cc5bd948']
+      x-ms-request-id: [3d790120-95b3-4276-85e8-11b2fca3c1d0]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:3d790120-95b3-4276-85e8-11b2fca3c1d0']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -242,11 +425,328 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/blah/resources?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/anzolochsendgrid/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1it6Z/mDqqym8yZfzi7qYnZ3VVeXxSyvm7uv9aPx6SIryrvZdFqtl23/
+        lY9GHy2zBaH1UeSb9nqFbwZgUQNqnwF9ajTNl22dlWt8vCoz+ugXG8jndZ7j07paVGh9Us3wsXw0
+        W09b+sP0+vtnP1jX3Ho9KYtmntf0pUHgo1/yS77/S/4fXq5uXUkBAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['326']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [b7577b2b-0fce-4fff-bf8b-8685777d28d8]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [b7577b2b-0fce-4fff-bf8b-8685777d28d8]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:b7577b2b-0fce-4fff-bf8b-8685777d28d8']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/basic-service-plan/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvm7iRriul2k9eXxTTfXpXZ8u6qri6LWV43dxfFtK6a6rwdF8umuJi3
+        zd1ptVhVy3xJv4avtnnTbuf1VV5O5x+NPlpmC0L0o41t2usV2mzshZq9LZYY7FU+oT/KapphtPxB
+        066bPfqwzS6ajx794o/mxWyWL7fLYvn20d2fZdp8YbH+bj652xQ0ts4L9Ikb7aOPXinwj37JLxn9
+        kObP4fi6rersIr/byM/j6bRaE3XldX0b+Bp0wwmMNtDZu7EPatq8XWN6FOTrNlvOsnr2+z9/9Zq+
+        bIu89j796JfYGVeA1GbTrP9ckJOnnBrl9bOsXsReI/x0uNHvesTrQKQmIdGe7NJHSqongEh/NsUP
+        7Ffn2aIor/EX/THNVtm0aOnPXUdNkor1O/oyQsufKwreJDQDNOy0idMSsOlLHfz5ejnFmLLVasSE
+        GE2rZZsVSyJonCTf/yX/DwjUlrZvBQAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['537']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [f40fee91-7c5a-47aa-bf14-9b270ac3a077]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [f40fee91-7c5a-47aa-bf14-9b270ac3a077]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:f40fee91-7c5a-47aa-bf14-9b270ac3a077']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/cloud-custodian/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvm7rSs1rPt6bppq1mRLe+u6uqymOV1c3dRTOuqqc7bcbFsiot5S42r
+        xapa5kv8Gr730eijZbYg1D7qf9Fer/DFRnjU7G2xxJiu8gn9UVbTDIPiD5p23ezRh2120Xz06Bd/
+        NC9ms3y5XRbLt4/u/myS4AuL8nfzyd2maPNea0LwlYL76Jf8ktHP/cQs86ttbttQ19uEcbud11d5
+        OZ0TBXWONrb5/9d0bRjqD3/mHIKv26rOLvK71AY/j6fTak10lXftq0REnbHe5zpLN0Kkps3bNaZB
+        Ib1us+Usq2e///NXr+nLtshr79OPfomdWQVIbTbN7v9rKEcTzc0xz5hmM8uWhMMNft7SksUkry/z
+        +llWL3rvEGY60P4XPZp1YFGTDq126aMuhahR8QP77Xm2KMpr/EV/TLNVNi1a+nPX0ZF0yPodfRmh
+        4s8J7VjFdFoTejrk/hdxqgEKfaljPF8vp0A9W61GPN7RlBg2K5ZEuv+XjZxEaki5WiJsbPOzQ4/v
+        /5L/B0tqGgAqCQAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['582']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [0c98280c-a5f4-41bc-b1b7-312b9751c730]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [0c98280c-a5f4-41bc-b1b7-312b9751c730]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:0c98280c-a5f4-41bc-b1b7-312b9751c730']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/linuxcontainer1/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmblks1++m1bLNimVe795d1dVlMcvr5u6imNZVU52342LZFBfztrk7
+        rRarapkv6ddstdKPOxA+Gn20zBaE5EebmrTXKzTZ2Ac1e1ssMc6rfEJ/lNU0w0D5g6ZdN3v0YZtd
+        NB89+sW/5JeMfu5p0nmPsFNK9L/4psf/0byYzfLlNvX09tHdn00SfGFR/m4+udsUbd5rTQi+UnAf
+        /ZJf8v1f8v8Ai660VrgCAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['359']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [1e00b091-0be1-4c03-a502-2838a0b7ac8c]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [1e00b091-0be1-4c03-a502-2838a0b7ac8c]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:1e00b091-0be1-4c03-a502-2838a0b7ac8c']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/linuxcontainer3/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmblks1++m1bLNimVe37u7qqvLYpbXzd1FMa2rpjpvx8WyKS7mbXN3
+        Wi1W1TJf0q+d9z4afbTMFoTaR/0v2usVvtgIj5q9LZYY01U+oT/KapphUPxB066bPfqwzS6ajx79
+        4o/mxWyWL7epp7eP7v5skuALi/J388ndpmjzXmtC8JWC++iX/JLRD2NiHFav26rOLvK7jfw8nk6r
+        NRGz++7Dnd0HRL74BOmXOkk3wqamzds1ZkHBvW6z5SyrZ7//81ev6cu2yGvv049+iZ1YBUhtNk7u
+        m+ziBUHepS/p15/MiOF36Wv6HR/veR/jLfodH2Ma6Ff+GCxHv+Pjfe/jfffxfe/j+/Jxjs8/9T7/
+        VD7Hxw+8j0Eq+p2bH3ifH8jn+Pih9/FD9/Hujvc5/fFLfsn3f8n/A2/E0tzRAwAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['504']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [16265876-8710-4434-946e-df3bd5e4e2d3]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [16265876-8710-4434-946e-df3bd5e4e2d3]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:16265876-8710-4434-946e-df3bd5e4e2d3']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/linuxcontainerDotNet/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmblks1++m1bLNimVeP63aF3l7d1VXl8Usr5u7i2JaV0113o6LZVNc
+        zNvm7rRarKplvqRfYy9/NPpomS0IyY8Gvm2vV/h2I2Rq9rZYYohX+YT+KKtphjHyB027bvbowza7
+        aD569Is/mhezWb7cpu7ePrr7s06RLyze380nd5uizeOvEKqvFPBHv+SXfP+X/D9E8kIlvQEAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['340']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [1588e598-a504-4f0a-9132-bf250fa4eb0a]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [1588e598-a504-4f0a-9132-bf250fa4eb0a]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:1588e598-a504-4f0a-9132-bf250fa4eb0a']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/stefanfunctiontest/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmbtPm59nyfL2cAkabN+3dVV1dFrO8bu4uimldNdV5Oy6WTXExb6mP
+        Mq/bel3mzd1nWVGu6zw9XlaLrCzyJt1O++A+Gn20zBaE9Ee3bt9er9B+Y+/UrKymGd6iplf04rrZ
+        ow/b7KL56NEv/mhezGb5crsslm8f3f0AMl18PTJNq8WqWuZL+rX/KiH8SsF/9Et+yejnbjI3Y2kn
+        Lvrd8CQ5qNTsbbHE4K7yCf3xQ5mx29DiC4v1d/PJ3aagryMvbF8uCNOfg6ly6L1uqzq7yKk5/zye
+        Tqs1EZb+7r5OlLzFdN0ImZo2b9eYD4X2us2Ws6ye/f7PX72mL9sir71PP/oldooVILXpTTN9prP8
+        c0FDnuK8vszrZ1m9iL1G+Oloo9/1aNeBSE06NNulj7qUokbFD+y359miKK/xF/0xzVbZtGjpz11H
+        TxKE9Tv6sk/NnysabhCTDQSUr+M0BET6Ukds3spWqxGPfjQlEFmxJEJG6fD9X/L/APvq/METBwAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['570']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [56baadb5-e771-4109-8df7-a430ca7eadf1]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [56baadb5-e771-4109-8df7-a430ca7eadf1]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:56baadb5-e771-4109-8df7-a430ca7eadf1']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/tag-add-test-erwelch/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmbptdbGez2XabN+12Xl/l5XR+d1VXl8Usr5u7i2JaV0113o6LZVNc
+        zNvm7rRarKplvqRfYy9/NPpomS0IyY8Gvm2vV/h2I2Rq9rZYYohX+YT+KKtphjHyB027bvboQ4Lf
+        fPToF380L2azfLldFsu3j+7+rFPkC4v3d/PJ3aagZtFXCNVXCvijX/JLRj+0GXP4vW6rOrvI7zby
+        83g6rdZEWwCg9/G6vk20dFPW+0rn60a41LR5u8aEKLDXbbacZfXs93/+6jV92RZ57X360S+xc6wA
+        qY03z1Pigzor14BLaGGmf27IyNOc15d5/SyrF/EXCUcd9MC3PSJ2oFKTDvF26aMuyahR8QP77Xm2
+        KMpr/EV/TLNVNi1a+nPXEZZEYv2OvoyS9eeOmMMy8/XICHj0pQ76fL2cYiTZajViAoym1bLNiiXR
+        cogU3/8l/w/4rN2DXAUAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['529']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [1538acf7-0b46-4e73-895e-1df13165eb80]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [1538acf7-0b46-4e73-895e-1df13165eb80]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:1538acf7-0b46-4e73-895e-1df13165eb80']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test-tanner/resources?api-version=2017-05-10
   response:
     body:
       string: !!binary |
@@ -258,16 +758,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:29 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [f12fbd03-33ea-4d62-b7a0-081c828665ef]
+      x-ms-correlation-request-id: [9fb72626-c96c-4f11-b080-b45d0ba1edc4]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [f12fbd03-33ea-4d62-b7a0-081c828665ef]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141029Z:f12fbd03-33ea-4d62-b7a0-081c828665ef']
+      x-ms-request-id: [9fb72626-c96c-4f11-b080-b45d0ba1edc4]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:9fb72626-c96c-4f11-b080-b45d0ba1edc4']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -276,42 +776,35 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test-tags/resources?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_cosmosdb/resources?api-version=2017-05-10
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
-        7892HuR367yp1vU0/7yu1qvm7pvT12+23xx//vruqq4ui1leN3e/KKZ11VTn7fikWqzWbX53VjRv
-        m7tt3rTb2Wy23WYXze//ZfOUPv39d39/gp19Orv34OGnWb5/7979hw8nO/fvZw/uTfZn2afTnY9G
-        Hy2zBaH90dcH0F6vAGAAM2rQvF1/9OgXm45e1vmiWC9+/+evXtN3bZHX7sOPfsnoo0W2zC7y2ZNr
-        +vjuhxORx4UxbSTiZVG366z8IpvOi2WubxlqEJplNc2AA+F0RV+tmz1C9Yc90zchqQTufjw4Px14
-        1DQyTHofYGj+6OcufcF8vkufT+s8ayvMXrYs19Xy4vdc2C6m1YJazAv6cnfv3j79/vtQBwS1qpkl
-        VnW+nb8rmrZYXmwD6qKaFedFPqPvJtWEPlhV1Ue/5JukMZOFxhBnhBd5C9zuLuXn2bLN6/Ns2qXy
-        wd4DwjBGaPmmR+tBuNQ4Qu2fswG/zqfrumiv/XfN0LaXzQWhGxu1fnXTsEPo9ML/K4a+Wk/KYnr2
-        8ng2o/eb7lxvFyvCNDpq/mZw0D241DjUgU+yppjSp6r9XuUXNNSsJBr8v4Myqhn0T++t7UuaUUJc
-        x9H7fJAmHYjUNDJQep9ggU6+fqAGVjv8EDXCa9JtZIjuNvLzeDqt1stW3sJLsyK7eLgLofeIEX7R
-        o8YATGoa8sfrNlvOsnoWGknzKTHER2+LJaigAKnNJnL+kl/y/V/y/wBd1U/EoQgAAA==
+        7892HuR367yp1vU0/7yu1qvmbps37e8/rZpF1cwmd1d1dVnM8rq5+0UxraumOm/HT6vpepEv26dP
+        7s6yNptkTX48nVbrZdvcnU7xvnn9o9FHy2xB+H3U+7y9XuHzW0Gl5m+LJcb3RbW8qJ4+oQ/Kapph
+        kPQhod/Op/RqnZVrNG6zi+ajR7/4o1l+nq3L9vTdKq+LfDnlDhXCL/kl3/8l/w9oRL1ePwEAAA==
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['733']
+      content-length: ['340']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:29 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [1677ad0a-ad3b-4929-b1b5-145199830d59]
+      x-ms-correlation-request-id: [e0959059-c38a-4f1a-8654-8af70e5151d2]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [1677ad0a-ad3b-4929-b1b5-145199830d59]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141030Z:1677ad0a-ad3b-4929-b1b5-145199830d59']
+      x-ms-request-id: [e0959059-c38a-4f1a-8654-8af70e5151d2]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:e0959059-c38a-4f1a-8654-8af70e5151d2']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -320,8 +813,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_emptyrg/resources?api-version=2017-05-10
@@ -336,16 +829,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:29 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [1124c8ba-7d2a-4550-997d-4056696298b4]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [1124c8ba-7d2a-4550-997d-4056696298b4]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141030Z:1124c8ba-7d2a-4550-997d-4056696298b4']
+      x-ms-correlation-request-id: [31ed1034-70cf-4a77-86eb-0d32d5799f6c]
+      x-ms-ratelimit-remaining-subscription-reads: ['14997']
+      x-ms-request-id: [31ed1034-70cf-4a77-86eb-0d32d5799f6c]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:31ed1034-70cf-4a77-86eb-0d32d5799f6c']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -354,11 +847,249 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_templates/resources?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_keyvault/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmbps37e//Nr++zNZle3dVV5fFLK+bu18U07pqqvN2/Hvl1z/JX3KT
+        5u50aprvfjT6aJktCKGPwg/b6xU+HIRBTcpqmgFrakb4tPNpvmzrrFzjuza7aD569It/yS/5/i/5
+        fwDnSjAt8wAAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['295']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [4c5f8e64-506f-4910-9400-591b87da97c5]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [4c5f8e64-506f-4910-9400-591b87da97c5]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:4c5f8e64-506f-4910-9400-591b87da97c5']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_load-balancer/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmbps37e9fVtlse5KV2XKa13dXdXVZzPK6uftFMa2rpjpvxy/y9qqq
+        395FyyfasLk7neJ1fGZe/mj00TJbEIofRb9rr1f47ga41LB5u/7o0S82sJ5kTTGlT9uCoDz66FV+
+        QePNyo9+yeijsppmGD19TONq59N82dZZuW7oy58zKq3Wk7KYnr08ns0IUJNTp8sfVITqfBuQtuX7
+        7WJFY9IhDjcYpJk08nqhxv9/o1ufi35/afT7M210nDe0+qFT8Pu/5P8BEFNTZ6sDAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['392']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [18a03748-534a-46ed-b656-96b090781134]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [18a03748-534a-46ed-b656-96b090781134]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:18a03748-534a-46ed-b656-96b090781134']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_plan/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmbps37e+/KrPl3VVdXRazvG7uflFM66qpztvxd/PJ3SavL/P6WVYv
+        mrvTKdpvZ6sVPi2mOd78aPTRMlsQWh8Nfd1er/D1IFxq0rxdf/ToFxtAr3fpo7bIa/zeZstZVs/o
+        k6b4gf32PFsU5TX+oj+m2SqbFi39uftLRh+9LZagDqFBX5XVNAN56INpvmzrrFw3H/2S7/+S/wcB
+        lZS6TQEAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['349']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [e5fa414e-120a-441b-87c2-0962bbd3e0b1]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [e5fa414e-120a-441b-87c2-0962bbd3e0b1]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:e5fa414e-120a-441b-87c2-0962bbd3e0b1']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmbps37e/ftFWdXeR3V3V1Wczyurn7RTGtq6Y6b8ev9TttczydVutl
+        29ydTlv96PrT7O31L1plF7P2XvXR6KNltiAcPxpu0F6v0ODGPqhp83b90aNfbEC+brPlLKtnv//z
+        V6/py7bIa+/Tj37J6KO3xRKEUYDUpqymGahDH9K42/k0X7Z1Vq4BvM0uGkB/k128yBb5LrWhX38y
+        Ixrv0tf0Oz7e8z7ecx/f8z6+5z7e9z7edx/f9z6+Lx/n+PxT7/NP5XN8/MD7+IF8zM0PvM8P5HN8
+        /ND7+KH7eHfH+5z++CW/5Pu/5P8BV1anQ0QCAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['428']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [2c9dfbb4-36d5-4f2f-878c-36779d2add09]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [2c9dfbb4-36d5-4f2f-878c-36779d2add09]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:2c9dfbb4-36d5-4f2f-878c-36779d2add09']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvm7pvT129+/5/84u6qri6LWV43d78opnXVVOft+KRarNZtfndWNG+b
+        u9Npmzft5eL3x597v3/2cOfhg3w2Pc8+/XT//Hz/YHqQH9D/Hswe7O3s3Ms/Gn20zBaE7Efv/2J7
+        vcKLA5hQg+bt+qNHv9h08LrNlrOsnv3+z1+9pi/bIq+9Tz/6JaOPFtkyu8hnT67p87sfTjSM5/e/
+        XGwk2mVRt+us/CKbzotl7shHCJbVNEPnhAyBbefTfNnWWbnGyNrsosHQ0Jh+pyb4Teb9l/yS0c/p
+        xH/ZPKUPfv/d3/9g9969g2k++/TeebZ/cP/+5CC7f34v35tkk/t7u/emNA6dmq/17o+mnyedfqcm
+        +O1nYfoBdmgML/L2qqrf3l3Kz7Nlm9fn2ZRGsbj+yS9eFJgjpb37oDdpg1Co8TAJfthjXK0nZTE9
+        e3k8m9HbDY/xpX5GiNphep8NjrQHixqHrPoka4RYwqOv8gsaXFbSqP9fRBJlXf2TWlz/5IvTN4S1
+        DsL+PUiIDgRq+nM/utdtVZMSuNvIz+PptFov2+bu/v3FL5peZA9Wb5urosnKYrl+x2Kqox38vjf6
+        gR6oacgERjMN66u3xRIUUYDUZph89L6qjDfZxYtske9SG/r1JzNSGbv0Nf2Oj/e8j/fcx/e8j++5
+        j/e9j/fdx/e9j+/Lxzk+/9T7/FP5HB8/8D5+IB9z8wPv8wP5HB8/9D5+6D7e3fE+pz9+yS/5/i/5
+        fwB5JoITCgkAAA==
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['751']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [30c87675-8f9d-40a7-be1f-e1151ce015d0]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [30c87675-8f9d-40a7-be1f-e1151ce015d0]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:30c87675-8f9d-40a7-be1f-e1151ce015d0']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_webapp/resources?api-version=2017-05-10
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
+        7892HuR367yp1vU0/7yu1qvmbps37e9/lU+y1eruqq4ui1leN3cXxbSumuq8HRfLpriYt83dabVY
+        Vct8iV+neEte+mj00TJbEE4fdT5tr1f4dCMkava2WGIk9Br9UVbTDEOhD/Ksaddo0GYXzUePfvFH
+        82I2y5fbZbF8++juh487W/6gou7m20B6O1sV3ui/sDh/N5/cbQpq0m9POL5SkB/9kl8y+tmekQ5O
+        eX2Z18+yekHkFMK/po+Kaf6yzJZ58/bB3upe8emkmFx+SjS0M3RjS521wd6oSfN2jflQmK936aO2
+        yGv83mbLWVbP6JOm+IH99jxbFOU1/qI/ptkqmxYt/bn7S+zs01DpKyKvmf0pcUedlcQAP3TK8mwL
+        oaQpYaZj7XwapxXepy/tyAr6IzoyAhCydp2XWZvPPoi7L2SkPW4dHi/P7Tnm9q7PGJ/ey/YO7u1v
+        P3y4NyW088WK5uyX/JLv/5L/B/jjfUeFBAAA
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['540']
+      content-type: [application/json; charset=utf-8]
+      date: ['Wed, 27 Jun 2018 14:21:31 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [0d0860ef-8239-4d27-97a6-bc72da85766c]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [0d0860ef-8239-4d27-97a6-bc72da85766c]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:0d0860ef-8239-4d27-97a6-bc72da85766c']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/testingtestingtesting123/resources?api-version=2017-05-10
   response:
     body:
       string: !!binary |
@@ -370,60 +1101,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:29 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [4a34cc7f-2ddf-4e2f-8b20-62098618cca5]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [4a34cc7f-2ddf-4e2f-8b20-62098618cca5]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141030Z:4a34cc7f-2ddf-4e2f-8b20-62098618cca5']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_vm/resources?api-version=2017-05-10
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
-        7892HuR367yp1vU0/7yu1qvm7pvT129+/5/84u6qri6LWV43d78opnXVVOft+KRarNZtfndWNG+b
-        u9Npmzft5eL3x597v//9bH/26d6ns/2dyYS62p3k+7M8u//pZP/+wcH5g+yj0UfLbEHIfvT+L7bX
-        K7w4gAk1aN6uP3r0i00Hr9tsOcvq2e///NVr+rIt8tr79KNfMvpokS2zi3z25Jo+v/vhRMN4fv/L
-        xUaiXRZ1u87KL7LpvFjmjnyEYFlNM3ROyBDYdj7Nl22dlWuMrM0uGgwNjel3aoLfZN5/yS8Z/ZxO
-        /JfNU/rg99/9/c/37z/cyT/Ndnb3pvsPPs1oCvOD+7s0e5N7e59OHtI4dGq+1rs/mn6edPqdmuC3
-        n6Pp3zAGJb33yeCkdaBQ069LAP52lz7iP3e/WYKgm6FJfZG3V1X99u5Sfp4t27w+z6ZEksX1T37x
-        opgSakoR90GPIINQqPEwSX7YY1ytJ2UxPXt5PJvR2w2P8aV+RojaYXqfDY60B4sah7L7JGuEWCK0
-        r/ILGlxW0qj/X0QS5WD9k1pc/+SL0zeEtQ7C/j1IiA4EavpzP7rXbVWTVrzbyM/j6bRaL9vm7v79
-        xS+aXmQPVm+bq6LJymK5fscSrqMd/L43+oEeqGnIBEZVDyvwt8USFFGA1GaYfPS+qJBf8ku+/0v+
-        H6fVFJ0yCQAA
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['693']
-      content-type: [application/json; charset=utf-8]
-      date: ['Thu, 19 Apr 2018 14:10:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [243ff69b-2977-4c52-a9ff-5793577306cd]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [243ff69b-2977-4c52-a9ff-5793577306cd]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141030Z:243ff69b-2977-4c52-a9ff-5793577306cd']
+      x-ms-correlation-request-id: [7d0cdbff-6850-48a9-b5bf-1b87d7b215f7]
+      x-ms-ratelimit-remaining-subscription-reads: ['14997']
+      x-ms-request-id: [7d0cdbff-6850-48a9-b5bf-1b87d7b215f7]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:7d0cdbff-6850-48a9-b5bf-1b87d7b215f7']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -433,8 +1120,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.16299) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: DELETE
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_emptyrg?api-version=2017-05-10
@@ -443,16 +1130,16 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Thu, 19 Apr 2018 14:10:31 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:32 GMT']
       expires: ['-1']
       location: ['https://management.azure.com/subscriptions/aa98974b-5d2a-4d98-a78a-382f3715d07e/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1URVNUOjVGRU1QVFlSRy1TT1VUSENFTlRSQUxVUyIsImpvYkxvY2F0aW9uIjoic291dGhjZW50cmFsdXMifQ?api-version=2017-05-10']
       pragma: [no-cache]
       retry-after: ['15']
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [e2641330-0667-4c45-a3f8-54c3a5ce96c1]
-      x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-id: [e2641330-0667-4c45-a3f8-54c3a5ce96c1]
-      x-ms-routing-request-id: ['WESTUS2:20180419T141031Z:e2641330-0667-4c45-a3f8-54c3a5ce96c1']
+      x-ms-correlation-request-id: [ac624739-772e-40ef-aeab-c19156187729]
+      x-ms-ratelimit-remaining-subscription-deletes: ['14999']
+      x-ms-request-id: [ac624739-772e-40ef-aeab-c19156187729]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142132Z:ac624739-772e-40ef-aeab-c19156187729']
     status: {code: 202, message: Accepted}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/ResourceGroupTest.test_delete_empty_group.yaml
+++ b/tools/c7n_azure/tests/cassettes/ResourceGroupTest.test_delete_empty_group.yaml
@@ -25,26 +25,25 @@ interactions:
         LheEdJQW/A39+f93OjT5cnZRE9QeHbxv6E9DhwgJfi6HMcmaYrrd5PVlMc23VyW7DjqQ6HfeUP5f
         oGVFf1orTKgo7v0v/t+FOJvewPIq4v0vPMR95iFk/9+AOhyfKOr4wkP9/3U0f1q1L3Lomij29ltv
         CP+voH7T5ufZEi4PYEDVEjY6hOh33gBkDugzwvfnBnvSeNvZTDye7by+ysvpnPBR/Ae+7Y3g55SL
-        GLk2WxKTEBoG8+BDD+H/V/AMsPv9xTmZTQgRD2n/Yw9tev3/V9aah5ovVu11fUEI+wRwnxLOg+Mn
-        XH8OMX+bX19m6xK09lH3Pt6E+/8f5q6sstn2JCMfZMoi5pOh+x3h//9rWqgn5pNAPyJszcj9QROC
-        P4fokgtWZxc54eFj7D71kKaXw+kiXH8OMecYxkeaP9iEr2GvVZ1v5++KpiVMt3epZVttv83zFTUJ
-        vtoLvqK30ZaThvD8Ovw4q7aXVbu9II/2/Prnng2v8km2Ato+heyHt6FSZ3z/L5U36iX8sbsH39Yb
-        NX0W/pAWNBZDgq/rt3z/l/w/MOBaD0QWAAA=
+        gNzvL5Z+NiFEDO6djz2k6fX/X5k+Hmq+WLXX9QUh7BPAfUo4D46fcP05xPxtfn2ZrUvQ2kfd+3gT
+        7v9/mLuyymbbk4wM+jSvCW2fDN3vCP//X9NC3RqfBPoRYWtG7g+aEPw5RJf8mTq7yAkPH2P3qYc0
+        vRxOF+H6c4g5BwQ+0vzBJnwNe63qfDt/VzQtYbq9Sy3bavttnq+oSfDVXvAVvY22nIGDG9Xhx1m1
+        vaza7QW5h+fXP/dseJVPshXQ9ilkP7wNlTrj+6bk7fu/5P8BHyxLKsYUAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['881']
+      content-length: ['842']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:25 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [61a853a3-cbff-4aae-855c-0c6da3859ff7]
+      x-ms-correlation-request-id: [2810e5e6-9216-4367-99d1-33b79251d291]
       x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [61a853a3-cbff-4aae-855c-0c6da3859ff7]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142126Z:61a853a3-cbff-4aae-855c-0c6da3859ff7']
+      x-ms-request-id: [2810e5e6-9216-4367-99d1-33b79251d291]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162258Z:2810e5e6-9216-4367-99d1-33b79251d291']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -74,16 +73,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['419']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:57 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [7237137c-529a-4858-ae3a-4ef4be18092a]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [7237137c-529a-4858-ae3a-4ef4be18092a]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142126Z:7237137c-529a-4858-ae3a-4ef4be18092a']
+      x-ms-correlation-request-id: [ab594e68-ebba-44d5-a5bc-5a2477960769]
+      x-ms-ratelimit-remaining-subscription-reads: ['14997']
+      x-ms-request-id: [ab594e68-ebba-44d5-a5bc-5a2477960769]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162258Z:ab594e68-ebba-44d5-a5bc-5a2477960769']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -114,16 +113,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['505']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [a889b083-eaa8-4482-bf70-dca95c795e24]
+      x-ms-correlation-request-id: [2511ee9c-d14e-4328-989c-70c6b1b6ac2e]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [a889b083-eaa8-4482-bf70-dca95c795e24]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:a889b083-eaa8-4482-bf70-dca95c795e24']
+      x-ms-request-id: [2511ee9c-d14e-4328-989c-70c6b1b6ac2e]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162258Z:2511ee9c-d14e-4328-989c-70c6b1b6ac2e']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -154,16 +153,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['500']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [ef375e83-515e-4560-a85c-410313924c6b]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [ef375e83-515e-4560-a85c-410313924c6b]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:ef375e83-515e-4560-a85c-410313924c6b']
+      x-ms-correlation-request-id: [ebb859a9-81e4-4982-bfbb-10c52d1c9639]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [ebb859a9-81e4-4982-bfbb-10c52d1c9639]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162258Z:ebb859a9-81e4-4982-bfbb-10c52d1c9639']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -193,16 +192,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['428']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [68569d4e-6c94-4867-93ee-5442db4a3a88]
+      x-ms-correlation-request-id: [a902a0ad-55b4-4016-a564-f91795077a75]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [68569d4e-6c94-4867-93ee-5442db4a3a88]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:68569d4e-6c94-4867-93ee-5442db4a3a88']
+      x-ms-request-id: [a902a0ad-55b4-4016-a564-f91795077a75]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162259Z:a902a0ad-55b4-4016-a564-f91795077a75']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -248,16 +247,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['1348']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [1424dc59-18a8-4a74-b785-c37c32e0d1ed]
+      x-ms-correlation-request-id: [a728debd-cf19-4983-bfc9-caa25ea4096b]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [1424dc59-18a8-4a74-b785-c37c32e0d1ed]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:1424dc59-18a8-4a74-b785-c37c32e0d1ed']
+      x-ms-request-id: [a728debd-cf19-4983-bfc9-caa25ea4096b]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162259Z:a728debd-cf19-4983-bfc9-caa25ea4096b']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -285,16 +284,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['293']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [71a0029c-3424-4f8b-b680-2b3fe0a5bcf7]
+      x-ms-correlation-request-id: [0f3d20ba-7b23-4f2f-85ad-38459ad1f213]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [71a0029c-3424-4f8b-b680-2b3fe0a5bcf7]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:71a0029c-3424-4f8b-b680-2b3fe0a5bcf7']
+      x-ms-request-id: [0f3d20ba-7b23-4f2f-85ad-38459ad1f213]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162259Z:0f3d20ba-7b23-4f2f-85ad-38459ad1f213']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -325,16 +324,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['503']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [e37bb897-80c3-4b50-9f6b-dec1e2d93f2b]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [e37bb897-80c3-4b50-9f6b-dec1e2d93f2b]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:e37bb897-80c3-4b50-9f6b-dec1e2d93f2b']
+      x-ms-correlation-request-id: [b0fbbc52-e704-4ab9-a076-f39e4ec0486d]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [b0fbbc52-e704-4ab9-a076-f39e4ec0486d]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162259Z:b0fbbc52-e704-4ab9-a076-f39e4ec0486d']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -362,16 +361,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['339']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:58 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [31b606e4-2a06-429d-b1f6-c634b63588f2]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [31b606e4-2a06-429d-b1f6-c634b63588f2]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:31b606e4-2a06-429d-b1f6-c634b63588f2']
+      x-ms-correlation-request-id: [c5128b2a-ceae-4a71-98e3-038a3eee1231]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [c5128b2a-ceae-4a71-98e3-038a3eee1231]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162259Z:c5128b2a-ceae-4a71-98e3-038a3eee1231']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -407,16 +406,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['786']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [3d790120-95b3-4276-85e8-11b2fca3c1d0]
+      x-ms-correlation-request-id: [7e3089d5-51c7-4a3e-8f4a-0838aa573406]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [3d790120-95b3-4276-85e8-11b2fca3c1d0]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:3d790120-95b3-4276-85e8-11b2fca3c1d0']
+      x-ms-request-id: [7e3089d5-51c7-4a3e-8f4a-0838aa573406]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162300Z:7e3089d5-51c7-4a3e-8f4a-0838aa573406']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -444,16 +443,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['326']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [b7577b2b-0fce-4fff-bf8b-8685777d28d8]
+      x-ms-correlation-request-id: [eef3bdf5-6a5e-4615-98c0-653d4ec67435]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [b7577b2b-0fce-4fff-bf8b-8685777d28d8]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:b7577b2b-0fce-4fff-bf8b-8685777d28d8']
+      x-ms-request-id: [eef3bdf5-6a5e-4615-98c0-653d4ec67435]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162300Z:eef3bdf5-6a5e-4615-98c0-653d4ec67435']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -485,16 +484,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['537']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [f40fee91-7c5a-47aa-bf14-9b270ac3a077]
+      x-ms-correlation-request-id: [373d1349-30af-4fd9-b60d-0c6a37aec41f]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [f40fee91-7c5a-47aa-bf14-9b270ac3a077]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142128Z:f40fee91-7c5a-47aa-bf14-9b270ac3a077']
+      x-ms-request-id: [373d1349-30af-4fd9-b60d-0c6a37aec41f]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162300Z:373d1349-30af-4fd9-b60d-0c6a37aec41f']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -527,16 +526,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['582']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [0c98280c-a5f4-41bc-b1b7-312b9751c730]
+      x-ms-correlation-request-id: [63ff0d02-9153-417d-963d-18802b670b81]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [0c98280c-a5f4-41bc-b1b7-312b9751c730]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:0c98280c-a5f4-41bc-b1b7-312b9751c730']
+      x-ms-request-id: [63ff0d02-9153-417d-963d-18802b670b81]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162300Z:63ff0d02-9153-417d-963d-18802b670b81']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -565,16 +564,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['359']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      date: ['Wed, 27 Jun 2018 16:22:59 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [1e00b091-0be1-4c03-a502-2838a0b7ac8c]
+      x-ms-correlation-request-id: [0a55c30f-c08e-4ca6-8140-809f3bd7ef5c]
       x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [1e00b091-0be1-4c03-a502-2838a0b7ac8c]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:1e00b091-0be1-4c03-a502-2838a0b7ac8c']
+      x-ms-request-id: [0a55c30f-c08e-4ca6-8140-809f3bd7ef5c]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162300Z:0a55c30f-c08e-4ca6-8140-809f3bd7ef5c']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -605,16 +604,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['504']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [16265876-8710-4434-946e-df3bd5e4e2d3]
+      x-ms-correlation-request-id: [fd62532a-c9b5-4d0b-a423-0710c6666ce3]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [16265876-8710-4434-946e-df3bd5e4e2d3]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:16265876-8710-4434-946e-df3bd5e4e2d3']
+      x-ms-request-id: [fd62532a-c9b5-4d0b-a423-0710c6666ce3]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162301Z:fd62532a-c9b5-4d0b-a423-0710c6666ce3']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -642,16 +641,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['340']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:28 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:00 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [1588e598-a504-4f0a-9132-bf250fa4eb0a]
+      x-ms-correlation-request-id: [7bf52158-278b-41e0-b3bf-5edaa546c936]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [1588e598-a504-4f0a-9132-bf250fa4eb0a]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:1588e598-a504-4f0a-9132-bf250fa4eb0a']
+      x-ms-request-id: [7bf52158-278b-41e0-b3bf-5edaa546c936]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162301Z:7bf52158-278b-41e0-b3bf-5edaa546c936']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -683,16 +682,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['570']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [56baadb5-e771-4109-8df7-a430ca7eadf1]
+      x-ms-correlation-request-id: [73279b6f-ae02-4f33-b7e6-63790f5268a2]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [56baadb5-e771-4109-8df7-a430ca7eadf1]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142129Z:56baadb5-e771-4109-8df7-a430ca7eadf1']
+      x-ms-request-id: [73279b6f-ae02-4f33-b7e6-63790f5268a2]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162301Z:73279b6f-ae02-4f33-b7e6-63790f5268a2']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -724,50 +723,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['529']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [1538acf7-0b46-4e73-895e-1df13165eb80]
+      x-ms-correlation-request-id: [e6110c13-3d4a-4c8f-b7e1-26679427bd5f]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [1538acf7-0b46-4e73-895e-1df13165eb80]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:1538acf7-0b46-4e73-895e-1df13165eb80']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test-tanner/resources?api-version=2017-05-10
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS97/+S/wdC6kBEDAAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [9fb72626-c96c-4f11-b080-b45d0ba1edc4]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [9fb72626-c96c-4f11-b080-b45d0ba1edc4]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:9fb72626-c96c-4f11-b080-b45d0ba1edc4']
+      x-ms-request-id: [e6110c13-3d4a-4c8f-b7e1-26679427bd5f]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162301Z:e6110c13-3d4a-4c8f-b7e1-26679427bd5f']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -795,16 +760,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['340']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [e0959059-c38a-4f1a-8654-8af70e5151d2]
+      x-ms-correlation-request-id: [04a84304-8a5e-4d72-84cb-99c379d6f6d9]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [e0959059-c38a-4f1a-8654-8af70e5151d2]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:e0959059-c38a-4f1a-8654-8af70e5151d2']
+      x-ms-request-id: [04a84304-8a5e-4d72-84cb-99c379d6f6d9]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162301Z:04a84304-8a5e-4d72-84cb-99c379d6f6d9']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -829,16 +794,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['133']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [31ed1034-70cf-4a77-86eb-0d32d5799f6c]
-      x-ms-ratelimit-remaining-subscription-reads: ['14997']
-      x-ms-request-id: [31ed1034-70cf-4a77-86eb-0d32d5799f6c]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:31ed1034-70cf-4a77-86eb-0d32d5799f6c']
+      x-ms-correlation-request-id: [2d85178b-d528-4c3b-976b-8b16a5d22a42]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [2d85178b-d528-4c3b-976b-8b16a5d22a42]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162301Z:2d85178b-d528-4c3b-976b-8b16a5d22a42']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -866,16 +831,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['295']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:29 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [4c5f8e64-506f-4910-9400-591b87da97c5]
+      x-ms-correlation-request-id: [8f3956cc-9c1d-47d7-af9e-b919cb9e4a34]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [4c5f8e64-506f-4910-9400-591b87da97c5]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:4c5f8e64-506f-4910-9400-591b87da97c5']
+      x-ms-request-id: [8f3956cc-9c1d-47d7-af9e-b919cb9e4a34]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162302Z:8f3956cc-9c1d-47d7-af9e-b919cb9e4a34']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -904,16 +869,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['392']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [18a03748-534a-46ed-b656-96b090781134]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [18a03748-534a-46ed-b656-96b090781134]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142130Z:18a03748-534a-46ed-b656-96b090781134']
+      x-ms-correlation-request-id: [189442fc-7936-46ce-942f-5eaa30baf514]
+      x-ms-ratelimit-remaining-subscription-reads: ['14997']
+      x-ms-request-id: [189442fc-7936-46ce-942f-5eaa30baf514]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162302Z:189442fc-7936-46ce-942f-5eaa30baf514']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -942,16 +907,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['349']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [e5fa414e-120a-441b-87c2-0962bbd3e0b1]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [e5fa414e-120a-441b-87c2-0962bbd3e0b1]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:e5fa414e-120a-441b-87c2-0962bbd3e0b1']
+      x-ms-correlation-request-id: [97fc3917-e1fd-44dd-9533-8ba90fd70c63]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [97fc3917-e1fd-44dd-9533-8ba90fd70c63]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162302Z:97fc3917-e1fd-44dd-9533-8ba90fd70c63']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -981,16 +946,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['428']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:01 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [2c9dfbb4-36d5-4f2f-878c-36779d2add09]
+      x-ms-correlation-request-id: [cde0fcce-17d8-43c1-9af4-8d2789a10f47]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [2c9dfbb4-36d5-4f2f-878c-36779d2add09]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:2c9dfbb4-36d5-4f2f-878c-36779d2add09']
+      x-ms-request-id: [cde0fcce-17d8-43c1-9af4-8d2789a10f47]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162302Z:cde0fcce-17d8-43c1-9af4-8d2789a10f47']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1026,16 +991,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['751']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [30c87675-8f9d-40a7-be1f-e1151ce015d0]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [30c87675-8f9d-40a7-be1f-e1151ce015d0]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:30c87675-8f9d-40a7-be1f-e1151ce015d0']
+      x-ms-correlation-request-id: [e052ff5f-a20a-44c4-938d-5e0d60e575ec]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [e052ff5f-a20a-44c4-938d-5e0d60e575ec]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162302Z:e052ff5f-a20a-44c4-938d-5e0d60e575ec']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1067,50 +1032,16 @@ interactions:
       content-encoding: [gzip]
       content-length: ['540']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:31 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:02 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [0d0860ef-8239-4d27-97a6-bc72da85766c]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [0d0860ef-8239-4d27-97a6-bc72da85766c]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:0d0860ef-8239-4d27-97a6-bc72da85766c']
-    status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
-          msrest_azure/0.4.31 resourcemanagementclient/1.2.1 Azure-SDK-For-Python]
-      accept-language: [en-US]
-    method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/testingtestingtesting123/resources?api-version=2017-05-10
-  response:
-    body:
-      string: !!binary |
-        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
-        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS97/+S/wdC6kBEDAAAAA==
-    headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['133']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:30 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [7d0cdbff-6850-48a9-b5bf-1b87d7b215f7]
-      x-ms-ratelimit-remaining-subscription-reads: ['14997']
-      x-ms-request-id: [7d0cdbff-6850-48a9-b5bf-1b87d7b215f7]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142131Z:7d0cdbff-6850-48a9-b5bf-1b87d7b215f7']
+      x-ms-correlation-request-id: [84b92d18-6867-4cb1-8624-a7b3f3689b27]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [84b92d18-6867-4cb1-8624-a7b3f3689b27]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162303Z:84b92d18-6867-4cb1-8624-a7b3f3689b27']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -1126,20 +1057,20 @@ interactions:
     method: DELETE
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourcegroups/test_emptyrg?api-version=2017-05-10
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       cache-control: [no-cache]
       content-length: ['0']
-      date: ['Wed, 27 Jun 2018 14:21:32 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:04 GMT']
       expires: ['-1']
       location: ['https://management.azure.com/subscriptions/aa98974b-5d2a-4d98-a78a-382f3715d07e/operationresults/eyJqb2JJZCI6IlJFU09VUkNFR1JPVVBERUxFVElPTkpPQi1URVNUOjVGRU1QVFlSRy1TT1VUSENFTlRSQUxVUyIsImpvYkxvY2F0aW9uIjoic291dGhjZW50cmFsdXMifQ?api-version=2017-05-10']
       pragma: [no-cache]
       retry-after: ['15']
       strict-transport-security: [max-age=31536000; includeSubDomains]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [ac624739-772e-40ef-aeab-c19156187729]
+      x-ms-correlation-request-id: [c53a716c-a2f9-4871-9499-49a8c8972b7d]
       x-ms-ratelimit-remaining-subscription-deletes: ['14999']
-      x-ms-request-id: [ac624739-772e-40ef-aeab-c19156187729]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142132Z:ac624739-772e-40ef-aeab-c19156187729']
+      x-ms-request-id: [c53a716c-a2f9-4871-9499-49a8c8972b7d]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162304Z:c53a716c-a2f9-4871-9499-49a8c8972b7d']
     status: {code: 202, message: Accepted}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_cycle_queue_message_by_uri.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_cycle_queue_message_by_uri.yaml
@@ -63,18 +63,18 @@ interactions:
       content-encoding: [gzip]
       content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:19:13 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:04 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [cf6bd7e3-44f6-4d59-af36-4484af6889ba]
-      x-ms-original-request-ids: [6e7786da-31e4-4062-9509-61468131c49f, ef9984bc-999c-4fa8-a6c6-a8beaecabbaf,
-        fc6336e1-1891-4da6-9458-6d921a6484fa, cb0f10b6-1d4d-4b72-a37d-23f36a56b8dc]
+      x-ms-correlation-request-id: [0631571d-85aa-450b-8ef6-9af8683ca6e6]
+      x-ms-original-request-ids: [7a3e5add-878e-41f6-8bdc-6b2a8e335fcd, bcbae896-8f57-42ec-80d1-aea9a21afa76,
+        18998b49-53e7-4011-b30d-92b7b162a567, 29a33c25-c144-492a-ac5d-55c83caf7402]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [cf6bd7e3-44f6-4d59-af36-4484af6889ba]
-      x-ms-routing-request-id: ['WESTUS2:20180627T141913Z:cf6bd7e3-44f6-4d59-af36-4484af6889ba']
+      x-ms-request-id: [0631571d-85aa-450b-8ef6-9af8683ca6e6]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162305Z:0631571d-85aa-450b-8ef6-9af8683ca6e6']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -140,18 +140,18 @@ interactions:
       content-encoding: [gzip]
       content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [5eee8b37-ad36-4f64-988e-a5d2d3b7d3e2]
-      x-ms-original-request-ids: [93d2835f-d26d-4f1c-95be-1b5a9640466a, 45f6acef-af41-45d5-afaf-480a27856cb7,
-        483cf958-3895-4f4b-8f69-2f1ebdc6d786, 81df143f-0965-4c47-be18-a3e5dfb30c19]
+      x-ms-correlation-request-id: [0e5bd36e-0adc-4606-a61f-7b82cfdb312e]
+      x-ms-original-request-ids: [cbbaef97-7873-4561-ae49-bd4b407d2eec, 78ac851e-b53c-435b-9eeb-993ba4de0890,
+        5c97b863-5c98-4e6b-ac25-6f1d9f7cf5d5, 2f43bb84-6c54-473c-89a7-63852dbe06b7]
       x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [5eee8b37-ad36-4f64-988e-a5d2d3b7d3e2]
-      x-ms-routing-request-id: ['WESTUS2:20180627T141914Z:5eee8b37-ad36-4f64-988e-a5d2d3b7d3e2']
+      x-ms-request-id: [0e5bd36e-0adc-4606-a61f-7b82cfdb312e]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162305Z:0e5bd36e-0adc-4606-a61f-7b82cfdb312e']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -180,7 +180,7 @@ interactions:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json]
-      date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -188,10 +188,10 @@ interactions:
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [7a13b612-bba0-49f4-a2d8-809102042a8e]
+      x-ms-correlation-request-id: [50330041-0621-4f27-90a8-8998c02e9572]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-id: [4e9b2440-d9e7-488c-ae4d-da73a1fc1aba]
-      x-ms-routing-request-id: ['WESTUS2:20180627T141914Z:7a13b612-bba0-49f4-a2d8-809102042a8e']
+      x-ms-request-id: [03a0ea78-f36e-4878-93d5-034c7a4f6500]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162305Z:50330041-0621-4f27-90a8-8998c02e9572']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -199,41 +199,41 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [f7464794-2003-00d6-5021-0e12d9000000]
+      x-ms-request-id: [0be99ed2-4003-00ab-0433-0e8e11000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
-    body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
+    body: '<?xml version=''1.0'' encoding=''utf-8''?>
 
       <QueueMessage><MessageText>hello queue</MessageText></QueueMessage>'
     headers:
       Connection: [keep-alive]
       Content-Length: ['106']
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       x-ms-version: ['2018-03-28']
     method: POST
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>2c9de829-e5c5-4279-b717-3d305e914d24</MessageId><InsertionTime>Wed,\
-        \ 27 Jun 2018 14:19:15 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
-        \ 14:19:15 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAlnXg0yEO1AE=</PopReceipt><TimeNextVisible>Wed,\
-        \ 27 Jun 2018 14:19:15 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>fcc19b25-7850-4443-a58b-5b040050d73a</MessageId><InsertionTime>Wed,\
+        \ 27 Jun 2018 16:23:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
+        \ 16:23:06 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAezEuITMO1AE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 27 Jun 2018 16:23:06 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
     headers:
       content-type: [application/xml]
-      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [f74647ab-2003-00d6-6521-0e12d9000000]
+      x-ms-request-id: [0be99ee7-4003-00ab-1633-0e8e11000000]
       x-ms-version: ['2018-03-28']
     status: {code: 201, message: Created}
 - request:
@@ -241,22 +241,22 @@ interactions:
     headers:
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       x-ms-version: ['2018-03-28']
     method: GET
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>2c9de829-e5c5-4279-b717-3d305e914d24</MessageId><InsertionTime>Wed,\
-        \ 27 Jun 2018 14:19:15 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
-        \ 14:19:15 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAASBPP5SEO1AE=</PopReceipt><TimeNextVisible>Wed,\
-        \ 27 Jun 2018 14:19:45 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>hello\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>fcc19b25-7850-4443-a58b-5b040050d73a</MessageId><InsertionTime>Wed,\
+        \ 27 Jun 2018 16:23:06 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
+        \ 16:23:06 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAD/oaMzMO1AE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 27 Jun 2018 16:23:36 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>hello\
         \ queue</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [f74647ba-2003-00d6-7421-0e12d9000000]
+      x-ms-request-id: [0be99ef9-4003-00ab-2533-0e8e11000000]
       x-ms-version: ['2018-03-28']
     status: {code: 200, message: OK}
 - request:
@@ -265,17 +265,17 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       x-ms-version: ['2018-03-28']
     method: DELETE
-    uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages/2c9de829-e5c5-4279-b717-3d305e914d24?popreceipt=AgAAAAMAAAAAAAAASBPP5SEO1AE%3D
+    uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages/fcc19b25-7850-4443-a58b-5b040050d73a?popreceipt=AgAAAAMAAAAAAAAAD%2FoaMzMO1AE%3D
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [f74647ca-2003-00d6-0321-0e12d9000000]
+      x-ms-request-id: [0be99f10-4003-00ab-3933-0e8e11000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
@@ -283,7 +283,7 @@ interactions:
     headers:
       Connection: [keep-alive]
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       x-ms-version: ['2018-03-28']
     method: GET
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
@@ -293,9 +293,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:05 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [f74647d9-2003-00d6-1221-0e12d9000000]
+      x-ms-request-id: [0be99f20-4003-00ab-4433-0e8e11000000]
       x-ms-version: ['2018-03-28']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_cycle_queue_message_by_uri.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_cycle_queue_message_by_uri.yaml
@@ -6,8 +6,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -18,40 +18,63 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
         alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
-        epp/XlfrVXO3zZv2928E7N1VXV0Ws7xu7n5RTOuqqc7bsXZ5V9scT6fVetk2d6fTVj+6/jR7e/2L
-        VtnFrL1XEWo6qOEG7fUKDW7sg5qW1TTD4Kg5od3Op/myrbNyje/a7KIhIhJ1CO9VXhPZ8PdHy7y9
-        quq3x9OS/5xcr7KGfvvo+AfrOn+d15fFlBqOPros6nadlS+k+at1SZ8++t73ibYr749Zfp6ty/Z4
-        qmgcl2V1hSlp63XT5rOnRZ1PCW/u/HsfPdg7f3hwMDnfPvj0fHd7fzc73364m02292YPprOd3d3Z
-        ZP/BRwS2Wa9WVd02327bVfOmzs7Pi+mXy/L6o0fnWdnko4/y5bS+5onFIBqDNv1+XpREvl9MLbJJ
-        mRMfECb0Qpk17al89KbgGdjb2T3Y3rm/vbP/ZvfTR7sHj+7dH9+//+m93U8f/BRGMCmryTcAiCC9
-        za9fM1dR4960oiuaocuiocEUywvi6xYNX6+n0zyfUcejj6Z1zvO8ocP9h8THn/4UNV7VxSKrr0+X
-        s1VVgE9oDDKWj+Yg56O7Q9w5RrPxtKrz8RVJVHXVjIlb7hLMX7TOIZo3AuB2UQgtKHYLCNwuCkEm
-        9kYAaBZ5n6nMhHm+QWgaIv66+fL8pTSlJtllVpTACTNJnPb/Fs2ULX9QkfjPt6Giti8X76WdzMt4
-        93IxK7KLh/d3CTkd1tDXP9JMxCE/NM20v7374M3e7qO9B4/27o3v7+/f29vZIYXy3pppCBBB+tnR
-        TGGH+we7Dx7eUjFFOe/2ain+OreKvt+CWDe+z62i78uM3vA6GkXeZuIyQf7/oZAw6N//PfXQ/v3F
-        L5peZA9Wb5urosnKYrl+d7kgpHQ4g9//SBMRa/wwNdHDN7sPH+3sPdrdH3+6f0B8sE8K5Otooigg
-        gvSzpon8Dnd27+/c1keK897tddHA+9wsCqAFvW4GwM2iAGRWb3ofrSKvM4WZKP//UEfUxfX26rqd
-        V8vt8/Vy+l56CS/Lu3iVsNLx9D7/enroilTlutmjD3+kgMA6NOWECb0wpDc41NnZeXT/00f7B+N7
-        O3v3du6THNMIII7fACCC9LOjgMIO9/b2dx/eu6UCCpnt9oqn8x5/HX2xBX2GX+Svoy/K7A29h28j
-        rzEFedCegnGS8PNSs8BFPHiI0EqHNfT1j/TMD0nP7N5/s3uPopZH9x+O9+493L+3T6ELjQDS9w0A
-        Ikg/W3rG73D3wacP7+1+LT2jPPd11Y15nVtF329BrRvf51bR92VKb3gdjSJvM3WZIF9DB33/l/w/
-        kzllB6MWAAA=
+        epp/XlfrFb2znF1vl8Vy/W57Wi3brFjm9e7dVV1dFrO8bu5+UUzrqqnO27H2fbeRn8fTabVets1d
+        ftm9S7jpqPpftNcrfHEjTGpaVtMMo6LmV3nTrvFZm100RDUiB+G3ymuiE/7+aJm3V1X99nha8p+T
+        61XW0G8fHf9gXeev8/qymFLD0UeXRd2us/KFNH+1LunTR9/7PhFz5f0xy8+zddkeT7X747KsrjAH
+        bb1u2nz2tKjzKeHLnX/vowd75w8PDibn2wefnu9u7+9m59sPd7PJ9t7swXS2s7s7m+w/+IjANuvV
+        qqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zyTGERj0Kbfz4uSyPaLqUU2KXOaeMKEXiiz
+        pj2Vj94UTPG9nd2D7Z1Pt3fvv9nbfbT34NG9++MHOw93H+x8+lMYwaSsJt8AIIL0Nr9+zWxEjXvT
+        ia5ohi6LhgZTLC+IkVs0fL2eTvN8Rh2PPprWOc/vhg7v33twb+fezk9R61VdLLL6+nQ5W1UFGIQG
+        IYP5aA56PrrbZcMxvh5PqzofX5HsVFfNmNjkLsH6RescQjj4In8ffbMFiTa8yd9H35QZHHwRX0fe
+        YzLywJ9HpKEhqq6bL89fShP6KrvMihI4YIqIhf5fpWOmJDzVrMiW995Lu+Bd9+rBXv4pIaZDin73
+        Ix3zw9Exe7tvdg8e7ew+2r8/3tn59P79/YekGr6GjokDIkg/WzrGdbg/frC/8/DevQe31DF9hru9
+        mom8y02iL7cg1OaXuUn0ZZnKTe+iReRVJikT4f/b+oYk6Dxbnq+XLF4tDeC9VE7/dcJNRxX97kcq
+        54ekcu6/2f300f2Hj3Yfjvd3P93Z24M38nVUThQQQfpZUzleh3sPd3ce7uzfUuXQ1HQY7vYqJ/Iu
+        N4m+3IJQm1/mJtGXZSo3vYsWkVeZpEyE/2+rHIzx91dxfy9lM522+tH1p9nb61+0yi5m7b2KUNNB
+        DTf4emqH0G7n03zZ1lnJRFb189Gb7OJFtsh3qQ39+pMZhaqI2eh3fLznfbznPr7nfXzPfbzvfbzv
+        Pr7vfXxfPs7x+afe5/Dh6Hd8/MD7+IF8zM0PvM8P5HN8/ND7+KH7eHfH+5z+IDagCfqRnh1Sj/e3
+        d/ahrchHQhB2/9N7u5+Sg0QjgOL5BgARpJ8dPRt2uP+QBJb0OoCx+tikZgek7Pa6dggAt4tCaEGx
+        W0DgdlEIMrE3AkCzyPtMZSaMp3p72uH/Oyo4W/6gIj0334Yu3r5cvJcaNi/j3csFecoXD+9D++mw
+        hr7+kQqmz3+kgr9pFby/vftA82B798b39/fv7e1QHoxGAH30DQAiSD87KjjscP9g9wEF84DF2mOT
+        Bo6K2O31b/x1bhV9vwWxbnyfW0Xflxm94XU0irzNxGWC/P9D82LQv/97Ktz9+4tfNL3IHqzeNldF
+        k3FG9HJBSOlwBr//kcqlz3+kcn8WVO7DN7sPH+3sPdrdH3+6f0AMTzE6jQAq6BsARJB+1lSu3+HO
+        7n0s0gAY641NOjcuZLdXugPvc7MogBb0uhkAN4sCkFm96X20irzOFGai/P9E72YX29lsJg5vXl/l
+        5XT+XkqYAND7eF3fJuR0WLGvvp7q9WlLUMGHRBRC8+ebMiKeuaUOoXXQgzd7O4/2dx/de0iR84OD
+        B3u7pEPeWxkNASJIPzvKKOxwf+fB/t6De7fURsQcIcvdXhH1X+UW0XdbkGnju9wi+i4Uy8ZX0SDy
+        JpOTCeBpHl8w/r+jdKZltZ651dz30jf8rn2VkNLh9D7/eppG8sbw02hiwGFEB0LvR3pmg3og1+EA
+        0dr9nfHDvft7+5/ukXr4OnomCogg/azpGa/Dg0/3Du49vK3XE3Lb7ZVM5z3+OvpiCwINv8hfR1+U
+        6Rt6D99GXmMS8qA93eJE4f87moW9tymtF2XFMq/vvZdm6bz7cGcXoZOOKf7lN6RjEGRxwEVf0q8S
+        b9HX9Ds+/lEE+fNIme6/2bv3aHf30f09pL52DvaRa/s6yjQKiCD9rClTr0NS3Z8+vH9LXRoRrdsr
+        1NjL3Cb6dgtK3fA2t4m+LZO58WU0ibzLVGVC/H9cv1IX11/TccOr9s3dg7170EI6ouh335ByJXIQ
+        mj/SORtUxf03e3uP7h88IgY+2Nv5dBeiSyOAEH4DgAjSz5rO8Tp8sPfpwcHe7ZcKuhx3e50TeZeb
+        RF9uQajNL3OT6MsylZveRYvIq0xSJsL/HxTO6rqdV8vt8/Vy+t4qR97Fq4SVjqf3+TekauDqsNtD
+        X9Kv4vXQ1/Q7Pv6RH/fzRafe397Zf7Oz8+j+p4/2D8b3dvbu7dyn0JJGACXzDQAiSD87OjXscG9v
+        f/fhvYf2OXgP7eoE7P00q/cefx19sQWphl/kr6MvykQOvYdvI68xMXnQP9KmeBevkgm6OHgI7abD
+        Gvr6R7qVfsfHP9Kt35BuJa9v994jCjbvPxzv3Xu4f2+fvD4aAdTMNwCIIP1s6Va/w90Hnz68t0tK
+        VZ+vp1tVzr6uijWvc6vo+y0Id+P73Cr6vszuDa+jUeRtJjQT5P/jeneSNcV0W5l+e1W+Z+jMr+vb
+        3koRIahDG27wDWlfIg4h/COlNKRLPt3e232z++DRvU8f7XC+7T5l3EiXvLdSGgJEkH52lFKnw517
+        93ZvHUQPsN3tldEQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMmJ8VlXSTSiK5IRb6JlQSLwx9zVTe
+        Mr/i5uA1j2ZEXNVHww1+pI9+WPpoh9Px+492Px3vPdjdfbCPuPHr6KMoIIL0s6aPvA4p+tx5sEMr
+        F4DGYrdJHw2w3e310RAAbheF0IJkt4DA7aIQZGZvBIBmkfeZzEyY/4/rI+rCW1nYey99hHfdq9mn
+        M8R0OqTodz/SQj8kLbR7gGTSvYckzuOHB/cf7DzcI+XxNbRQHBBB+tnSQkGHOw8+3d0lNwzQWJA2
+        aaE+x91eAUXe5SbRl1sQavPL3CT6skzlpnfRIvIqk5SJ8DU0zvd/yf8DoFf+RcJIAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1205']
+      content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 21 May 2018 17:24:20 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:13 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [c16ecccd-3c3b-4fc9-bb1b-be9c38dfa044]
-      x-ms-original-request-ids: [9e98e281-80a5-40a0-bac5-92c235202541, c6026736-6b68-48b7-9230-c68b1650f68a]
-      x-ms-ratelimit-remaining-subscription-reads: ['14997']
-      x-ms-request-id: [c16ecccd-3c3b-4fc9-bb1b-be9c38dfa044]
-      x-ms-routing-request-id: ['WESTUS2:20180521T172420Z:c16ecccd-3c3b-4fc9-bb1b-be9c38dfa044']
+      x-ms-correlation-request-id: [cf6bd7e3-44f6-4d59-af36-4484af6889ba]
+      x-ms-original-request-ids: [6e7786da-31e4-4062-9509-61468131c49f, ef9984bc-999c-4fa8-a6c6-a8beaecabbaf,
+        fc6336e1-1891-4da6-9458-6d921a6484fa, cb0f10b6-1d4d-4b72-a37d-23f36a56b8dc]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [cf6bd7e3-44f6-4d59-af36-4484af6889ba]
+      x-ms-routing-request-id: ['WESTUS2:20180627T141913Z:cf6bd7e3-44f6-4d59-af36-4484af6889ba']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -60,8 +83,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -72,40 +95,63 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
         alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
-        epp/XlfrVXO3zZv2928E7N1VXV0Ws7xu7n5RTOuqqc7bsXZ5V9scT6fVetk2d6fTVj+6/jR7e/2L
-        VtnFrL1XEWo6qOEG7fUKDW7sg5qW1TTD4Kg5od3Op/myrbNyje/a7KIhIhJ1CO9VXhPZ8PdHy7y9
-        quq3x9OS/5xcr7KGfvvo+AfrOn+d15fFlBqOPros6nadlS+k+at1SZ8++t73ibYr749Zfp6ty/Z4
-        qmgcl2V1hSlp63XT5rOnRZ1PCW/u/HsfPdg7f3hwMDnfPvj0fHd7fzc73364m02292YPprOd3d3Z
-        ZP/BRwS2Wa9WVd02327bVfOmzs7Pi+mXy/L6o0fnWdnko4/y5bS+5onFIBqDNv1+XpREvl9MLbJJ
-        mRMfECb0Qpk17al89KbgGdjb2T3Y3rm/vbP/ZvfTR7sHj+7dH9+//+m93U8f/BRGMCmryTcAiCC9
-        za9fM1dR4960oiuaocuiocEUywvi6xYNX6+n0zyfUcejj6Z1zvO8ocP9h8THn/4UNV7VxSKrr0+X
-        s1VVgE9oDDKWj+Yg56O7Q9w5RrPxtKrz8RVJVHXVjIlb7hLMX7TOIZo3AuB2UQgtKHYLCNwuCkEm
-        9kYAaBZ5n6nMhHm+QWgaIv66+fL8pTSlJtllVpTACTNJnPb/Fs2ULX9QkfjPt6Giti8X76WdzMt4
-        93IxK7KLh/d3CTkd1tDXP9JMxCE/NM20v7374M3e7qO9B4/27o3v7+/f29vZIYXy3pppCBBB+tnR
-        TGGH+we7Dx7eUjFFOe/2ain+OreKvt+CWDe+z62i78uM3vA6GkXeZuIyQf7/oZAw6N//PfXQ/v3F
-        L5peZA9Wb5urosnKYrl+d7kgpHQ4g9//SBMRa/wwNdHDN7sPH+3sPdrdH3+6f0B8sE8K5Otooigg
-        gvSzpon8Dnd27+/c1keK897tddHA+9wsCqAFvW4GwM2iAGRWb3ofrSKvM4WZKP//UEfUxfX26rqd
-        V8vt8/Vy+l56CS/Lu3iVsNLx9D7/enroilTlutmjD3+kgMA6NOWECb0wpDc41NnZeXT/00f7B+N7
-        O3v3du6THNMIII7fACCC9LOjgMIO9/b2dx/eu6UCCpnt9oqn8x5/HX2xBX2GX+Svoy/K7A29h28j
-        rzEFedCegnGS8PNSs8BFPHiI0EqHNfT1j/TMD0nP7N5/s3uPopZH9x+O9+493L+3T6ELjQDS9w0A
-        Ikg/W3rG73D3wacP7+1+LT2jPPd11Y15nVtF329BrRvf51bR92VKb3gdjSJvM3WZIF9DB33/l/w/
-        kzllB6MWAAA=
+        epp/XlfrFb2znF1vl8Vy/W57Wi3brFjm9e7dVV1dFrO8bu5+UUzrqqnO27H2fbeRn8fTabVets1d
+        ftm9S7jpqPpftNcrfHEjTGpaVtMMo6LmV3nTrvFZm100RDUiB+G3ymuiE/7+aJm3V1X99nha8p+T
+        61XW0G8fHf9gXeev8/qymFLD0UeXRd2us/KFNH+1LunTR9/7PhFz5f0xy8+zddkeT7X747KsrjAH
+        bb1u2nz2tKjzKeHLnX/vowd75w8PDibn2wefnu9u7+9m59sPd7PJ9t7swXS2s7s7m+w/+IjANuvV
+        qqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zyTGERj0Kbfz4uSyPaLqUU2KXOaeMKEXiiz
+        pj2Vj94UTPG9nd2D7Z1Pt3fvv9nbfbT34NG9++MHOw93H+x8+lMYwaSsJt8AIIL0Nr9+zWxEjXvT
+        ia5ohi6LhgZTLC+IkVs0fL2eTvN8Rh2PPprWOc/vhg7v33twb+fezk9R61VdLLL6+nQ5W1UFGIQG
+        IYP5aA56PrrbZcMxvh5PqzofX5HsVFfNmNjkLsH6RescQjj4In8ffbMFiTa8yd9H35QZHHwRX0fe
+        YzLywJ9HpKEhqq6bL89fShP6KrvMihI4YIqIhf5fpWOmJDzVrMiW995Lu+Bd9+rBXv4pIaZDin73
+        Ix3zw9Exe7tvdg8e7ew+2r8/3tn59P79/YekGr6GjokDIkg/WzrGdbg/frC/8/DevQe31DF9hru9
+        mom8y02iL7cg1OaXuUn0ZZnKTe+iReRVJikT4f/b+oYk6Dxbnq+XLF4tDeC9VE7/dcJNRxX97kcq
+        54ekcu6/2f300f2Hj3Yfjvd3P93Z24M38nVUThQQQfpZUzleh3sPd3ce7uzfUuXQ1HQY7vYqJ/Iu
+        N4m+3IJQm1/mJtGXZSo3vYsWkVeZpEyE/2+rHIzx91dxfy9lM522+tH1p9nb61+0yi5m7b2KUNNB
+        DTf4emqH0G7n03zZ1lnJRFb189Gb7OJFtsh3qQ39+pMZhaqI2eh3fLznfbznPr7nfXzPfbzvfbzv
+        Pr7vfXxfPs7x+afe5/Dh6Hd8/MD7+IF8zM0PvM8P5HN8/ND7+KH7eHfH+5z+IDagCfqRnh1Sj/e3
+        d/ahrchHQhB2/9N7u5+Sg0QjgOL5BgARpJ8dPRt2uP+QBJb0OoCx+tikZgek7Pa6dggAt4tCaEGx
+        W0DgdlEIMrE3AkCzyPtMZSaMp3p72uH/Oyo4W/6gIj0334Yu3r5cvJcaNi/j3csFecoXD+9D++mw
+        hr7+kQqmz3+kgr9pFby/vftA82B798b39/fv7e1QHoxGAH30DQAiSD87KjjscP9g9wEF84DF2mOT
+        Bo6K2O31b/x1bhV9vwWxbnyfW0Xflxm94XU0irzNxGWC/P9D82LQv/97Ktz9+4tfNL3IHqzeNldF
+        k3FG9HJBSOlwBr//kcqlz3+kcn8WVO7DN7sPH+3sPdrdH3+6f0AMTzE6jQAq6BsARJB+1lSu3+HO
+        7n0s0gAY641NOjcuZLdXugPvc7MogBb0uhkAN4sCkFm96X20irzOFGai/P9E72YX29lsJg5vXl/l
+        5XT+XkqYAND7eF3fJuR0WLGvvp7q9WlLUMGHRBRC8+ebMiKeuaUOoXXQgzd7O4/2dx/de0iR84OD
+        B3u7pEPeWxkNASJIPzvKKOxwf+fB/t6De7fURsQcIcvdXhH1X+UW0XdbkGnju9wi+i4Uy8ZX0SDy
+        JpOTCeBpHl8w/r+jdKZltZ651dz30jf8rn2VkNLh9D7/eppG8sbw02hiwGFEB0LvR3pmg3og1+EA
+        0dr9nfHDvft7+5/ukXr4OnomCogg/azpGa/Dg0/3Du49vK3XE3Lb7ZVM5z3+OvpiCwINv8hfR1+U
+        6Rt6D99GXmMS8qA93eJE4f87moW9tymtF2XFMq/vvZdm6bz7cGcXoZOOKf7lN6RjEGRxwEVf0q8S
+        b9HX9Ds+/lEE+fNIme6/2bv3aHf30f09pL52DvaRa/s6yjQKiCD9rClTr0NS3Z8+vH9LXRoRrdsr
+        1NjL3Cb6dgtK3fA2t4m+LZO58WU0ibzLVGVC/H9cv1IX11/TccOr9s3dg7170EI6ouh335ByJXIQ
+        mj/SORtUxf03e3uP7h88IgY+2Nv5dBeiSyOAEH4DgAjSz5rO8Tp8sPfpwcHe7ZcKuhx3e50TeZeb
+        RF9uQajNL3OT6MsylZveRYvIq0xSJsL/HxTO6rqdV8vt8/Vy+t4qR97Fq4SVjqf3+TekauDqsNtD
+        X9Kv4vXQ1/Q7Pv6RH/fzRafe397Zf7Oz8+j+p4/2D8b3dvbu7dyn0JJGACXzDQAiSD87OjXscG9v
+        f/fhvYf2OXgP7eoE7P00q/cefx19sQWphl/kr6MvykQOvYdvI68xMXnQP9KmeBevkgm6OHgI7abD
+        Gvr6R7qVfsfHP9Kt35BuJa9v994jCjbvPxzv3Xu4f2+fvD4aAdTMNwCIIP1s6Va/w90Hnz68t0tK
+        VZ+vp1tVzr6uijWvc6vo+y0Id+P73Cr6vszuDa+jUeRtJjQT5P/jeneSNcV0W5l+e1W+Z+jMr+vb
+        3koRIahDG27wDWlfIg4h/COlNKRLPt3e232z++DRvU8f7XC+7T5l3EiXvLdSGgJEkH52lFKnw517
+        93ZvHUQPsN3tldEQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMmJ8VlXSTSiK5IRb6JlQSLwx9zVTe
+        Mr/i5uA1j2ZEXNVHww1+pI9+WPpoh9Px+492Px3vPdjdfbCPuPHr6KMoIIL0s6aPvA4p+tx5sEMr
+        F4DGYrdJHw2w3e310RAAbheF0IJkt4DA7aIQZGZvBIBmkfeZzEyY/4/rI+rCW1nYey99hHfdq9mn
+        M8R0OqTodz/SQj8kLbR7gGTSvYckzuOHB/cf7DzcI+XxNbRQHBBB+tnSQkGHOw8+3d0lNwzQWJA2
+        aaE+x91eAUXe5SbRl1sQavPL3CT6skzlpnfRIvIqk5SJ8DU0zvd/yf8DoFf+RcJIAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1205']
+      content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 21 May 2018 17:24:20 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [66443bc7-547a-4f0b-a4ce-5d42212e3220]
-      x-ms-original-request-ids: [04f8b596-3104-4e63-90d1-3295b5fa9768, 9a323a59-e8d3-4e60-8e40-5d224124858e]
-      x-ms-ratelimit-remaining-subscription-reads: ['14996']
-      x-ms-request-id: [66443bc7-547a-4f0b-a4ce-5d42212e3220]
-      x-ms-routing-request-id: ['WESTUS2:20180521T172421Z:66443bc7-547a-4f0b-a4ce-5d42212e3220']
+      x-ms-correlation-request-id: [5eee8b37-ad36-4f64-988e-a5d2d3b7d3e2]
+      x-ms-original-request-ids: [93d2835f-d26d-4f1c-95be-1b5a9640466a, 45f6acef-af41-45d5-afaf-480a27856cb7,
+        483cf958-3895-4f4b-8f69-2f1ebdc6d786, 81df143f-0965-4c47-be18-a3e5dfb30c19]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [5eee8b37-ad36-4f64-988e-a5d2d3b7d3e2]
+      x-ms-routing-request-id: ['WESTUS2:20180627T141914Z:5eee8b37-ad36-4f64-988e-a5d2d3b7d3e2']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -115,8 +161,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o/listKeys?api-version=2017-10-01
@@ -127,14 +173,14 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
         6+ajR9/jX15ki/yjR/ht96PRR5dZucafTxb3d5Y78180n/xE+ennBw/v//SzYmf+U7ufT35qOpkt
         Pn8wuf6Jh5MH5YOzs4vz4tW3T37i7b3r4y9++tMmf/Pd+fonLr+aFLOf+PTu+bJ+UF7ez/KfvPzy
-        q4vPPqMuVnm9KJqmqJaEw0fPvnr+/KNfMuqgskftDCrF/ax4e7wsz+5fFPXF7z15un75ez+8eFG+
-        O929/n2++MG3H7z9ve4Vv/eD3/sH85PX00/W3/5kVr/7/Ntn3zn+qdNPHhbvHs723959Xp+9OPhy
-        vbfI7z1cf+fBT82OB1H5/i/5fwChpkAKIAEAAA==
+        q4vPPqMuVnm9KJqmqJaEw0fP1mX50S8ZdVDZo3YGleJ+Vrw9XpZn9y+K+uL3njxdv/y9H168KN+d
+        7l7/Pl/84NsP3v5e94rf+8Hv/YP5yevpJ+tvfzKr333+7bPvHP/U6ScPi3cPZ/tv7z6vz14cfLne
+        W+T3Hq6/8+CnZseDqHz/l/w/zRmIASABAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json]
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:14 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -142,29 +188,29 @@ interactions:
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [a0646eee-c468-4d73-9855-c36cbff51f0f]
+      x-ms-correlation-request-id: [7a13b612-bba0-49f4-a2d8-809102042a8e]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-id: [d694054d-49d8-4196-acc6-de38e6e4d937]
-      x-ms-routing-request-id: ['WESTUS2:20180521T172421Z:a0646eee-c468-4d73-9855-c36cbff51f0f']
+      x-ms-request-id: [4e9b2440-d9e7-488c-ae4d-da73a1fc1aba]
+      x-ms-routing-request-id: ['WESTUS2:20180627T141914Z:7a13b612-bba0-49f4-a2d8-809102042a8e']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.34.3 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Mon, 21 May 2018 17:24:19 GMT']
-      x-ms-version: ['2016-05-31']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [825f41cd-8003-00bd-0c28-f14f8f000000]
-      x-ms-version: ['2016-05-31']
+      x-ms-request-id: [f7464794-2003-00d6-5021-0e12d9000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
     body: !!python/unicode '<?xml version=''1.0'' encoding=''utf-8''?>
@@ -173,72 +219,72 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['106']
-      User-Agent: [Azure-Storage/0.34.3 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Mon, 21 May 2018 17:24:20 GMT']
-      x-ms-version: ['2016-05-31']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-version: ['2018-03-28']
     method: POST
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>2daa2a7d-86a2-491f-a5d9-d6ab51fbbd8f</MessageId><InsertionTime>Mon,\
-        \ 21 May 2018 17:24:22 GMT</InsertionTime><ExpirationTime>Mon, 28 May 2018\
-        \ 17:24:22 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAyR3Ejijx0wE=</PopReceipt><TimeNextVisible>Mon,\
-        \ 21 May 2018 17:24:22 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>2c9de829-e5c5-4279-b717-3d305e914d24</MessageId><InsertionTime>Wed,\
+        \ 27 Jun 2018 14:19:15 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
+        \ 14:19:15 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAlnXg0yEO1AE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 27 Jun 2018 14:19:15 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
     headers:
       content-type: [application/xml]
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [825f41de-8003-00bd-1a28-f14f8f000000]
-      x-ms-version: ['2016-05-31']
+      x-ms-request-id: [f74647ab-2003-00d6-6521-0e12d9000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.34.3 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Mon, 21 May 2018 17:24:20 GMT']
-      x-ms-version: ['2016-05-31']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-version: ['2018-03-28']
     method: GET
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>2daa2a7d-86a2-491f-a5d9-d6ab51fbbd8f</MessageId><InsertionTime>Mon,\
-        \ 21 May 2018 17:24:22 GMT</InsertionTime><ExpirationTime>Mon, 28 May 2018\
-        \ 17:24:22 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAA8T/eoCjx0wE=</PopReceipt><TimeNextVisible>Mon,\
-        \ 21 May 2018 17:24:52 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>hello\
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>2c9de829-e5c5-4279-b717-3d305e914d24</MessageId><InsertionTime>Wed,\
+        \ 27 Jun 2018 14:19:15 GMT</InsertionTime><ExpirationTime>Wed, 04 Jul 2018\
+        \ 14:19:15 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAASBPP5SEO1AE=</PopReceipt><TimeNextVisible>Wed,\
+        \ 27 Jun 2018 14:19:45 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>hello\
         \ queue</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [825f4229-8003-00bd-5d28-f14f8f000000]
-      x-ms-version: ['2016-05-31']
+      x-ms-request-id: [f74647ba-2003-00d6-7421-0e12d9000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.34.3 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Mon, 21 May 2018 17:24:20 GMT']
-      x-ms-version: ['2016-05-31']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-version: ['2018-03-28']
     method: DELETE
-    uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages/2daa2a7d-86a2-491f-a5d9-d6ab51fbbd8f?popreceipt=AgAAAAMAAAAAAAAA8T%2FeoCjx0wE%3D
+    uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages/2c9de829-e5c5-4279-b717-3d305e914d24?popreceipt=AgAAAAMAAAAAAAAASBPP5SEO1AE%3D
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [825f4241-8003-00bd-7328-f14f8f000000]
-      x-ms-version: ['2016-05-31']
+      x-ms-request-id: [f74647ca-2003-00d6-0321-0e12d9000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/0.34.3 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Mon, 21 May 2018 17:24:20 GMT']
-      x-ms-version: ['2016-05-31']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:19:14 GMT']
+      x-ms-version: ['2018-03-28']
     method: GET
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
@@ -247,9 +293,9 @@ interactions:
     headers:
       cache-control: [no-cache]
       content-type: [application/xml]
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:19:15 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [825f424d-8003-00bd-7e28-f14f8f000000]
-      x-ms-version: ['2016-05-31']
+      x-ms-request-id: [f74647d9-2003-00d6-1221-0e12d9000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri.yaml
@@ -63,18 +63,18 @@ interactions:
       content-encoding: [gzip]
       content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [8871449a-8605-4c9a-9840-4d0653142f7b]
-      x-ms-original-request-ids: [af91e054-f65d-47c9-970d-4be1eb5eb553, 4514fa3c-e813-4c6d-9205-cf33326fa4b7,
-        da39419b-1fda-4128-9cbd-c32c473c7eaf, 6dabe81f-7832-4cd6-8c06-6ab8da9823ce]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [8871449a-8605-4c9a-9840-4d0653142f7b]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142126Z:8871449a-8605-4c9a-9840-4d0653142f7b']
+      x-ms-correlation-request-id: [651b8602-9c68-4fec-8f83-df55742f7c58]
+      x-ms-original-request-ids: [7107ace7-f913-4f62-b2c8-8286e4796564, 227ac78e-04f5-4619-8986-e935d3a60297,
+        d7ec0928-d11b-4550-9266-7e09ce400498, 0cc73fa7-1802-4b69-9bae-60f3eb696707]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [651b8602-9c68-4fec-8f83-df55742f7c58]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162307Z:651b8602-9c68-4fec-8f83-df55742f7c58']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -140,18 +140,18 @@ interactions:
       content-encoding: [gzip]
       content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [9bf562f1-c60d-429d-8a92-595d4c2a0b6a]
-      x-ms-original-request-ids: [08dda735-cd2f-4afc-9879-dbe8a57ac8ae, fa49672a-c9a9-4404-b28c-b5961d9ceab6,
-        f5da2307-83d3-4b20-9eca-4cd4f9935746, 3b6bf1c8-62b8-40d6-ae14-f0aa4c5e5595]
-      x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [9bf562f1-c60d-429d-8a92-595d4c2a0b6a]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:9bf562f1-c60d-429d-8a92-595d4c2a0b6a']
+      x-ms-correlation-request-id: [57ed49cd-b844-43f4-b378-a8eac2c089c0]
+      x-ms-original-request-ids: [0952074d-2efd-42c7-ad24-7ab800aa48d7, 453d53b2-df4c-4ab9-baaf-0483d022fe32,
+        dcd9e377-1a32-454b-a43c-cf59f91ea607, ef6a314d-31f4-4521-a442-b3fa40911d24]
+      x-ms-ratelimit-remaining-subscription-reads: ['14999']
+      x-ms-request-id: [57ed49cd-b844-43f4-b378-a8eac2c089c0]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162307Z:57ed49cd-b844-43f4-b378-a8eac2c089c0']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -180,7 +180,7 @@ interactions:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json]
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:07 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -188,10 +188,10 @@ interactions:
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [a8df036a-5e43-4e71-95a9-2d50a8703104]
+      x-ms-correlation-request-id: [80cd44fe-01ef-4446-b946-66ec6a1774a6]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-id: [bad360c8-19c0-4005-ae4e-0715c1af6d9a]
-      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:a8df036a-5e43-4e71-95a9-2d50a8703104']
+      x-ms-request-id: [53b21a86-6ac5-44df-9ce0-86a9d5e0396a]
+      x-ms-routing-request-id: ['WESTUS2:20180627T162308Z:80cd44fe-01ef-4446-b946-66ec6a1774a6']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -199,17 +199,17 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      x-ms-date: ['Wed, 27 Jun 2018 16:23:07 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
       content-length: ['0']
-      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      date: ['Wed, 27 Jun 2018 16:23:07 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [2e2a6b24-c003-007d-5422-0ec5cb000000]
+      x-ms-request-id: [1c770b9c-3003-00e0-7233-0ebf8b000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri.yaml
@@ -6,8 +6,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -18,40 +18,63 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
         alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
-        epp/XlfrVXO3zZv2928E7N1VXV0Ws7xu7n5RTOuqqc7bsXZ5V9scT6fVetk2d6fTVj+6/jR7e/2L
-        VtnFrL1XEWo6qOEG7fUKDW7sg5qW1TTD4Kg5od3Op/myrbNyje/a7KIhIhJ1CO9VXhPZ8PdHy7y9
-        quq3x9OS/5xcr7KGfvvo+AfrOn+d15fFlBqOPros6nadlS+k+at1SZ8++t73ibYr749Zfp6ty/Z4
-        qmgcl2V1hSlp63XT5rOnRZ1PCW/u/HsfPdg7f3hwMDnfPvj0fHd7fzc73364m02292YPprOd3d3Z
-        ZP/BRwS2Wa9WVd02327bVfOmzs7Pi+mXy/L6o0fnWdnko4/y5bS+5onFIBqDNv1+XpREvl9MLbJJ
-        mRMfECb0Qpk17al89KbgGdjb2T3Y3rm/vbP/ZvfTR7sHj+7dH9+//+m93U8f/BRGMCmryTcAiCC9
-        za9fM1dR4960oiuaocuiocEUywvi6xYNX6+n0zyfUcejj6Z1zvO8ocP9h8THn/4UNV7VxSKrr0+X
-        s1VVgE9oDDKWj+Yg56O7Q9w5RrPxtKrz8RVJVHXVjIlb7hLMX7TOIZo3AuB2UQgtKHYLCNwuCkEm
-        9kYAaBZ5n6nMhHm+QWgaIv66+fL8pTSlJtllVpTACTNJnPb/Fs2ULX9QkfjPt6Giti8X76WdzMt4
-        93IxK7KLh/d3CTkd1tDXP9JMxCE/NM20v7374M3e7qO9B4/27o3v7+/f29vZIYXy3pppCBBB+tnR
-        TGGH+we7Dx7eUjFFOe/2ain+OreKvt+CWDe+z62i78uM3vA6GkXeZuIyQf7/oZAw6N//PfXQ/v3F
-        L5peZA9Wb5urosnKYrl+d7kgpHQ4g9//SBMRa/wwNdHDN7sPH+3sPdrdH3+6f0B8sE8K5Otooigg
-        gvSzpon8Dnd27+/c1keK897tddHA+9wsCqAFvW4GwM2iAGRWb3ofrSKvM4WZKP//UEfUxfX26rqd
-        V8vt8/Vy+l56CS/Lu3iVsNLx9D7/enroilTlutmjD3+kgMA6NOWECb0wpDc41NnZeXT/00f7B+N7
-        O3v3du6THNMIII7fACCC9LOjgMIO9/b2dx/eu6UCCpnt9oqn8x5/HX2xBX2GX+Svoy/K7A29h28j
-        rzEFedCegnGS8PNSs8BFPHiI0EqHNfT1j/TMD0nP7N5/s3uPopZH9x+O9+493L+3T6ELjQDS9w0A
-        Ikg/W3rG73D3wacP7+1+LT2jPPd11Y15nVtF329BrRvf51bR92VKb3gdjSJvM3WZIF9DB33/l/w/
-        kzllB6MWAAA=
+        epp/XlfrFb2znF1vl8Vy/W57Wi3brFjm9e7dVV1dFrO8bu5+UUzrqqnO27H2fbeRn8fTabVets1d
+        ftm9S7jpqPpftNcrfHEjTGpaVtMMo6LmV3nTrvFZm100RDUiB+G3ymuiE/7+aJm3V1X99nha8p+T
+        61XW0G8fHf9gXeev8/qymFLD0UeXRd2us/KFNH+1LunTR9/7PhFz5f0xy8+zddkeT7X747KsrjAH
+        bb1u2nz2tKjzKeHLnX/vowd75w8PDibn2wefnu9u7+9m59sPd7PJ9t7swXS2s7s7m+w/+IjANuvV
+        qqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zyTGERj0Kbfz4uSyPaLqUU2KXOaeMKEXiiz
+        pj2Vj94UTPG9nd2D7Z1Pt3fvv9nbfbT34NG9++MHOw93H+x8+lMYwaSsJt8AIIL0Nr9+zWxEjXvT
+        ia5ohi6LhgZTLC+IkVs0fL2eTvN8Rh2PPprWOc/vhg7v33twb+fezk9R61VdLLL6+nQ5W1UFGIQG
+        IYP5aA56PrrbZcMxvh5PqzofX5HsVFfNmNjkLsH6RescQjj4In8ffbMFiTa8yd9H35QZHHwRX0fe
+        YzLywJ9HpKEhqq6bL89fShP6KrvMihI4YIqIhf5fpWOmJDzVrMiW995Lu+Bd9+rBXv4pIaZDin73
+        Ix3zw9Exe7tvdg8e7ew+2r8/3tn59P79/YekGr6GjokDIkg/WzrGdbg/frC/8/DevQe31DF9hru9
+        mom8y02iL7cg1OaXuUn0ZZnKTe+iReRVJikT4f/b+oYk6Dxbnq+XLF4tDeC9VE7/dcJNRxX97kcq
+        54ekcu6/2f300f2Hj3Yfjvd3P93Z24M38nVUThQQQfpZUzleh3sPd3ce7uzfUuXQ1HQY7vYqJ/Iu
+        N4m+3IJQm1/mJtGXZSo3vYsWkVeZpEyE/2+rHIzx91dxfy9lM522+tH1p9nb61+0yi5m7b2KUNNB
+        DTf4emqH0G7n03zZ1lnJRFb189Gb7OJFtsh3qQ39+pMZhaqI2eh3fLznfbznPr7nfXzPfbzvfbzv
+        Pr7vfXxfPs7x+afe5/Dh6Hd8/MD7+IF8zM0PvM8P5HN8/ND7+KH7eHfH+5z+IDagCfqRnh1Sj/e3
+        d/ahrchHQhB2/9N7u5+Sg0QjgOL5BgARpJ8dPRt2uP+QBJb0OoCx+tikZgek7Pa6dggAt4tCaEGx
+        W0DgdlEIMrE3AkCzyPtMZSaMp3p72uH/Oyo4W/6gIj0334Yu3r5cvJcaNi/j3csFecoXD+9D++mw
+        hr7+kQqmz3+kgr9pFby/vftA82B798b39/fv7e1QHoxGAH30DQAiSD87KjjscP9g9wEF84DF2mOT
+        Bo6K2O31b/x1bhV9vwWxbnyfW0Xflxm94XU0irzNxGWC/P9D82LQv/97Ktz9+4tfNL3IHqzeNldF
+        k3FG9HJBSOlwBr//kcqlz3+kcn8WVO7DN7sPH+3sPdrdH3+6f0AMTzE6jQAq6BsARJB+1lSu3+HO
+        7n0s0gAY641NOjcuZLdXugPvc7MogBb0uhkAN4sCkFm96X20irzOFGai/P9E72YX29lsJg5vXl/l
+        5XT+XkqYAND7eF3fJuR0WLGvvp7q9WlLUMGHRBRC8+ebMiKeuaUOoXXQgzd7O4/2dx/de0iR84OD
+        B3u7pEPeWxkNASJIPzvKKOxwf+fB/t6De7fURsQcIcvdXhH1X+UW0XdbkGnju9wi+i4Uy8ZX0SDy
+        JpOTCeBpHl8w/r+jdKZltZ651dz30jf8rn2VkNLh9D7/eppG8sbw02hiwGFEB0LvR3pmg3og1+EA
+        0dr9nfHDvft7+5/ukXr4OnomCogg/azpGa/Dg0/3Du49vK3XE3Lb7ZVM5z3+OvpiCwINv8hfR1+U
+        6Rt6D99GXmMS8qA93eJE4f87moW9tymtF2XFMq/vvZdm6bz7cGcXoZOOKf7lN6RjEGRxwEVf0q8S
+        b9HX9Ds+/lEE+fNIme6/2bv3aHf30f09pL52DvaRa/s6yjQKiCD9rClTr0NS3Z8+vH9LXRoRrdsr
+        1NjL3Cb6dgtK3fA2t4m+LZO58WU0ibzLVGVC/H9cv1IX11/TccOr9s3dg7170EI6ouh335ByJXIQ
+        mj/SORtUxf03e3uP7h88IgY+2Nv5dBeiSyOAEH4DgAjSz5rO8Tp8sPfpwcHe7ZcKuhx3e50TeZeb
+        RF9uQajNL3OT6MsylZveRYvIq0xSJsL/HxTO6rqdV8vt8/Vy+t4qR97Fq4SVjqf3+TekauDqsNtD
+        X9Kv4vXQ1/Q7Pv6RH/fzRafe397Zf7Oz8+j+p4/2D8b3dvbu7dyn0JJGACXzDQAiSD87OjXscG9v
+        f/fhvYf2OXgP7eoE7P00q/cefx19sQWphl/kr6MvykQOvYdvI68xMXnQP9KmeBevkgm6OHgI7abD
+        Gvr6R7qVfsfHP9Kt35BuJa9v994jCjbvPxzv3Xu4f2+fvD4aAdTMNwCIIP1s6Va/w90Hnz68t0tK
+        VZ+vp1tVzr6uijWvc6vo+y0Id+P73Cr6vszuDa+jUeRtJjQT5P/jeneSNcV0W5l+e1W+Z+jMr+vb
+        3koRIahDG27wDWlfIg4h/COlNKRLPt3e232z++DRvU8f7XC+7T5l3EiXvLdSGgJEkH52lFKnw517
+        93ZvHUQPsN3tldEQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMmJ8VlXSTSiK5IRb6JlQSLwx9zVTe
+        Mr/i5uA1j2ZEXNVHww1+pI9+WPpoh9Px+492Px3vPdjdfbCPuPHr6KMoIIL0s6aPvA4p+tx5sEMr
+        F4DGYrdJHw2w3e310RAAbheF0IJkt4DA7aIQZGZvBIBmkfeZzEyY/4/rI+rCW1nYey99hHfdq9mn
+        M8R0OqTodz/SQj8kLbR7gGTSvYckzuOHB/cf7DzcI+XxNbRQHBBB+tnSQkGHOw8+3d0lNwzQWJA2
+        aaE+x91eAUXe5SbRl1sQavPL3CT6skzlpnfRIvIqk5SJ8DU0zvd/yf8DoFf+RcJIAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1205']
+      content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 21 May 2018 17:24:20 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [6da573b3-2867-4d39-9453-ab42829bab35]
-      x-ms-original-request-ids: [83d7a990-f60e-4464-91af-c8bc6457693a, c096b6da-157d-4816-a4da-3686135426da]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [6da573b3-2867-4d39-9453-ab42829bab35]
-      x-ms-routing-request-id: ['WESTUS2:20180521T172421Z:6da573b3-2867-4d39-9453-ab42829bab35']
+      x-ms-correlation-request-id: [8871449a-8605-4c9a-9840-4d0653142f7b]
+      x-ms-original-request-ids: [af91e054-f65d-47c9-970d-4be1eb5eb553, 4514fa3c-e813-4c6d-9205-cf33326fa4b7,
+        da39419b-1fda-4128-9cbd-c32c473c7eaf, 6dabe81f-7832-4cd6-8c06-6ab8da9823ce]
+      x-ms-ratelimit-remaining-subscription-reads: ['14998']
+      x-ms-request-id: [8871449a-8605-4c9a-9840-4d0653142f7b]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142126Z:8871449a-8605-4c9a-9840-4d0653142f7b']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -60,8 +83,8 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2017-10-01
@@ -72,40 +95,63 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi5y
         alPgz7vNetJM62LVFtWyuZtlDw8ePtifbN+f7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTr
-        epp/XlfrVXO3zZv2928E7N1VXV0Ws7xu7n5RTOuqqc7bsXZ5V9scT6fVetk2d6fTVj+6/jR7e/2L
-        VtnFrL1XEWo6qOEG7fUKDW7sg5qW1TTD4Kg5od3Op/myrbNyje/a7KIhIhJ1CO9VXhPZ8PdHy7y9
-        quq3x9OS/5xcr7KGfvvo+AfrOn+d15fFlBqOPros6nadlS+k+at1SZ8++t73ibYr749Zfp6ty/Z4
-        qmgcl2V1hSlp63XT5rOnRZ1PCW/u/HsfPdg7f3hwMDnfPvj0fHd7fzc73364m02292YPprOd3d3Z
-        ZP/BRwS2Wa9WVd02327bVfOmzs7Pi+mXy/L6o0fnWdnko4/y5bS+5onFIBqDNv1+XpREvl9MLbJJ
-        mRMfECb0Qpk17al89KbgGdjb2T3Y3rm/vbP/ZvfTR7sHj+7dH9+//+m93U8f/BRGMCmryTcAiCC9
-        za9fM1dR4960oiuaocuiocEUywvi6xYNX6+n0zyfUcejj6Z1zvO8ocP9h8THn/4UNV7VxSKrr0+X
-        s1VVgE9oDDKWj+Yg56O7Q9w5RrPxtKrz8RVJVHXVjIlb7hLMX7TOIZo3AuB2UQgtKHYLCNwuCkEm
-        9kYAaBZ5n6nMhHm+QWgaIv66+fL8pTSlJtllVpTACTNJnPb/Fs2ULX9QkfjPt6Giti8X76WdzMt4
-        93IxK7KLh/d3CTkd1tDXP9JMxCE/NM20v7374M3e7qO9B4/27o3v7+/f29vZIYXy3pppCBBB+tnR
-        TGGH+we7Dx7eUjFFOe/2ain+OreKvt+CWDe+z62i78uM3vA6GkXeZuIyQf7/oZAw6N//PfXQ/v3F
-        L5peZA9Wb5urosnKYrl+d7kgpHQ4g9//SBMRa/wwNdHDN7sPH+3sPdrdH3+6f0B8sE8K5Otooigg
-        gvSzpon8Dnd27+/c1keK897tddHA+9wsCqAFvW4GwM2iAGRWb3ofrSKvM4WZKP//UEfUxfX26rqd
-        V8vt8/Vy+l56CS/Lu3iVsNLx9D7/enroilTlutmjD3+kgMA6NOWECb0wpDc41NnZeXT/00f7B+N7
-        O3v3du6THNMIII7fACCC9LOjgMIO9/b2dx/eu6UCCpnt9oqn8x5/HX2xBX2GX+Svoy/K7A29h28j
-        rzEFedCegnGS8PNSs8BFPHiI0EqHNfT1j/TMD0nP7N5/s3uPopZH9x+O9+493L+3T6ELjQDS9w0A
-        Ikg/W3rG73D3wacP7+1+LT2jPPd11Y15nVtF329BrRvf51bR92VKb3gdjSJvM3WZIF9DB33/l/w/
-        kzllB6MWAAA=
+        epp/XlfrFb2znF1vl8Vy/W57Wi3brFjm9e7dVV1dFrO8bu5+UUzrqqnO27H2fbeRn8fTabVets1d
+        ftm9S7jpqPpftNcrfHEjTGpaVtMMo6LmV3nTrvFZm100RDUiB+G3ymuiE/7+aJm3V1X99nha8p+T
+        61XW0G8fHf9gXeev8/qymFLD0UeXRd2us/KFNH+1LunTR9/7PhFz5f0xy8+zddkeT7X747KsrjAH
+        bb1u2nz2tKjzKeHLnX/vowd75w8PDibn2wefnu9u7+9m59sPd7PJ9t7swXS2s7s7m+w/+IjANuvV
+        qqrb5tttu2re1Nn5eTH9cllef/ToPCubfPRRvpzW1zyTGERj0Kbfz4uSyPaLqUU2KXOaeMKEXiiz
+        pj2Vj94UTPG9nd2D7Z1Pt3fvv9nbfbT34NG9++MHOw93H+x8+lMYwaSsJt8AIIL0Nr9+zWxEjXvT
+        ia5ohi6LhgZTLC+IkVs0fL2eTvN8Rh2PPprWOc/vhg7v33twb+fezk9R61VdLLL6+nQ5W1UFGIQG
+        IYP5aA56PrrbZcMxvh5PqzofX5HsVFfNmNjkLsH6RescQjj4In8ffbMFiTa8yd9H35QZHHwRX0fe
+        YzLywJ9HpKEhqq6bL89fShP6KrvMihI4YIqIhf5fpWOmJDzVrMiW995Lu+Bd9+rBXv4pIaZDin73
+        Ix3zw9Exe7tvdg8e7ew+2r8/3tn59P79/YekGr6GjokDIkg/WzrGdbg/frC/8/DevQe31DF9hru9
+        mom8y02iL7cg1OaXuUn0ZZnKTe+iReRVJikT4f/b+oYk6Dxbnq+XLF4tDeC9VE7/dcJNRxX97kcq
+        54ekcu6/2f300f2Hj3Yfjvd3P93Z24M38nVUThQQQfpZUzleh3sPd3ce7uzfUuXQ1HQY7vYqJ/Iu
+        N4m+3IJQm1/mJtGXZSo3vYsWkVeZpEyE/2+rHIzx91dxfy9lM522+tH1p9nb61+0yi5m7b2KUNNB
+        DTf4emqH0G7n03zZ1lnJRFb189Gb7OJFtsh3qQ39+pMZhaqI2eh3fLznfbznPr7nfXzPfbzvfbzv
+        Pr7vfXxfPs7x+afe5/Dh6Hd8/MD7+IF8zM0PvM8P5HN8/ND7+KH7eHfH+5z+IDagCfqRnh1Sj/e3
+        d/ahrchHQhB2/9N7u5+Sg0QjgOL5BgARpJ8dPRt2uP+QBJb0OoCx+tikZgek7Pa6dggAt4tCaEGx
+        W0DgdlEIMrE3AkCzyPtMZSaMp3p72uH/Oyo4W/6gIj0334Yu3r5cvJcaNi/j3csFecoXD+9D++mw
+        hr7+kQqmz3+kgr9pFby/vftA82B798b39/fv7e1QHoxGAH30DQAiSD87KjjscP9g9wEF84DF2mOT
+        Bo6K2O31b/x1bhV9vwWxbnyfW0Xflxm94XU0irzNxGWC/P9D82LQv/97Ktz9+4tfNL3IHqzeNldF
+        k3FG9HJBSOlwBr//kcqlz3+kcn8WVO7DN7sPH+3sPdrdH3+6f0AMTzE6jQAq6BsARJB+1lSu3+HO
+        7n0s0gAY641NOjcuZLdXugPvc7MogBb0uhkAN4sCkFm96X20irzOFGai/P9E72YX29lsJg5vXl/l
+        5XT+XkqYAND7eF3fJuR0WLGvvp7q9WlLUMGHRBRC8+ebMiKeuaUOoXXQgzd7O4/2dx/de0iR84OD
+        B3u7pEPeWxkNASJIPzvKKOxwf+fB/t6De7fURsQcIcvdXhH1X+UW0XdbkGnju9wi+i4Uy8ZX0SDy
+        JpOTCeBpHl8w/r+jdKZltZ651dz30jf8rn2VkNLh9D7/eppG8sbw02hiwGFEB0LvR3pmg3og1+EA
+        0dr9nfHDvft7+5/ukXr4OnomCogg/azpGa/Dg0/3Du49vK3XE3Lb7ZVM5z3+OvpiCwINv8hfR1+U
+        6Rt6D99GXmMS8qA93eJE4f87moW9tymtF2XFMq/vvZdm6bz7cGcXoZOOKf7lN6RjEGRxwEVf0q8S
+        b9HX9Ds+/lEE+fNIme6/2bv3aHf30f09pL52DvaRa/s6yjQKiCD9rClTr0NS3Z8+vH9LXRoRrdsr
+        1NjL3Cb6dgtK3fA2t4m+LZO58WU0ibzLVGVC/H9cv1IX11/TccOr9s3dg7170EI6ouh335ByJXIQ
+        mj/SORtUxf03e3uP7h88IgY+2Nv5dBeiSyOAEH4DgAjSz5rO8Tp8sPfpwcHe7ZcKuhx3e50TeZeb
+        RF9uQajNL3OT6MsylZveRYvIq0xSJsL/HxTO6rqdV8vt8/Vy+t4qR97Fq4SVjqf3+TekauDqsNtD
+        X9Kv4vXQ1/Q7Pv6RH/fzRafe397Zf7Oz8+j+p4/2D8b3dvbu7dyn0JJGACXzDQAiSD87OjXscG9v
+        f/fhvYf2OXgP7eoE7P00q/cefx19sQWphl/kr6MvykQOvYdvI68xMXnQP9KmeBevkgm6OHgI7abD
+        Gvr6R7qVfsfHP9Kt35BuJa9v994jCjbvPxzv3Xu4f2+fvD4aAdTMNwCIIP1s6Va/w90Hnz68t0tK
+        VZ+vp1tVzr6uijWvc6vo+y0Id+P73Cr6vszuDa+jUeRtJjQT5P/jeneSNcV0W5l+e1W+Z+jMr+vb
+        3koRIahDG27wDWlfIg4h/COlNKRLPt3e232z++DRvU8f7XC+7T5l3EiXvLdSGgJEkH52lFKnw517
+        93ZvHUQPsN3tldEQAG4XhdCCZLeAwO2iEGRmbwSAZpH3mcxMmJ8VlXSTSiK5IRb6JlQSLwx9zVTe
+        Mr/i5uA1j2ZEXNVHww1+pI9+WPpoh9Px+492Px3vPdjdfbCPuPHr6KMoIIL0s6aPvA4p+tx5sEMr
+        F4DGYrdJHw2w3e310RAAbheF0IJkt4DA7aIQZGZvBIBmkfeZzEyY/4/rI+rCW1nYey99hHfdq9mn
+        M8R0OqTodz/SQj8kLbR7gGTSvYckzuOHB/cf7DzcI+XxNbRQHBBB+tnSQkGHOw8+3d0lNwzQWJA2
+        aaE+x91eAUXe5SbRl1sQavPL3CT6skzlpnfRIvIqk5SJ8DU0zvd/yf8DoFf+RcJIAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
-      content-length: ['1205']
+      content-length: ['2501']
       content-type: [application/json; charset=utf-8]
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:26 GMT']
       expires: ['-1']
       pragma: [no-cache]
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [649417dd-be11-4f95-a9c5-47ff6d254929]
-      x-ms-original-request-ids: [f938d2ac-f97c-4ec6-8f41-c838eb29487f, 7c6344fa-99cb-429b-9951-cdc51825dec6]
+      x-ms-correlation-request-id: [9bf562f1-c60d-429d-8a92-595d4c2a0b6a]
+      x-ms-original-request-ids: [08dda735-cd2f-4afc-9879-dbe8a57ac8ae, fa49672a-c9a9-4404-b28c-b5961d9ceab6,
+        f5da2307-83d3-4b20-9eca-4cd4f9935746, 3b6bf1c8-62b8-40d6-ae14-f0aa4c5e5595]
       x-ms-ratelimit-remaining-subscription-reads: ['14998']
-      x-ms-request-id: [649417dd-be11-4f95-a9c5-47ff6d254929]
-      x-ms-routing-request-id: ['WESTUS2:20180521T172421Z:649417dd-be11-4f95-a9c5-47ff6d254929']
+      x-ms-request-id: [9bf562f1-c60d-429d-8a92-595d4c2a0b6a]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:9bf562f1-c60d-429d-8a92-595d4c2a0b6a']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -115,8 +161,8 @@ interactions:
       Connection: [keep-alive]
       Content-Length: ['0']
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.27
-          msrest_azure/0.4.25 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.13 (Windows-10-10.0.17134) requests/2.18.4 msrest/0.4.29
+          msrest_azure/0.4.31 azure-mgmt-storage/1.5.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: POST
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/test_storage/providers/Microsoft.Storage/storageAccounts/cctstoragey6akyqpagdt3o/listKeys?api-version=2017-10-01
@@ -127,14 +173,14 @@ interactions:
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR2/z
         6+ajR9/jX15ki/yjR/ht96PRR5dZucafTxb3d5Y78180n/xE+ennBw/v//SzYmf+U7ufT35qOpkt
         Pn8wuf6Jh5MH5YOzs4vz4tW3T37i7b3r4y9++tMmf/Pd+fonLr+aFLOf+PTu+bJ+UF7ez/KfvPzy
-        q4vPPqMuVnm9KJqmqJaEw0fPvnr+/KNfMuqgskftDCrF/ax4e7wsz+5fFPXF7z15un75ez+8eFG+
-        O929/n2++MG3H7z9ve4Vv/eD3/sH85PX00/W3/5kVr/7/Ntn3zn+qdNPHhbvHs723959Xp+9OPhy
-        vbfI7z1cf+fBT82OB1H5/i/5fwChpkAKIAEAAA==
+        q4vPPqMuVnm9KJqmqJaEw0fP1mX50S8ZdVDZo3YGleJ+Vrw9XpZn9y+K+uL3njxdv/y9H168KN+d
+        7l7/Pl/84NsP3v5e94rf+8Hv/YP5yevpJ+tvfzKr333+7bPvHP/U6ScPi3cPZ/tv7z6vz14cfLne
+        W+T3Hq6/8+CnZseDqHz/l/w/zRmIASABAAA=
     headers:
       cache-control: [no-cache]
       content-encoding: [gzip]
       content-type: [application/json]
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
       expires: ['-1']
       pragma: [no-cache]
       server: ['Microsoft-Azure-Storage-Resource-Provider/1.0,Microsoft-HTTPAPI/2.0
@@ -142,28 +188,28 @@ interactions:
       strict-transport-security: [max-age=31536000; includeSubDomains]
       vary: [Accept-Encoding]
       x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [7f3dbbb1-2b0b-4eb1-a877-1d736615cabf]
+      x-ms-correlation-request-id: [a8df036a-5e43-4e71-95a9-2d50a8703104]
       x-ms-ratelimit-remaining-subscription-writes: ['1199']
-      x-ms-request-id: [ebe01cee-772c-4439-b537-1c451007d047]
-      x-ms-routing-request-id: ['WESTUS2:20180521T172421Z:7f3dbbb1-2b0b-4eb1-a877-1d736615cabf']
+      x-ms-request-id: [bad360c8-19c0-4005-ae4e-0715c1af6d9a]
+      x-ms-routing-request-id: ['WESTUS2:20180627T142127Z:a8df036a-5e43-4e71-95a9-2d50a8703104']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/0.34.3 (Python CPython 2.7.13; Windows 10)]
-      x-ms-date: ['Mon, 21 May 2018 17:24:20 GMT']
-      x-ms-version: ['2016-05-31']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.13; Windows 10)]
+      x-ms-date: ['Wed, 27 Jun 2018 14:21:27 GMT']
+      x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc
   response:
     body: {string: !!python/unicode ''}
     headers:
       content-length: ['0']
-      date: ['Mon, 21 May 2018 17:24:21 GMT']
+      date: ['Wed, 27 Jun 2018 14:21:27 GMT']
       server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [68c6bad1-b003-0097-2528-f13aca000000]
-      x-ms-version: ['2016-05-31']
+      x-ms-request-id: [2e2a6b24-c003-007d-5422-0ec5cb000000]
+      x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 version: 1


### PR DESCRIPTION
Azure Storage rev'd to 1.3 last night, broke some of our tests and caused some package conflicts.

I've reduced our Azure SDK dependencies by removing the `azure` bundle and I have updated our test recordings to be compatible with the new API version.

I also updated `make install` to match the tox testenv.