### PR TITLE
aws lambda policy perf optimization via model loading on cold start only

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -35,8 +35,11 @@ logging.root.setLevel(logging.DEBUG)
 logging.getLogger('botocore').setLevel(logging.WARNING)
 log = logging.getLogger('custodian.lambda')
 
-
 account_id = None
+
+# On cold start load all resources, requires a pythonpath directory scan
+if 'AWS_EXECUTION_ENV' in os.environ:
+    load_resources()
 
 
 def dispatch_event(event, context):
@@ -82,7 +85,6 @@ def dispatch_event(event, context):
         options_overrides['output_dir'] = output_dir
     options = Config.empty(**options_overrides)
 
-    load_resources()
     policies = PolicyCollection.from_data(policy_config, options)
     if policies:
         for p in policies:

--- a/setup.py
+++ b/setup.py
@@ -23,8 +23,8 @@ setup(
         'console_scripts': [
             'custodian = c7n.cli:main']},
     install_requires=[
-        "boto3>=1.7.32",
-        "botocore>=1.10.32",
+        "boto3>=1.7.48",
+        "botocore>=1.10.48",
         "pyyaml",
         "jsonschema",
         "jsonpatch>=1.21",


### PR DESCRIPTION
 move load_resources call to global cold start initialize only, update botocore/boto version reqs for sqs lambda min version