### PR TITLE
Adding NZST to the supported timezones on the offhours filter

### DIFF
--- a/c7n/filters/offhours.py
+++ b/c7n/filters/offhours.py
@@ -307,6 +307,7 @@ class Time(Filter):
         'sgt': 'Asia/Singapore',
         'aet': 'Australia/Sydney',
         'brt': 'America/Sao_Paulo',
+        'nzst': 'Pacific/Auckland',
         'utc': 'Etc/UTC',
     }
 


### PR DESCRIPTION
Adding NZST(New Zealand Standard Time, GMT+12)  to the supported timezones on the offhours filter.