### PR TITLE
network-location filter - default to empty dict rather than None

### DIFF
--- a/c7n/resources/asg.py
+++ b/c7n/resources/asg.py
@@ -130,7 +130,7 @@ class SecurityGroupFilter(
     def get_related_ids(self, asgs):
         group_ids = set()
         for asg in asgs:
-            cfg = self.configs.get(asg['LaunchConfigurationName'])
+            cfg = self.configs.get(asg['LaunchConfigurationName'], {})
             group_ids.update(cfg.get('SecurityGroups', ()))
         return group_ids
 


### PR DESCRIPTION
Related: https://github.com/capitalone/cloud-custodian/issues/2664