### PR TITLE
azure - update the azure functions namespace 

### DIFF
--- a/tools/c7n_azure/c7n_azure/function.py
+++ b/tools/c7n_azure/c7n_azure/function.py
@@ -23,7 +23,7 @@ from c7n_azure import handler, entry
 
 try:
     import azure.functions as func
-    from azure.worker.bindings.http import HttpRequest
+    from azure.functions_worker.bindings.http import HttpRequest
 except ImportError:
     pass
 


### PR DESCRIPTION

- Related to this [pr](https://github.com/Azure/azure-functions-python-worker/pull/145), we need to update the following namespace **azure.worker** to **azure.functions_worker**
