### PR TITLE
Remove session from resource type registration.

### DIFF
--- a/tools/c7n_azure/c7n_azure/resources/access_control.py
+++ b/tools/c7n_azure/c7n_azure/resources/access_control.py
@@ -13,11 +13,12 @@
 # limitations under the License.
 
 from c7n_azure.provider import resources
-from c7n_azure.query import QueryResourceManager
+from c7n_azure.query import QueryResourceManager, DescribeSource
 from c7n_azure.session import Session
 
 from c7n.filters import ValueFilter
 from c7n.filters.related import RelatedResourceFilter
+from c7n.query import sources
 from c7n.utils import type_schema
 
 
@@ -42,10 +43,8 @@ class RoleAssignment(QueryResourceManager):
 class RoleDefinition(QueryResourceManager):
 
     class resource_type(object):
-        s = Session()
         service = 'azure.mgmt.authorization'
         client = 'AuthorizationManagementClient'
-        enum_spec = ('role_definitions', 'list', '/subscriptions/%s' % (s.subscription_id))
         get_spec = ('role_definitions', 'get_by_id', None)
         type = 'roleDefinition'
         id = 'id'
@@ -58,6 +57,20 @@ class RoleDefinition(QueryResourceManager):
             'properties.type',
             'properties.permissions'
         )
+
+    @property
+    def source_type(self):
+        return self.data.get('source', 'describe-azure-roledefinition')
+
+
+@sources.register('describe-azure-roledefinition')
+class DescribeSource(DescribeSource):
+
+    def get_resources(self, query):
+        s = Session()
+        scope = '/subscriptions/%s' % (s.subscription_id)
+        resources = self.manager.get_client().role_definitions.list(scope)
+        return [r.serialize(True) for r in resources]
 
 
 @RoleAssignment.filter_registry.register('role')


### PR DESCRIPTION
Role definition list requires the scope to the subscription as a parameter. Moving the call to session where it's needed (get_resources). 