### PR TITLE
iam-role/user/group - add InlinePolicies attribute to iam role when using has-inline-policy filter

### DIFF
--- a/c7n/resources/iam.py
+++ b/c7n/resources/iam.py
@@ -378,7 +378,7 @@ class IamRoleInlinePolicy(Filter):
     def _inline_policies(self, client, resource):
         policies = client.list_role_policies(
             RoleName=resource['RoleName'])['PolicyNames']
-        resource['InlinePolicies'] = policies
+        resource['c7n:InlinePolicies'] = policies
         return resource
 
     def process(self, resources, event=None):
@@ -387,9 +387,9 @@ class IamRoleInlinePolicy(Filter):
         value = self.data.get('value', True)
         for r in resources:
             r = self._inline_policies(c, r)
-            if len(r['InlinePolicies']) > 0 and value:
+            if len(r['c7n:InlinePolicies']) > 0 and value:
                 res.append(r)
-            if len(r['InlinePolicies']) == 0 and not value:
+            if len(r['c7n:InlinePolicies']) == 0 and not value:
                 res.append(r)
         return res
 
@@ -893,7 +893,7 @@ class IamUserInlinePolicy(Filter):
     permissions = ('iam:ListUserPolicies',)
 
     def _inline_policies(self, client, resource):
-        resource['InlinePolicies'] = client.list_user_policies(
+        resource['c7n:InlinePolicies'] = client.list_user_policies(
             UserName=resource['UserName'])['PolicyNames']
         return resource
 
@@ -903,9 +903,9 @@ class IamUserInlinePolicy(Filter):
         res = []
         for r in resources:
             r = self._inline_policies(c, r)
-            if len(r['InlinePolicies']) > 0 and value:
+            if len(r['c7n:InlinePolicies']) > 0 and value:
                 res.append(r)
-            if len(r['InlinePolicies']) == 0 and not value:
+            if len(r['c7n:InlinePolicies']) == 0 and not value:
                 res.append(r)
         return res
 
@@ -1437,7 +1437,7 @@ class IamGroupInlinePolicy(Filter):
     permissions = ('iam:ListGroupPolicies',)
 
     def _inline_policies(self, client, resource):
-        resource['InlinePolicies'] = client.list_group_policies(
+        resource['c7n:InlinePolicies'] = client.list_group_policies(
             GroupName=resource['GroupName'])['PolicyNames']
         return resource
 
@@ -1447,8 +1447,8 @@ class IamGroupInlinePolicy(Filter):
         res = []
         for r in resources:
             r = self._inline_policies(c, r)
-            if len(r['InlinePolicies']) > 0 and value:
+            if len(r['c7n:InlinePolicies']) > 0 and value:
                 res.append(r)
-            if len(r['InlinePolicies']) == 0 and not value:
+            if len(r['c7n:InlinePolicies']) == 0 and not value:
                 res.append(r)
         return res

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -567,7 +567,7 @@ class IamInlinePolicyUsage(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["UserName"], "kapil")
-        self.assertEqual(resources[0]["InlinePolicies"][0],
+        self.assertEqual(resources[0]["c7n:InlinePolicies"][0],
             "policygen-andrewalexander-201612112039")
 
     def test_iam_user_no_inline_policy(self):
@@ -595,7 +595,7 @@ class IamInlinePolicyUsage(BaseTest):
             sorted([r["UserName"] for r in resources]),
             ["andrewalexander", "scot@sixfeetup.com"],
         )
-        self.assertFalse(resources[0]["InlinePolicies"])
+        self.assertFalse(resources[0]["c7n:InlinePolicies"])
 
     def test_iam_role_has_inline_policy(self):
         session_factory = self.replay_flight_data("test_iam_role_has_inline_policy")
@@ -611,7 +611,7 @@ class IamInlinePolicyUsage(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(
-            resources[0]['InlinePolicies'][0],
+            resources[0]['c7n:InlinePolicies'][0],
             "oneClick_lambda_basic_execution_1466943062384")
 
     def test_iam_role_no_inline_policy(self):
@@ -627,7 +627,7 @@ class IamInlinePolicyUsage(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 6)
-        self.assertFalse(resources[0]["InlinePolicies"])
+        self.assertFalse(resources[0]["c7n:InlinePolicies"])
 
     def test_iam_group_has_inline_policy(self):
         session_factory = self.replay_flight_data("test_iam_group_has_inline_policy")
@@ -643,7 +643,7 @@ class IamInlinePolicyUsage(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(
-            resources[0]['InlinePolicies'][0],
+            resources[0]['c7n:InlinePolicies'][0],
             "Access-Key-and-Read-Only-Access")
 
     def test_iam_group_has_inline_policy2(self):
@@ -660,7 +660,7 @@ class IamInlinePolicyUsage(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(
-            resources[0]['InlinePolicies'][0],
+            resources[0]['c7n:InlinePolicies'][0],
             "Access-Key-and-Read-Only-Access")
 
     def test_iam_group_no_inline_policy(self):
@@ -676,7 +676,7 @@ class IamInlinePolicyUsage(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 2)
-        self.assertFalse(resources[0]["InlinePolicies"])
+        self.assertFalse(resources[0]["c7n:InlinePolicies"])
 
 
 class KMSCrossAccount(BaseTest):

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -607,6 +607,9 @@ class IamInlinePolicyUsage(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['InlinePolicies'][0],
+            "oneClick_lambda_basic_execution_1466943062384")
 
     def test_iam_role_no_inline_policy(self):
         session_factory = self.replay_flight_data("test_iam_role_no_inline_policy")

--- a/tests/test_iam.py
+++ b/tests/test_iam.py
@@ -567,6 +567,8 @@ class IamInlinePolicyUsage(BaseTest):
         resources = p.run()
         self.assertEqual(len(resources), 1)
         self.assertEqual(resources[0]["UserName"], "kapil")
+        self.assertEqual(resources[0]["InlinePolicies"][0],
+            "policygen-andrewalexander-201612112039")
 
     def test_iam_user_no_inline_policy(self):
         session_factory = self.replay_flight_data("test_iam_user_no_inline_policy")
@@ -593,6 +595,7 @@ class IamInlinePolicyUsage(BaseTest):
             sorted([r["UserName"] for r in resources]),
             ["andrewalexander", "scot@sixfeetup.com"],
         )
+        self.assertFalse(resources[0]["InlinePolicies"])
 
     def test_iam_role_has_inline_policy(self):
         session_factory = self.replay_flight_data("test_iam_role_has_inline_policy")
@@ -624,6 +627,7 @@ class IamInlinePolicyUsage(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 6)
+        self.assertFalse(resources[0]["InlinePolicies"])
 
     def test_iam_group_has_inline_policy(self):
         session_factory = self.replay_flight_data("test_iam_group_has_inline_policy")
@@ -638,6 +642,9 @@ class IamInlinePolicyUsage(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['InlinePolicies'][0],
+            "Access-Key-and-Read-Only-Access")
 
     def test_iam_group_has_inline_policy2(self):
         session_factory = self.replay_flight_data("test_iam_group_has_inline_policy")
@@ -652,6 +659,9 @@ class IamInlinePolicyUsage(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
+        self.assertEqual(
+            resources[0]['InlinePolicies'][0],
+            "Access-Key-and-Read-Only-Access")
 
     def test_iam_group_no_inline_policy(self):
         session_factory = self.replay_flight_data("test_iam_group_no_inline_policy")
@@ -666,6 +676,7 @@ class IamInlinePolicyUsage(BaseTest):
         )
         resources = p.run()
         self.assertEqual(len(resources), 2)
+        self.assertFalse(resources[0]["InlinePolicies"])
 
 
 class KMSCrossAccount(BaseTest):


### PR DESCRIPTION
resolves https://github.com/capitalone/cloud-custodian/issues/2630

adds `InlinePolicies` attribute to resources when using the `has-inline-policy` filter, this can be coupled with a value filter to do additional checks on the resource, i.e.:

```yaml
policies:
  - name: iam-role-with-some-inline-role
    resource: iam-role
    filters:
      - has-inline-policy
      - type: value
        key: "'c7n:InlinePolicies'"
        value: some-policy
        op: in
        value_type: swap
```