### PR TITLE
Add invoke-function action to support local functions for remediation

### DIFF
--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -22,6 +22,7 @@ from datetime import datetime
 import jmespath
 import logging
 import zlib
+import sys
 
 import six
 from botocore.exceptions import ClientError
@@ -420,10 +421,9 @@ class FunctionInvoke(EventAction):
         results = []
         for resource_set in utils.chunks(resources, self.data.get('batch_size', 250)):
             payload['resources'] = utils.dumps(resource_set)
-            module = __import__(self.data['module'])
-            a_class = getattr(module, self.data['class'])
+            a_class = getattr(sys.modules[self.data['module']], self.data['class'])
             f = a_class()
-            result = getattr(f, self.data['function'])(payload)
+            result = getattr(f, self.data['method'])(payload)
             results.append(result)
         return results
 

--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -378,6 +378,8 @@ class LambdaInvoke(EventAction):
             params['Payload'] = utils.dumps(payload)
             result = client.invoke(**params)
             result['Payload'] = result['Payload'].read()
+            if isinstance(result['Payload'], bytes):
+                result['Payload'] = result['Payload'].decode()
             results.append(result)
         return results
 

--- a/c7n/actions.py
+++ b/c7n/actions.py
@@ -407,6 +407,9 @@ class FunctionInvoke(EventAction):
         }
     }
 
+    def get_permissions(self):
+        return ()
+
     def process(self, resources, event=None):
         kwargs = dict(FunctionName=self.data['class'])
         if self.data.get('qualifier'):

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -250,7 +250,6 @@ def generate(resource_types=()):
 
 def process_resource(type_name, resource_type, resource_defs, alias_name=None):
     r = resource_defs.setdefault(type_name, {'actions': {}, 'filters': {}})
-
     seen_actions = set()  # Aliases get processed once
     action_refs = []
     for action_name, a in resource_type.action_registry.items():

--- a/tests/test_dynamodb.py
+++ b/tests/test_dynamodb.py
@@ -19,6 +19,7 @@ from dateutil import zoneinfo
 
 from c7n.resources.dynamodb import DeleteTable
 from c7n.executor import MainThreadExecutor
+from c7n.invocable import InvocableFunction
 
 
 class DynamodbTest(BaseTest):
@@ -41,6 +42,24 @@ class DynamodbTest(BaseTest):
                 "name": "tables",
                 "resource": "dynamodb-table",
                 "actions": [{"type": "invoke-lambda", "function": "process_resources"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_invoke_function(self):
+        session_factory = self.replay_flight_data("test_dynamodb_invoke_action")
+        import sys
+        assert 'c7n.invocable' in sys.modules.keys()
+        i = InvocableFunction()
+        assert i.is_imported()
+        p = self.load_policy(
+            {
+                "name": "tables",
+                "resource": "dynamodb-table",
+                "actions": [{"type": "invoke-function", "module": "c7n.invocable",
+                    "class": "InvocableFunction", "method": "process"}],
             },
             session_factory=session_factory,
         )


### PR DESCRIPTION
We are running Cloud Custodian in Fargate using dynamically generated policies. Rather than managing a separate set of lambdas, we'd like to run remediation code locally in the Fargate task itself.  We can maintain a separate repo of remediation functions that will be built into the container and this will also allow us to test policies much more quickly.

This PR introduces a new `invoke-function` (with unit test) that calls a local function instead of a lambda. I've also added it to the `ActionRegistry`. The action looks like this:
```
- action
    - type: invoke-function
      module: my_module
      class: my_class
      function: my_function
```
