### PR TITLE
mu support for native aws lambda sqs integration

### DIFF
--- a/tests/data/placebo/test_mu_sqs_subscriber/lambda.CreateFunction_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/lambda.CreateFunction_1.json
@@ -1,0 +1,41 @@
+{
+    "status_code": 201,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "8960745e-7ba5-11e8-8385-175083c0feec",
+            "HTTPStatusCode": 201,
+            "HTTPHeaders": {
+                "date": "Fri, 29 Jun 2018 14:05:55 GMT",
+                "content-type": "application/json",
+                "content-length": "664",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "8960745e-7ba5-11e8-8385-175083c0feec"
+            },
+            "RetryAttempts": 0
+        },
+        "FunctionName": "c7n-hello-sqs",
+        "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+        "Runtime": "python2.7",
+        "Role": "arn:aws:iam::644160558196:role/custodian-mu",
+        "Handler": "helloworld.main",
+        "CodeSize": 2037392,
+        "Description": "Hello World",
+        "Timeout": 15,
+        "MemorySize": 512,
+        "LastModified": "2018-06-29T14:05:55.306+0000",
+        "CodeSha256": "K6xi0RYM2+mpDcRDiSZwpzod0Dc7wDDFV5FDT9kQ4Ac=",
+        "Version": "4",
+        "VpcConfig": {
+            "SubnetIds": [],
+            "SecurityGroupIds": [],
+            "VpcId": ""
+        },
+        "Environment": {
+            "Variables": {}
+        },
+        "TracingConfig": {
+            "Mode": "PassThrough"
+        },
+        "RevisionId": "78294760-c5d3-4233-ab6d-8daad9849cc1"
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/lambda.DeleteEventSourceMapping_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/lambda.DeleteEventSourceMapping_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 202,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "b07d6c75-7ba5-11e8-a26a-8376f837b330",
+            "HTTPStatusCode": 202,
+            "HTTPHeaders": {
+                "date": "Fri, 29 Jun 2018 14:06:59 GMT",
+                "content-type": "application/json",
+                "content-length": "327",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "b07d6c75-7ba5-11e8-a26a-8376f837b330"
+            },
+            "RetryAttempts": 0
+        },
+        "UUID": "90282713-22c8-4931-8847-ad391732994e",
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:us-east-1:644160558196:my-dev-test-3",
+        "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2018,
+            "month": 6,
+            "day": 29,
+            "hour": 10,
+            "minute": 6,
+            "second": 59,
+            "microsecond": 619000
+        },
+        "State": "Deleting",
+        "StateTransitionReason": "USER_INITIATED"
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/lambda.DeleteFunction_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/lambda.DeleteFunction_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 204,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "b08fbb85-7ba5-11e8-ab72-ed38a18debdd",
+            "HTTPStatusCode": 204,
+            "HTTPHeaders": {
+                "date": "Fri, 29 Jun 2018 14:06:59 GMT",
+                "content-type": "application/json",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "b08fbb85-7ba5-11e8-ab72-ed38a18debdd"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/lambda.GetFunction_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/lambda.GetFunction_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 404,
+    "data": {
+        "Error": {
+            "Message": "Function not found: arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+            "Code": "ResourceNotFoundException"
+        },
+        "ResponseMetadata": {
+            "RequestId": "89491ad2-7ba5-11e8-bf37-25db19d8463a",
+            "HTTPStatusCode": 404,
+            "HTTPHeaders": {
+                "date": "Fri, 29 Jun 2018 14:05:53 GMT",
+                "content-type": "application/json",
+                "content-length": "108",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "89491ad2-7ba5-11e8-bf37-25db19d8463a",
+                "x-amzn-errortype": "ResourceNotFoundException"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/lambda.ListEventSourceMappings_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/lambda.ListEventSourceMappings_1.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "8ac6e1ae-7ba5-11e8-9ec8-b3ced88feb65",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "date": "Fri, 29 Jun 2018 14:05:56 GMT",
+                "content-type": "application/json",
+                "content-length": "699",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "8ac6e1ae-7ba5-11e8-9ec8-b3ced88feb65"
+            },
+            "RetryAttempts": 0
+        },
+        "EventSourceMappings": [
+            {
+                "UUID": "0d8c2609-317d-4e2d-a777-721dc33895a3",
+                "BatchSize": 10,
+                "EventSourceArn": "arn:aws:sqs:us-east-1:644160558196:my-dev-test-4",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+                "LastModified": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 6,
+                    "day": 29,
+                    "hour": 9,
+                    "minute": 47,
+                    "second": 29,
+                    "microsecond": 87000
+                },
+                "State": "Disabled",
+                "StateTransitionReason": "USER_INITIATED"
+            },
+            {
+                "UUID": "90282713-22c8-4931-8847-ad391732994e",
+                "BatchSize": 10,
+                "EventSourceArn": "arn:aws:sqs:us-east-1:644160558196:my-dev-test-3",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+                "LastModified": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 6,
+                    "day": 29,
+                    "hour": 9,
+                    "minute": 39,
+                    "second": 3,
+                    "microsecond": 873000
+                },
+                "State": "Disabled",
+                "StateTransitionReason": "USER_INITIATED"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/lambda.ListEventSourceMappings_2.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/lambda.ListEventSourceMappings_2.json
@@ -1,0 +1,55 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "b07296ef-7ba5-11e8-84e3-dfb268fa40a1",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "date": "Fri, 29 Jun 2018 14:06:59 GMT",
+                "content-type": "application/json",
+                "content-length": "698",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "b07296ef-7ba5-11e8-84e3-dfb268fa40a1"
+            },
+            "RetryAttempts": 0
+        },
+        "EventSourceMappings": [
+            {
+                "UUID": "0d8c2609-317d-4e2d-a777-721dc33895a3",
+                "BatchSize": 10,
+                "EventSourceArn": "arn:aws:sqs:us-east-1:644160558196:my-dev-test-4",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+                "LastModified": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 6,
+                    "day": 29,
+                    "hour": 9,
+                    "minute": 47,
+                    "second": 29,
+                    "microsecond": 87000
+                },
+                "State": "Disabled",
+                "StateTransitionReason": "USER_INITIATED"
+            },
+            {
+                "UUID": "90282713-22c8-4931-8847-ad391732994e",
+                "BatchSize": 10,
+                "EventSourceArn": "arn:aws:sqs:us-east-1:644160558196:my-dev-test-3",
+                "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+                "LastModified": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 6,
+                    "day": 29,
+                    "hour": 10,
+                    "minute": 5,
+                    "second": 56,
+                    "microsecond": 424000
+                },
+                "State": "Enabled",
+                "StateTransitionReason": "USER_INITIATED"
+            }
+        ]
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/lambda.UpdateEventSourceMapping_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/lambda.UpdateEventSourceMapping_1.json
@@ -1,0 +1,33 @@
+{
+    "status_code": 202,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "8ad11a9f-7ba5-11e8-ae54-5332f4bb8ca7",
+            "HTTPStatusCode": 202,
+            "HTTPHeaders": {
+                "date": "Fri, 29 Jun 2018 14:05:56 GMT",
+                "content-type": "application/json",
+                "content-length": "327",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "8ad11a9f-7ba5-11e8-ae54-5332f4bb8ca7"
+            },
+            "RetryAttempts": 0
+        },
+        "UUID": "90282713-22c8-4931-8847-ad391732994e",
+        "BatchSize": 10,
+        "EventSourceArn": "arn:aws:sqs:us-east-1:644160558196:my-dev-test-3",
+        "FunctionArn": "arn:aws:lambda:us-east-1:644160558196:function:c7n-hello-sqs",
+        "LastModified": {
+            "__class__": "datetime",
+            "year": 2018,
+            "month": 6,
+            "day": 29,
+            "hour": 10,
+            "minute": 5,
+            "second": 56,
+            "microsecond": 424000
+        },
+        "State": "Enabling",
+        "StateTransitionReason": "USER_INITIATED"
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/logs.DeleteLogGroup_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/logs.DeleteLogGroup_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "b032ce29-7ba5-11e8-8888-490bed176cff",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "b032ce29-7ba5-11e8-8888-490bed176cff",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "0",
+                "date": "Fri, 29 Jun 2018 14:06:59 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/logs.DescribeLogGroups_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/c7n-hello-sqs",
+                "creationTime": 1530281121546,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/c7n-hello-sqs:*",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "aeee679c-7ba5-11e8-a3c4-ed07ccc24f7b",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "aeee679c-7ba5-11e8-a3c4-ed07ccc24f7b",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "209",
+                "date": "Fri, 29 Jun 2018 14:06:56 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/logs.DescribeLogStreams_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/logs.DescribeLogStreams_1.json
@@ -1,0 +1,38 @@
+{
+    "status_code": 200,
+    "data": {
+        "logStreams": [
+            {
+                "logStreamName": "2018/06/29/[$LATEST]f16430ece01f4404ba59c6f03fd274b6",
+                "creationTime": 1530281202641,
+                "firstEventTimestamp": 1530281202663,
+                "lastEventTimestamp": 1530281202663,
+                "lastIngestionTime": 1530281203966,
+                "uploadSequenceToken": "49583223086134434462789778147011664823562067731898565314",
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/c7n-hello-sqs:log-stream:2018/06/29/[$LATEST]f16430ece01f4404ba59c6f03fd274b6",
+                "storedBytes": 0
+            },
+            {
+                "logStreamName": "2018/06/29/[$LATEST]73900d3745df45b289c61a73e2718b74",
+                "creationTime": 1530281121575,
+                "firstEventTimestamp": 1530281106432,
+                "lastEventTimestamp": 1530281107773,
+                "lastIngestionTime": 1530281121592,
+                "uploadSequenceToken": "49584193858201115809449199208645333593643063264460050066",
+                "arn": "arn:aws:logs:us-east-1:644160558196:log-group:/aws/lambda/c7n-hello-sqs:log-stream:2018/06/29/[$LATEST]73900d3745df45b289c61a73e2718b74",
+                "storedBytes": 0
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "af5a21e4-7ba5-11e8-a3c4-ed07ccc24f7b",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "af5a21e4-7ba5-11e8-a3c4-ed07ccc24f7b",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "912",
+                "date": "Fri, 29 Jun 2018 14:06:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/logs.GetLogEvents_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/logs.GetLogEvents_1.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "events": [
+            {
+                "timestamp": 1530281106432,
+                "message": "START RequestId: 1d24998e-3cf5-5606-8ada-ca3e02270dfe Version: $LATEST\n",
+                "ingestionTime": 1530281121592
+            },
+            {
+                "timestamp": 1530281106772,
+                "message": "END RequestId: 1d24998e-3cf5-5606-8ada-ca3e02270dfe\n",
+                "ingestionTime": 1530281121592
+            },
+            {
+                "timestamp": 1530281106772,
+                "message": "REPORT RequestId: 1d24998e-3cf5-5606-8ada-ca3e02270dfe\tDuration: 339.77 ms\tBilled Duration: 400 ms \tMemory Size: 512 MB\tMax Memory Used: 29 MB\t\n",
+                "ingestionTime": 1530281121592
+            },
+            {
+                "timestamp": 1530281107773,
+                "message": "{\"Records\": [{\"body\": \"{\\\"jurassic\\\": \\\"block\\\"}\", \"receiptHandle\": \"AQEB+ma20xDMQH73M+pRPmPQ9dOBGebH6nQFEq3zheIYr9BvJzN0uHjU1pHrFa66PEbx6WbuLiudXXh3s0LauNDkmOUxbD4fBBXY1pMMISwlFICzRr/FvsLwB4tbfOVSTRP7Zx5Q5z3UxXp7uw4Q58URJspf8j3XjE+LBQSNmwqkPdyQw47LRkNspM/INNYpgfDOQYphRiTWGOfLilx4sAWqpFPUl23Exy+obGBCy4AyZubcNv1WJ1+xVdHQkvP28NrIvz2wrevuhrQdP0kNUeqWDS8xLU2mI8tvGiO7wjPho4vNO17yfX5TZyOvH2TS5grInxN7Zq+JI8TnmG5IOgI03sSHiZ35WoNxcsRezrNxu9p100JWVGRSHtzBT2rD5UUG\", \"md5OfBody\": \"ca25a487df6e351a06f025728468e323\", \"eventSourceARN\": \"arn:aws:sqs:us-east-1:644160558196:my-dev-test-1\", \"eventSource\": \"aws:sqs\", \"awsRegion\": \"us-east-1\", \"messageId\": \"ea061ee4-932f-4b90-a3d2-5a9d6a77aa5d\", \"attributes\": {\"ApproximateFirstReceiveTimestamp\": \"1530281106218\", \"SenderId\": \"AIDAJEZOTH6YPO3DY45QW\", \"ApproximateReceiveCount\": \"1\", \"SentTimestamp\": \"1530281079298\"}, \"messageAttributes\": {}}]}",
+                "ingestionTime": 1530281121592
+            }
+        ],
+        "nextForwardToken": "f/34126409066570852794743264685877183649537151739821228035",
+        "nextBackwardToken": "b/34126409036665553483513699053077785445915698960301490176",
+        "ResponseMetadata": {
+            "RequestId": "af9c0ca4-7ba5-11e8-a3c4-ed07ccc24f7b",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "af9c0ca4-7ba5-11e8-a3c4-ed07ccc24f7b",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "1948",
+                "date": "Fri, 29 Jun 2018 14:06:57 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/logs.GetLogEvents_2.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/logs.GetLogEvents_2.json
@@ -1,0 +1,40 @@
+{
+    "status_code": 200,
+    "data": {
+        "events": [
+            {
+                "timestamp": 1530281202663,
+                "message": "START RequestId: 376c8bdc-3cd8-595d-8fd9-d86c03ea7426 Version: $LATEST\n",
+                "ingestionTime": 1530281202663
+            },
+            {
+                "timestamp": 1530281202973,
+                "message": "END RequestId: 376c8bdc-3cd8-595d-8fd9-d86c03ea7426\n",
+                "ingestionTime": 1530281202967
+            },
+            {
+                "timestamp": 1530281202973,
+                "message": "REPORT RequestId: 376c8bdc-3cd8-595d-8fd9-d86c03ea7426\tDuration: 309.82 ms\tBilled Duration: 400 ms \tMemory Size: 512 MB\tMax Memory Used: 29 MB\t\n",
+                "ingestionTime": 1530281202967
+            },
+            {
+                "timestamp": 1530281203973,
+                "message": "{\"Records\": [{\"body\": \"{\\\"jurassic\\\": \\\"block\\\"}\", \"receiptHandle\": \"AQEBZOghR/RbKO2yKsbFv+OdoKJ7raULCd6vLMaWgdfWsmP7ItyMApEJAR+IgKoZUJtJvfS5sJGaFifsH6nWKsWjFq2EeZ0++IkVys4XabATX6D+NbuYAs9sdC1fNbOU0A8n9zMYAnLi4wajRBVOfKuew/ozmOktoOgFF0PssU1x3ipvq1BAnJweb1UGEJm0vwqyiJgUwmpAedljDb/vm4JeQczce+MiBFMuarbzzsoOBKXuoAFaib/qItILOYhzdsc+P4gUyzLIZk8UJ4FMe+fMKCGeUF7BK6q1sM0edRi4kZCZrrKbnky0g3saEyD5C4C/REpwdTW1xiHBV4TIv22px3ZgepTMrwl4nUMEAX/ULHxhRA0QMt4bHe7GWaNXhHUy\", \"md5OfBody\": \"ca25a487df6e351a06f025728468e323\", \"eventSourceARN\": \"arn:aws:sqs:us-east-1:644160558196:my-dev-test-3\", \"eventSource\": \"aws:sqs\", \"awsRegion\": \"us-east-1\", \"messageId\": \"6ce9ed27-0968-4053-8e61-f490b84ed84a\", \"attributes\": {\"ApproximateFirstReceiveTimestamp\": \"1530281202455\", \"SenderId\": \"AIDAJEZOTH6YPO3DY45QW\", \"ApproximateReceiveCount\": \"1\", \"SentTimestamp\": \"1530281156483\"}, \"messageAttributes\": {}}]}",
+                "ingestionTime": 1530281203966
+            }
+        ],
+        "nextForwardToken": "f/34126411211902540893389211001197578269659190337313177600",
+        "nextBackwardToken": "b/34126411182688564683314094684210485488236978096881795072",
+        "ResponseMetadata": {
+            "RequestId": "aff50252-7ba5-11e8-a3c4-ed07ccc24f7b",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "aff50252-7ba5-11e8-a3c4-ed07ccc24f7b",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "1948",
+                "date": "Fri, 29 Jun 2018 14:06:58 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/sqs.CreateQueue_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/sqs.CreateQueue_1.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200,
+    "data": {
+        "QueueUrl": "https://queue.amazonaws.com/644160558196/my-dev-test-3",
+        "ResponseMetadata": {
+            "RequestId": "9c23d520-54db-5e3a-9ef8-86906bdbebea",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "server": "Server",
+                "date": "Fri, 29 Jun 2018 14:05:53 GMT",
+                "content-type": "text/xml",
+                "content-length": "325",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "9c23d520-54db-5e3a-9ef8-86906bdbebea"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/sqs.DeleteQueue_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/sqs.DeleteQueue_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "ee24fa3d-9038-50ab-9eec-a98daf7b357b",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "server": "Server",
+                "date": "Fri, 29 Jun 2018 14:07:00 GMT",
+                "content-type": "text/xml",
+                "content-length": "211",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "ee24fa3d-9038-50ab-9eec-a98daf7b357b"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/sqs.GetQueueAttributes_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/sqs.GetQueueAttributes_1.json
@@ -1,0 +1,21 @@
+{
+    "status_code": 200,
+    "data": {
+        "Attributes": {
+            "QueueArn": "arn:aws:sqs:us-east-1:644160558196:my-dev-test-3"
+        },
+        "ResponseMetadata": {
+            "RequestId": "57272eeb-9e91-5fb1-a92b-7d5ba190da61",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "server": "Server",
+                "date": "Fri, 29 Jun 2018 14:05:53 GMT",
+                "content-type": "text/xml",
+                "content-length": "385",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "57272eeb-9e91-5fb1-a92b-7d5ba190da61"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_mu_sqs_subscriber/sqs.SendMessage_1.json
+++ b/tests/data/placebo/test_mu_sqs_subscriber/sqs.SendMessage_1.json
@@ -1,0 +1,20 @@
+{
+    "status_code": 200,
+    "data": {
+        "MD5OfMessageBody": "ca25a487df6e351a06f025728468e323",
+        "MessageId": "6ce9ed27-0968-4053-8e61-f490b84ed84a",
+        "ResponseMetadata": {
+            "RequestId": "9f79bbd2-3888-543e-8776-e862078c21ee",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "server": "Server",
+                "date": "Fri, 29 Jun 2018 14:05:56 GMT",
+                "content-type": "text/xml",
+                "content-length": "378",
+                "connection": "keep-alive",
+                "x-amzn-requestid": "9f79bbd2-3888-543e-8776-e862078c21ee"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}


### PR DESCRIPTION
lambda provisioning support for sqs event source per https://aws.amazon.com/blogs/aws/aws-lambda-adds-amazon-simple-queue-service-to-supported-event-sources/ and  https://docs.aws.amazon.com/lambda/latest/dg/with-sqs.html