### PR TITLE
Adding Python 3.7 Support: async is now a reserved keyword

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+sudo: false
 cache:
   pip: true
 env:
@@ -8,13 +9,10 @@ matrix:
     include:
         - python: 2.7
           dist: trusty
-          sudo: false
         - python: 3.6
           dist: trusty
-          sudo: false
         - python: 3.7
           dist: xenial
-          sudo: true
 
 install:
   - pip install coveralls tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,6 +9,7 @@ env:
 python:
   - "2.7"
   - "3.6"
+  - "3.7"
 install:
   - pip install coveralls tox
 script:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,15 @@
 language: python
-sudo: false
-cache:
-  pip: true
+cache: pip
 env:
   - C7N_TEST_WORKERS=8
 
 matrix:
     include:
         - python: 2.7
-          dist: trusty
         - python: 3.6
-          dist: trusty
         - python: 3.7
           dist: xenial
+          sudo: true
 
 install:
   - pip install coveralls tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,15 +1,21 @@
 language: python
-dist: trusty
-sudo: false
 cache:
   pip: true
 env:
   - C7N_TEST_WORKERS=8
 
-python:
-  - "2.7"
-  - "3.6"
-  - "3.7"
+matrix:
+    include:
+        - python: 2.7
+          dist: trusty
+          sudo: false
+        - python: 3.6
+          dist: trusty
+          sudo: false
+        - python: 3.7
+          dist: xenial
+          sudo: true
+
 install:
   - pip install coveralls tox
 script:

--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -336,16 +336,20 @@ class LambdaInvoke(EventAction):
        function: my-function
     """
 
-    schema = utils.type_schema(
-        'invoke-lambda',
-        function={'type': 'string'},
-        c7n_async={'type': 'boolean'},
-        qualifier={'type': 'string'},
-        batch_size={'type': 'integer'},
-        required=('function',))
+    schema = {
+        'type': 'object',
+        'required': ['function'],
+        'properties': {
+            'type': {'enum': ['invoke-lambda']},
+            'function': {'type': 'string'},
+            'async': {'type': 'boolean'},
+            'qualifier': {'type': 'string'},
+            'batch_size': {'type': 'integer'}
+        }
+    }
 
     def get_permissions(self):
-        if self.data.get('c7n_async', True):
+        if self.data.get('async', True):
             return ('lambda:InvokeAsync',)
         return ('lambda:Invoke',)
 

--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -339,13 +339,13 @@ class LambdaInvoke(EventAction):
     schema = utils.type_schema(
         'invoke-lambda',
         function={'type': 'string'},
-        async={'type': 'boolean'},
+        c7n_async={'type': 'boolean'},
         qualifier={'type': 'string'},
         batch_size={'type': 'integer'},
         required=('function',))
 
     def get_permissions(self):
-        if self.data.get('async', True):
+        if self.data.get('c7n_async', True):
             return ('lambda:InvokeAsync',)
         return ('lambda:Invoke',)
 
@@ -359,7 +359,7 @@ class LambdaInvoke(EventAction):
         if self.data.get('qualifier'):
             params['Qualifier'] = self.data['Qualifier']
 
-        if self.data.get('async', True):
+        if self.data.get('c7n_async', True):
             params['InvocationType'] = 'Event'
 
         payload = {

--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -338,7 +338,7 @@ class LambdaInvoke(EventAction):
 
     schema = {
         'type': 'object',
-        'required': ['function'],
+        'required': ['type', 'function'],
         'properties': {
             'type': {'enum': ['invoke-lambda']},
             'function': {'type': 'string'},
@@ -363,7 +363,7 @@ class LambdaInvoke(EventAction):
         if self.data.get('qualifier'):
             params['Qualifier'] = self.data['Qualifier']
 
-        if self.data.get('c7n_async', True):
+        if self.data.get('async', True):
             params['InvocationType'] = 'Event'
 
         payload = {

--- a/c7n/executor.py
+++ b/c7n/executor.py
@@ -43,11 +43,11 @@ def executor(name, **kw):
 class MainThreadExecutor(object):
     """ For running tests.
 
