### PR TITLE
tools/c7n_mailer | Add support for CC in notify block for mailer.

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -175,6 +175,10 @@ class EmailDelivery(object):
         # or it's an email from an aws event username from an ldap_lookup
         email_to_addrs_to_resources_map = {}
         targets = sqs_message['action']['to']
+
+        if sqs_message['action'].get('cc'):
+            targets += sqs_message['action']['cc']
+
         no_owner_targets = self.get_valid_emails_from_list(
             sqs_message['action'].get('owner_absent_contact', [])
         )


### PR DESCRIPTION
Adding in-line support for a `CC` block in Custodian notifications, following the below convention:

```
- type: notify
  template: default.html
  subject: "CC Test"
  from: foo@bar.com
  cc:
    - cc-test@foobar.com
  to:
    - to-recipient@foobar.com
  transport:
    type: sqs
    queue: foobar-queue