### PR TITLE
Convert bytes to str to prevent serialization error

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -378,6 +378,8 @@ class LambdaInvoke(EventAction):
             params['Payload'] = utils.dumps(payload)
             result = client.invoke(**params)
             result['Payload'] = result['Payload'].read()
+            if isinstance(result['Payload'], bytes):
+                result['Payload'] = result['Payload'].decode()
             results.append(result)
         return results
 


### PR DESCRIPTION
The actual data type coming back from the read() operation is type bytes which throws a JSON serialization error. I'm not sure why this wasn't reported sooner, but this fix just does type check and converts to string if needed.

Fixes issue #2652