-    async == True  -> catch exceptions and store them in the future.
-    async == False -> let exceptions bubble up.
+    c7n_async == True  -> catch exceptions and store them in the future.
+    c7n_async == False -> let exceptions bubble up.
     """
 
-    async = True
+    c7n_async = True
 
     # For Dev/Unit Testing with concurrent.futures
     def __init__(self, *args, **kw):
@@ -62,7 +62,7 @@ class MainThreadExecutor(object):
         try:
             return MainThreadFuture(func(*args, **kw))
         except Exception as e:
-            if self.async:
+            if self.c7n_async:
                 return MainThreadFuture(None, exception=e)
             raise
 

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -94,7 +94,7 @@ class PythonPackageArchive(object):
                 # https://docs.python.org/3/reference/import.html#module-path
                 for directory in module.__path__:
                     self.add_directory(directory, ignore)
-                if not hasattr(module, '__file__'):
+                if getattr(module, '__file__', None) is None:
 
                     # Likely a namespace package. Try to add *.pth files so
                     # submodules are importable under Python 2.7.

--- a/tests/test_s3.py
+++ b/tests/test_s3.py
@@ -1886,7 +1886,7 @@ class S3Test(BaseTest):
         )
         self.patch(s3.S3, "executor_factory", MainThreadExecutor)
         self.patch(s3.RemovePolicyStatement, "executor_factory", MainThreadExecutor)
-        self.patch(MainThreadExecutor, "async", False)
+        self.patch(MainThreadExecutor, "c7n_async", False)
 
         bname = "custodian-policy-test"
         statement = {

--- a/tools/c7n_index/c7n_index/metrics.py
+++ b/tools/c7n_index/c7n_index/metrics.py
@@ -38,7 +38,7 @@ from c7n.utils import chunks, dumps, get_retry, local_session
 # from c7n.executor import MainThreadExecutor
 # ThreadPoolExecutor = MainThreadExecutor
 # ProcessPoolExecutor = MainThreadExecutor
-# MainThreadExecutor.async = False
+# MainThreadExecutor.c7n_async = False
 
 MAX_POINTS = 1440.0
 NAMESPACE = 'CloudMaid'

--- a/tools/c7n_logexporter/c7n_logexporter/exporter.py
+++ b/tools/c7n_logexporter/c7n_logexporter/exporter.py
@@ -35,7 +35,7 @@ from tabulate import tabulate
 import yaml
 
 from c7n.executor import MainThreadExecutor
-MainThreadExecutor.async = False
+MainThreadExecutor.c7n_async = False
 
 logging.basicConfig(level=logging.INFO)
 logging.getLogger('c7n.worker').setLevel(logging.DEBUG)

--- a/tools/c7n_mailer/requirements.txt
+++ b/tools/c7n_mailer/requirements.txt
@@ -10,7 +10,7 @@ Markup
 MarkupSafe==1.0
 python-dateutil>=2.5.2
 ldap3
-ruamel.yaml==0.15.42 # rq.filter: <0.15
+ruamel.yaml==0.15.42
 six==1.11.0
 redis
 datadog

--- a/tools/c7n_mailer/requirements.txt
+++ b/tools/c7n_mailer/requirements.txt
@@ -10,7 +10,7 @@ Markup
 MarkupSafe==1.0
 python-dateutil>=2.5.2
 ldap3
-ruamel.yaml<=0.15 # rq.filter: <0.15
+ruamel.yaml==0.15.42 # rq.filter: <0.15
 six==1.11.0
 redis
 datadog

--- a/tools/c7n_mailer/requirements.txt
+++ b/tools/c7n_mailer/requirements.txt
@@ -10,7 +10,7 @@ Markup
 MarkupSafe==1.0
 python-dateutil>=2.5.2
 ldap3
-ruamel.yaml<0.15 # rq.filter: <0.15
+ruamel.yaml<=0.15 # rq.filter: <0.15
 six==1.11.0
 redis
 datadog

--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -21,7 +21,7 @@ requires = [
     "Jinja2",
     "boto3",
     "jsonschema",
-    "ruamel.yaml<=0.15",
+    "ruamel.yaml==0.15.42",
     "datadog",
     "slackclient",
     "sendgrid",

--- a/tools/c7n_mailer/setup.py
+++ b/tools/c7n_mailer/setup.py
@@ -21,7 +21,7 @@ requires = [
     "Jinja2",
     "boto3",
     "jsonschema",
-    "ruamel.yaml<0.15",
+    "ruamel.yaml<=0.15",
     "datadog",
     "slackclient",
     "sendgrid",

--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -157,7 +157,7 @@ def init(config, use, debug, verbose, accounts, tags, policies, resource=None, p
     filter_accounts(accounts_config, tags, accounts)
 
     load_resources()
-    MainThreadExecutor.async = False
+    MainThreadExecutor.c7n_async = False
     executor = debug and MainThreadExecutor or ProcessPoolExecutor
     return accounts_config, custodian_config, executor
 

--- a/tools/c7n_salactus/c7n_salactus/cli.py
+++ b/tools/c7n_salactus/c7n_salactus/cli.py
@@ -249,7 +249,7 @@ def save(dbpath):
 @cli.command()
 # todo check redis version if >=4 support this
 # @click.option('--async/--sync', default=False)
-def reset(async=None):
+def reset(c7n_async=None):
     """Delete all persistent cluster state.
     """
     click.echo('Delete db? Are you Sure? [yn] ', nl=False)

--- a/tools/dev/citoxenv.py
+++ b/tools/dev/citoxenv.py
@@ -5,3 +5,5 @@ if pyver == '2.7':
     print('py27-cov,docs,lint')
 elif pyver == '3.6':
     print('py36')
+elif pyver == '3.7':
+    print('py37')

--- a/tools/zerodark/zerodark/floweni.py
+++ b/tools/zerodark/zerodark/floweni.py
@@ -34,7 +34,7 @@ from c7n.executor import MainThreadExecutor
 
 EPOCH_32_MAX = 2147483647
 
-MainThreadExecutor.async = False
+MainThreadExecutor.c7n_async = False
 
 log = logging.getLogger('traffic')
 

--- a/tools/zerodark/zerodark/ipdb.py
+++ b/tools/zerodark/zerodark/ipdb.py
@@ -667,7 +667,7 @@ def load_resources(bucket, prefix, region, account_config, accounts,
     executor = ProcessPoolExecutor
     if debug:
         from c7n.executor import MainThreadExecutor
-        MainThreadExecutor.async = False
+        MainThreadExecutor.c7n_async = False
         executor = MainThreadExecutor
 
     stats = Counter()

--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,7 @@ ignore = E128,E401
 max-line-length = 100
 
 [tox]
-envlist = py27,py36,lint
+envlist = py27,py36,py37,lint
 
 [testenv]
 deps =
@@ -41,6 +41,10 @@ commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} --cov c7n --durations 20 tests tools {posargs}
 
 [testenv:py36]
+commands =
+    py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
+
+[testenv:py37]
 commands =
     py.test -n {env:C7N_TEST_WORKERS:auto} tests tools {posargs}
 


### PR DESCRIPTION
- renamed references to async to c7n_async to avoid confusion

I am open to a better name but this was the first one that came to mind.