### PR TITLE
azure - fix azure failing tests and version conflicts

### DIFF
--- a/docs/source/azure/policy/resources/accesscontrol.rst
+++ b/docs/source/azure/policy/resources/accesscontrol.rst
@@ -108,8 +108,6 @@ they are not returned in this filter.
 
     policies:
         - name: role-definition-permissions
-          description: |
-            Adds a tag to all virtual machines
           resource: azure.roledefinition
           filters:
             - type: value

--- a/tools/c7n_azure/c7n_azure/resources/datalake_store.py
+++ b/tools/c7n_azure/c7n_azure/resources/datalake_store.py
@@ -22,7 +22,7 @@ class DataLakeStore(ArmResourceManager):
     class resource_type(ArmResourceManager.resource_type):
         service = 'azure.mgmt.datalake.store'
         client = 'DataLakeStoreAccountManagementClient'
-        enum_spec = ('account', 'list', None)
+        enum_spec = ('accounts', 'list', None)
         default_report_fields = (
             'name',
             'location',

--- a/tools/c7n_azure/requirements.txt
+++ b/tools/c7n_azure/requirements.txt
@@ -1,4 +1,4 @@
 vcrpy==1.11.0
 vcrpy_unittest
-adal~=0.5.0
+adal~=1.0.0
 backports.functools_lru_cache

--- a/tools/c7n_azure/setup.py
+++ b/tools/c7n_azure/setup.py
@@ -53,7 +53,7 @@ setup(
                       "c7n",
                       "requests",
                       "azure-cli-core<=2.0.40",
-                      "adal~=0.5.0",
+                      "adal~=1.0.0",
                       "backports.functools_lru_cache",
                       "futures>=3.1.1"],
 

--- a/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_find_by_name.yaml
+++ b/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_find_by_name.yaml
@@ -6,70 +6,140 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.10 (Darwin-17.5.0-x86_64-i386-64bit) requests/2.18.4
-          msrest/0.4.27 msrest_azure/0.4.24 resourcemanagementclient/1.2.2 Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 resourcemanagementclient/2.0.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?api-version=2017-05-10
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?api-version=2018-05-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
         uc4/evS9X/xRMfvo0Ud3m/WkmdbFqi2qZXM3yx4ePHywP9m+P9vLtvdnDw+2swcH2fa9g73zew92
-        7892HuR367yp1vU0/7yu1it6Zzm73l5dt/NquX2+Xk7vrurqspjldXP3i2JaV0113o5ft1WdXeR3
-        G/l5PJ1W62UrL8u7ePWj0UfLbEHofdT7vL1e4fMbIVLT5u36o0e/2EB63RKsrJ79/s9fvaYv2yKv
-        vU8/+iWjj94WS5BCAVKbsppmoAd9eJU37brZow/b7KIhsL/kl4x+yKT7bj652+T1ZV4/y+pFc/c1
-        /V5M85dltnxG7xBqZqS9L3pE68CiJh1i7dJHXRJRo+IH9tvzbFGU1/iL/phmq2xatPTnriNkWSzX
-        7+jLCBl/bohXtHm/OSGog458Eycc4NCXOkw0BfbZajXiIY+m1bLNiiVRLzp4Ais89NG8mM3y5Xad
-        l1mbzx7d/QBiXLwvMXj2zzH7PU569FG+WNFkfqM8fkyYvSEKaGfb9YWH28LiViyb4mIOjVDmdVuv
-        S5qyZ1lRrus8PV5Wi6ws8ibdpt9DcOY9oq5O53u+pVO9ERNq5s1nnmE+6bPOdBITvP0m5rKL7E0U
-        m1aLVbXMSfn1XjVtCOtX2snP7ezeBlc7kxtaDM+a64Gaqai+qGb5+DtQWBum8YdHFyeRanO6Ruzu
-        ennv7fx++Yuaq9X9RfYDSDTjQtgqbTa0UNrc2As17Wh/1fgfYirps59DejoNx/at+xohp0Ptf9Gj
-        WgcWNdHRG1qT4qcP+xT4uRo3zFP3BULwPUcMKPTlz8FYs+UPKuphvj0tq/Vsm/Boo4M9KbOmKaYn
-        JOjrNr87IzVfLF/QKKMgCG2lQPzLHhWGwVNret9QYEo6ps7Kny0iAL3tbFV4JNio7fpvErrdkXtf
-        6bg3wqRmygdX+YT+IBhm9F3t+Y0ZwVvQwc2V5dh+e8LxZ8fk9XoaxoxETbWH72vln97L9g7u7W8/
-        fLgHZ1MnaUMLnatB6NSko8nhqXf1NzV6Lz++J/M/fI7vjHhgpi0JY1/FaQdI9KUdKVrSm/2REoCQ
-        wb9Rp72D7vDIea57XnvIJySU37z7HuI4rZpF1UTRfFpN1wsi29PJ3VnWZpOssY5GFAhRNjpr9tve
-        xG3ogZrrVH5RLS+qp0/oAwJpppNG1M5jczrLz7N12Z6+W+V1kS9JVTgIP4tkfJtfX6LfKCF/r/z6
-        J/lLbjL0Kg0iSj7v+x4BO5CpCb13E42+UTIcv/ipL59/efLt7Tenr99s/+QXUQJYy1s0b6mbYHiX
-        i9//y+YpffH77/7++f2d/N5sd/Jgcj7ZPzi4N7m/9+DTPL93L9/dmd3ff0hjiJLoPWH0yBjgRw1C
-        1fuyzhfFehH60Poh6c2PFtmSXOfZE9K13wRFu0PbSNHLom7XWflFNp1TmqL/MiFMfw5wxM8ZH9wC
-        a6V95JvB2etApab05sDQCYwIw0dvsgu4gnvUhn79yYySqZTV+iZJ0x1DlDQv8vaqqt/eXcrPs2UL
-        6zCNEGf3Poz9AH3kyx6JBqFTY3p9gEg/10R4nU/XNfkwAyC2l80F4T9ACf32JlKEfdALBOP/beRY
-        rSdlMT17eTybEZgmwhPbBRy7IUrwl4OE6EGnxqECfJJR9ESfqup7lV/QuLOSCPL/RmqpGtA/+y9v
-        X9LU02h0cENfD9KrA5+a0uv/byGC5nG6iSH7Mt69XMyK7OIha4oOEbpf94gwAJ+ahixjQpTQaJpP
-        iS7Gu1OA1Ib6H6AivS/K+mdFLTf5cnZRFzOPnq/1o/EpZQrKu5mOsvcKYabjjXyjtBuARQ2ovRmw
-        P9YVhQE0VgP5vM5BHUJuUaH1CWU+6WP5aLaetvSH6fX3z35AeXJ8BZlu5kJ0/fKbNWrw1uuyuvKo
-        5rhEZSOuY+2rwsjVikKwppkT1jriwe+Vorfsh17wKEzI+yz1jZKC0Pz9JciZTaL0sHHOk16cc3c6
-        xfvmdUJaqdD7vDf6DVCpucqXiX02EYNgi3z98KInjO33N5FNlGad0IboZJpDMVki+R/2KNSBQU1u
-        QYRvfpxllc22JxnJ9TSvo4M1jIyWT7QhhozX8Zl5mbC0I5fvgu96BIjCpYahsv45t+8YyntQibWb
-        77FYxSwqQ74Xt0eHONxgkGbSyOuFGv//jW59Lvr9pdHvz7TRcd7Q6v/zFFRnJko79U+6Dg8opx9d
-        f5q9vf5Fq+xi1t6raCw6tOEGPXoN9EFNQ2oZ9+n/xU4Vov/f/4bon7MsICDRnjI3+HPv988e7jx8
-        kM+m59mnn+6fn+8fTA/yA/rfg9mDvZ2dexiLUuH9X+wRPMCEGrwvmb/hjA/G8/sPOPQGVY06THLD
-        ko8QvMUcf4TG9Ds1wW+X9O03vIbyNSbepuwOdu/dO5jms0/vnWf7B/fvTw6y++f38r1JRsm73XtQ
-        EDo1X+vdH00/Tzr9Tk3w28/R9G8Yg5Le+2Rw0jpQqOn/KwgAsEOTaOyhhiku+3Z3cf2TX7xgC6gU
-        cB/0CDAIhRoPk+CHPcaezacxvtTPCFE7TO+zwZH2YFHjUFb/3+E/3EAS5Vj9k1pc/+SL0zeEtQ7C
-        /j1IiA4EavpzPzr1MbpOy939+4tfNL3IHqzeNldFk5XFcv2OJVpHO/h9b/QDPVDTkAmMah5W2D/n
-        bhET8iqf0AK8R8yFHWqxbIqLOVFvSlquWhI29CsrQ3mJ0NLBdj5Vom2ERM2UAPQa/eENPs+a1h+0
-        WRKnWXn7QevhOu4w7Nq4Ho71+357wvGVgvxZ0NdEDyLjME60Lp/Xz3iNfiqE95fqm7cP9lb3ik8n
-        xeTyU6KhnaEbW+qsDfZGTToszumNDmNTo+IH9tvzbFGU8EggA9NslU0pE/bRo13H/jRU+orIa2bf
-        cf0PnbI820IoaUqY6Vg7n8ZphffpSzuygv6IjowAhKxd52XW5rMP4u4LGWmPW4fHy3N7jrml5LJj
-        jE/vZXsH9/a3Hz7cmxLa+WJFc/ZLfsn3f8n/A3j1a2PXMQAA
+        7892HuR367yp1vU0/7yu1it6Zzm7Pl8vp6syW95d1dVlMcvr5u6imNZVU52342LZFBfzllqWed3W
+        6zJv7j7LinJd5+nxslpkZZE36XbqA/po9NEyWxCiH92iZXu9QsuNPVKzsppmGCY1vcqbdt3s0Ydt
+        dtF89OgXfzQvZrN8uV0Wy7eP7n4AUS7elyjTarGqlvmSfvVfIiRfKciPfskvGf1cTNcQZnZqOp8O
+        T4ODRM3eFksM5Sqf0B8/lDnZPPIvLL7fzSd3m6Il9vSbbmdtmy9W7S7h+EOdEofY67aqs4v8biM/
+        j6fTak3EDF4kum2clhuhUdPm7Rp0VzivW4KU1bPf//mr1/RlW+S19+lHv8ROpQKkNpum84dLMp7L
+        vL7M62dZvQhfIJx0iJ1Pe6TqQKEmIYle7l7yCIU0L+t8UawXP4mPmuIHXoPzbFGU1/ib/5xmq2xa
+        tPTBrqMisfn6HX0ZoeEPn3IbpCBKPP/rOBUBkb7UweI9jCFbrUY88NG0WrZZsSRC/r+WBJcLYuWL
+        YnmRv8sWqxIMHyNFpNn/B0jyg4q6mG9Py2o92ybE2ihlTsqsaYrpCSn0dZvfnZFNLpYviAhREIS3
+        JVDsyx5ZhsFTa3rfkGBKtqTOynXzs0MEoLedrQqPBButWv9NQrc7cu8rHfdGmNRMGaNnKfMMDECf
+        EZ9Bs37zhrKDskcHN1eWhfvtCcefLUvZ6WkYM6e1776m34tp/pKEM//0XrZ3cG9/++HDvSlRUCdp
+        Qwudq0Ho1CS0Ca9ZB4pFsMaSGolB4G+tOYBdjRoDUgL0FQ3VzPkPn+M7Ix6YaUvC2Fdx2gESfWlH
+        ipb0Zn+kBCBk8DovszaffRCPWwe9g+7wyHmuzzHXw5xEQknW7/pnk9unVbOomiiaT6vpekFkezq5
+        O8vabJI11quLAiHKRmfNftubuA09UHOdyi+q5UX19Al9QCDNdNKI2nlsTmf5ebYu29N3q7wu8iWp
+        CgfhGyXj8Yuf+vL5lyff3n5z+vrN9k9+ESWhNTlF85a6Cchyufj9v2ye0he//+7vn9/fye/NdicP
+        JueT/YODe5P7ew8+zfN79/Ldndn9/Yc0wChp3xNGbwIC/KhBqHPU8ww9df2QFMZHi2xJDvrsCSmZ
+        b4Ki3aFtpOhlUbfrrPwim87Jl+m/TAjTnwPs8k3yQbfjKNYv8vaqqt/eXcrPs2UL2Z9G8N69D1Wu
+        ExD/sjeLg9CpMb3+/1IivM6n65os1ACI7WVzQfgPUEK/vYkUYR/0AsEYIAcBUxVy8ur0+M3p0+0n
+        vw+1Mh3/ns6tIm/qm1Ulpg8zuI3UW60nZTE9e3k8mxGYJsJC2wWs/BDh+MtBuvWgU+NQKTzJyJWm
+        T1UdvMovaNxZSez0/wPiqlbRP/svb18SY9FolBZDXw+StwOfmtLrAzT7oRNBEy7dDI59Ge9eLmZF
+        dvGQ9VCHCN2ve0QYgE9NQw4z7m1od8ynRBfjGShAakP9D1CR3lfOe5NdIOZDwo1+/cmMMtZAk37H
+        x3vex0im0O/4+J738T338b738b77+L738X35OMfnn3qffyqf4+MH3scP5GNufuB9fiCf4+OH3sew
+        5vQ7Pt7d8T6nP35WpKfJl7OLuph5jPNaPxqfUjhd3s10OnuvEKY6sZFvlEkGYFEDam9m1p9UpEQw
+        qQr5vM7BBoTcokLrk2qGj+Wj2Xra0h+m198/+wFl/vEVdF0zF+7SL79Z6pFDW0y34eqTe78NnD36
+        OZ0XidM7r0K2tvP6Ki+nc8JcR72xjVJ2Yy/UTEWplw0w6SACpPKj0dI3lQ4Ike/QxikNjpUQ23Ve
+        oE/caGGGBPgPcf4cjqqHuopNXte3ga9BN5zAaAOdvRv7oKbfpPLszfo3Sk7J0k3XNAYyEz4tN3Jp
+        9z3CTgfb/0LpthEeNVMa/PC5voOxRwI31Y7lO60JwZ8dPu/042G1kZDkZV9tc9uGug5F0s7Rxjb/
+        /5quDUP94c+cQ1Alvas65F37KhFRZ6z3uc7SIEQDkZr+/0EZ3ThOTDQ3xzxjms0sWxION/j/JS2f
+        StJt+5iWmi4p3H5eXRyXeU2UYiowVSMynlFzSs0JDF6oqouLCxqXpWP4odLuBkjU0Bv4RVlNKDql
+        l38Wxq3Tuk3TPctXZXXNQn/DoEGYel2SvnhGvi65ounxklakyiJv0u00DpLwV4q81zsbCGaxoGYe
+        uXp88o1pVJmcr0UyZwsGXifEf3bUa7y7D8XWTubg98MT56BTM5X4H75djCPu0cXpN2ce4y/JPyzo
+        QIew/zmaSoeyatCuSjYgLAQAIBqHk9n9VqfyRujU9P87Cl/Hehti8vxTiKMLmwOvEp467MHve4Ts
+        QKYmHQIivdMlGzV6ryVTkpj1O/oyQtqfS4K+h0DdQFn5x28eJzR6pC+VLKY9rSiPmESjKXk6GS3F
+        wFD/f5ZY2xCY9yEXv/DzmWBIir4XwfDC/2cIRhi1MhYsU3sE22iZB14ntDuU6n2vhNkInZopiX7u
+        7H6IuEeXyJQOvMR/bnt/I6f+s2v60aPrcBhrZ1MGXiUC33ImByFTk//vW6tw1PseRTdy8ND7hLgS
+        Y7iB0nUjfGqm9Ph/i4T4pOmwxAYR2ee/fy5lJI63OpxdD9bA6IAgWoez2v9eJ/XGHqhpR2hUUP7f
+        7CN3hhulKHOCUw5D7xKmOvDhBj1admBTkw4NoVq6lKNG/99UPJ1xv6d03URf/rv7Spzi6Jm+VPr0
+        vBn66ueEVvc9Wm1UokPvE+IbaYQGSpGN8KmZ0ub/LUraJ01kMofe4r99nrhPQ/hhKuk43qrxuirU
+        wOiAIFqHs9r/Xif1xh6oaUfBqFL5/46SjlOUOcEp0qF3CVMd+HCDHi07sKlJh4ZQw13KUaP/7yjp
+        DTR9T+m6ib78d/eVOMXRM32p9Pl/jZL+1KPVRiU69D4hvpFGaKAU2Qifmilt/t+ipH3SRCZz6C3+
+        2+eJT2kIP0wlHcdbNV5XhRoYHRBE63BW+9/rpN7YAzXtKBhVKv/fUdJxijInOEU69C5hqgMfbtCj
+        ZQc2NenQEGq4Szlq9P8dJR2nKY97g3TFpOsm+vLf3VfiFEfP9KXSp6ekfw7ygoSQNxaPDyPK1K20
+        blrvDSHSQJR67/OKUm8jDtQsQiJ6V8T2G9Ph4WpviOpmejnjE3+b0P5Z1dthbx+Iq53Hoa+H58zB
+        pmbK+z9nRjjE2yNKRFTj74i8G+El1H9uJtHhq3asaxjjEIjAt5vIG+FT047RUEPx/2LDGw42Sk2e
+        fWca428Sljrooa97VOzApSYd6sGodmlGjf5fbHLDQQ9T87ayxEuQSo7bNo/TGT3Sl0oV88L/Kw1t
+        BPP4O53BY/XxPWiF5v+vp1XT5ufZ0qBAePmEiliWjNuphZaXvY8gMkqh6HdKjhvgUkNv1BdlNclK
+        +uxnQ0kJlu83/EtSAc+ri2P4RQbC749XMcJg9PbTzeMOAFLr/9cOHgiyJxj1RvvgCG+lx63bb6CU
+        7Z2aeSQyUkHvCo2+MTdGuPG9yeScr8irhPDPjvPS7+pDsLQTF/1ueJIcVGqm+u2H73j2kfZoEdHF
+        kRe2m2yxKjHKn4Ppciiq30bN+adxBOnv7utEzVtM2Y2QqWnHSVLH6ENcTPpMZ/rngoY8zc4NjLxG
+        +Oloo9/1aNeBSE1Cmj1hnS+UepI1xZT+VK+Sv7Je5RP64/28SiL4zw0Bh+Rk3rYrQlRHPtwgTkRA
+        pS911Oa9W3pC/6+jxYKsHKM6TA3b5OcDPVSHbqKHbfL/dnq02SSry+oqSoUnWTud353gX6NI706n
+        hDvUhw7e/t0baeRtatYbzjfr+N88nuOzu1dV/bYh9UTTa9G/3XCCl6lVZDT06s+CUdg4rpNsOs/v
+        vspnhRlQjd8JlWBU5sPe0Lz36WtvTFNyeeqsJJ6jt344o3Le13S2xOfnpFnMsOgj/YQQCsYWfKMD
+        jIOi70OzZoz+728JQhz5/w0q3M2Xs1VVkGSZr3LyUuUjQlYHqF+5t/SDoO1Gmrl+qOXPLWXsJI1P
+        qotlQWFm/pp8loLkkaJOUTM6wO1pdbENh4awC0jhf6Hjvg1Yah1yzrMdcIpq8SfF8mL8epXn0zk1
+        9Iikwe4PkS6L1brN714WdbvOyi9IuMmUvJ5SpPk6t8QhHHUU9u8IKTZColdCelhJevp69/e/ZFUo
+        3qL5gj5xfuEe0c4jk9GfPzQ6Pc3a7BklKqr6+u45/6QAXqmzPaMvt+XTa8JaBxj/ske3KGRq6I02
+        zzBa+oywWrZMj1/80aoultNilZVnGP9kenAvv5fPtrPZg53t/XvTfHvy6d7+9uR85yB/uDP5dHb/
+        AQFo82W2bPmNB3vnDw8OJufbB5+e727v72bn2w93s8n23uzBdLazuzub7PMbgu/ra3JcFscNxbjL
+        nEOeH7oIg1DPs7c5gqzcypnOAahc0peEcUB+73MdyU0AqWWP9D9MRstFj5xV7bepJx3edlG18zVy
+        CMHo3Mf9wYVwqElH/BCEtRskDpGYRwiROGrxQ5931STP86xektpEfmVRtEg2vywz6lBIsSgJv1lR
+        4TPCUkcZ/a5Hqxt6oFdC2hFt3xBY+vw9CEgDbudxG/hzRMjvWue0Q0Maho609/mNtHNAqfXw8H+W
+        ucd5JgtyVLO7/C+MOMuEjsr7jHANRxx+p6PeCJWaecMVcfkh6o0vgEuIUWScFKHWOWVelhenxknT
+        VuTBGb+NRjJIjGhrJc9mZPo905sRihG4H7qGAaIddGWc/meREdydUTC/LkGDYYq5Nv9fp9OLvEVA
+        a1w8/dPQ6ieXOQYZEEI/6w1cX+1CoqaRkf7QxgdHgNK3NAX80yQidHxGC+q3hGsw1P7XvVEPwKem
+        oX0x5uTr5ZtpvL6mpfd/FvmEoiPNPikDRwl7YhppmEQWNvzA0LgHjtBXogw36NH55u7oLY9iP5uM
+        1kP49x8YyO+vWAwQUIKr7JJyp9mkKMnDQFR1l2Z/2a6qqtzufLV97/6DnQc7O1AUSsFbtY0QM941
+        tf3/BwkXGYU2dUCTJqSJ0u/mhv8vIt6b4yfHr55/+d3tky9fvDk+e3H66vXpq588Ozn9/U9O3py+
+        ftP//Lv06VevNxOPkn6k798eNNuOmcz4t3d+/y+bp9Tg99/9/Q92Zwef7j6YPPh0/2B/Z58i0Hz/
+        093J7NMHD+8f3L+HiEWJ+o3AGqQ740sNQv36ss4XxXoRqlf9kCaBJnpJKM2ekBP/TUzFzw4fq+lU
+        /3t4UmiEEVajYYtV+CibNvnygkD8JPUjjS53xrsPxzvbGdNuSv4I3n7NY6Kv6Y3tDb1VNSWIG7I+
+        ZJyo9e+1nuQ1uQF582h3fDDe3acmeOmFzIUFQh8buuGr1+vz8+IdNTCwv9m1559t8VBdYZDf3tnO
+        yWnG9zROZcMb270nWxsHIeRr8+n/pxm7RyYa388SV8e6ej+WFgj0mSEXPv//Gz87/bx3fzq9T9nE
+        vcnBvf29892DLNv/9Dz/9ODh5F5+vnuPCKEM+uGAfiQRP5KIW07Fz45ExKaCGEhMWEgi5cENLQa5
+        udMLNf1ZmtoBxN5vdi0Q+thMAr7qT/Doo/P1ckpo04dFy6lCfLjMr57hc8Lwjf/dN8sQPzzZtATx
+        qHo3f0eLL5gdinXl3eO3zfNiuX73pChLyveAEEQ1GuwgjMEXb8tJHhb0VoSp/n9K8CaXNszdN1I5
+        aP3/StL+8JSbqG6PPDQ4j4Cxr29LMWoaIRO9/8FqLYbV++k0gUCfGcLj85+3Ck2o4dHTY/ZhpbSJ
+        TYbfui33eCjQWxFG+v8jqUkzaQOw9GYCh21/HpBVVxHullU2e0Kr/sspvveoU04sgWhsfeqF3/co
+        FoVPDcOY40nWFFP6VIONV/kFkScriW7/36Qm6Uj8PFsShc6xrssUZfsIfWkptr0spsxpSocbWg1S
+        t9cfNf5/OeHeh3DKagE9QA+PakNNft6Q7HU+XdeUKde+ojRpYCs2EY0b3ESysCd64f+TZFutJ2Ux
+        PXt5PJtRf03IacVqW2AvLhbBYkWfeINNB8nY65ka//9bHRLsNn+TTcqQyoZY2/w9dV1iZVJpcGO7
+        QfpyK+mNmv1/kmDqX+ifQrRLEj9LChqYR6fuV4Ok6cClpj/r5LnYzmazbSZFXl/l5XTujXxhMSzI
+        fbqYt+SukYtVLckExl8mlHXgA9/q2DdCpmZviyWGeJVjKSxCBAKkEdW8mM3y5TZ52m8f3f1Zp4ib
+        s+/mk7tNQc2irxCqrxTwNx0g9TuL4veaYkLyVe428vN4Oq3WRFsAoPfxur5NtHRT1vtK5+tGuNQ0
+        VJImIz2cp9Y5VoDUxpvnKfFBnZVrwCW0MNPfLBlpkL//tGoWVTObROn3tJquF4TF0yd3ZxnUSGPH
+        eld0h3mdUNQx9z7vUW8DVGquFPmiWl5UT5/QBx5FCP12HiHLR7P8PFuX7em7VV4XOTnw1NhA+OZp
+        xrkBApGtVtt1/osaj3YbZfrutKzWs+3pmvhmVmRLZmAahaFc/Ful30bI1Ezp9nOgLaiDTSRxE+/U
+        RXSoP2vqgoDfDkEVw65cC7oWW8Ajcvqz1v1O5+xGyNT0m9QYvbn+OaIjTzT5Enn9LKsXSr/udIcU
+        7H/bo2EHKjUJafdklz5Sihn3tCl+YL86zxZFiQVBaJVptsqmFCF89GjXEZVEYv2OvoyQ9OeQkCwx
+        9P92e5avyup6m2Sc3iI8deDR7+LkAyz6Usfr4TDisY+sK0iNfhhUeJtfX0JzR0f/e+XXP8lfchNi
+        o6lpjunUwYcf9kbdgUFNvGERPlF78s2LDXJL2xNNLkUHqw5vmIWiIeN1fGZeJiztyCPf9QgQhUsN
+        O7Kj8qLiMxDO0bh8ev0cUqkXoN7Nlj+oCNU5q49t+Z4iXxqTDnG4wSDNpJHXCzX+/xvd+lz0+0uj
+        359po+O8odX/5ym4okFFCcda0xkdJdc2aUx8SsEy3iT0dTRDX/cI1IFLTUKyvGZtJjSx5p8aiT3j
+        b609g6cQtWeEBn3lkfFnkYJkveGQRImozkrX+wEx9aPrT7O3179olV3M2nsV4axUGG7QI+hAH9S0
+        Q1gl5tfzsGjcPh/S+2IxPqL1QCwl7lIb+vUns3JNv4/wOz7e8z6Ge0a/4+N73sf33Mf73sdYv6Tf
+        8fF97+P78jEvX37qff6pfI6PH3gfP5CPufmB9/mBfI6PH3ofP3Qf7+54n9Mf36hpxJL27/+TX0R5
+        xqxjzYqGskvECMRkl4vfH3/u/f57ew8/ne49uPfp+f3J/oPpwcHk3r3Z+YPZwe7k/sPzc1BBp/v9
+        X+xxVoAJNXhfflpkSyL97AnJ5jdBNIzn979cbCSaJtHs4p+hAiF4G2ZGY/qdmuC3S/r2Gw7JvvbE
+        Zw93Hj7IZ9Pz7NNP98/P9w+mB/kB/e/B7MHezs49SKvOy/u/+KOJ5+mm36kJfvt/x8R/2TylD37/
+        3d+fBHTy4PzT/enB7v39T/ezbHfy8OHu3qf3Jrs72fRBRuPQqfla7/5o+nnS6Xdqgt/+Xzb9B7v3
+        7h1M89mn986z/YP79ycH2f3ze/neJJvc39u9Bx9Sp+Zrvfuj6edJp9+pCX77OZr+DWNQ0nufDE5a
+        Bwo1vQ0BFlkxI0c2o1wHNTPZyHRW5U26rNp0kedtuqooorl+lJKjufo993Z2D+7uPLi7A5fJprAU
+        xnvBoP/BM+SUDM9B0X6XIihKutDA86tn+JzQJ1fMfffNzg6oOsRhJp6jVTz8PKNEZ32eTWl+Ftc/
+        +cULjuB0etwHvdkZhEKNh+fnhz3GXsxKY3ypnxGidpjeZ4Mj7cGixqEi+X9H/HsDSVSc9E9qcf2T
+        L07fENY6CPv3ICE6EKjpz/3oNMLrhox39+8vftH0InuwettcFU3GmVFWNzrawe97ox/ogZqGTGDs
+        xrA1+VFQCg1Lv+NjikPd5/THN68GJY3ucc3G5Tc1UvISoamz2vlUuWMjJGqmM02v0R/eLOcZcvD0
+        mZndb3gdL8yPZqvCG73jaM5bYRWh355wNObuhzEjHZxcLo1mgwn/mj6iDNxLysDlzdsHe6t7xaeT
+        YnIJdrQzdGNLnbXB3qhJR5YhYl0Jpkb/r83c3URZnm0hlDQlzHSsnU/jtML79KUdWUF/REdGAELW
+        rvMya/PZB3H3hYy0x63D4+W5Pcfc3vUZ49N72d7Bvf3thw/3poR2vljRnP2SX/L9X/L/APRaT9vn
+        qQAA
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['2373']
-      content-type: [application/json; charset=utf-8]
-      date: ['Tue, 08 May 2018 18:35:43 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [1be597cd-f5ad-41da-8c73-bc178a4b1eae]
-      x-ms-ratelimit-remaining-subscription-reads: ['14999']
-      x-ms-request-id: [1be597cd-f5ad-41da-8c73-bc178a4b1eae]
-      x-ms-routing-request-id: ['WESTUS2:20180508T183544Z:1be597cd-f5ad-41da-8c73-bc178a4b1eae']
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['6330']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 02 Aug 2018 22:12:40 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [8696c109-a668-4938-a868-8d24e4d68c90]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [8696c109-a668-4938-a868-8d24e4d68c90]
+      x-ms-routing-request-id: ['WESTUS2:20180802T221240Z:8696c109-a668-4938-a868-8d24e4d68c90']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_find.yaml
+++ b/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_find.yaml
@@ -5,69 +5,71 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 computemanagementclient/3.0.1
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 computemanagementclient/4.0.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2018-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFHswfTfPbw3r3thwcPZtv709397YefHmTbk4e7k8n9
-        7OHuLM8/Gn00z+rZVVbnL+vqvCgJHgC8Ln5Av330us2WM/r+93+y23z0S0YfNW1VZxd+02JBf7/K
-        z/M6X075k9V6UhbNPK/p/ZNsWS2LaVZSP9U5NaLPvpqsl+36dV5f0p8E8u2aPtz9dLyzv/38zWv6
-        hD5vimpJn5ZZmzctOq6ap0XzFuCr5s31ijr66HmxXL+j5stsgT+z5Q+qsprOt/HK9uXi9/+SX/n9
-        d3///P5Ofm+2O3kwOZ/sHxzcm9zfe/Bpnt+7l+/uzO7vPyQY0zqnrr5ctdLvs7panGFg+Cqbzovl
-        BX36Ks9m362LFp8usiV9PUMPQErpcjydVjQ4RfBlnS+K9eL3f/4KoyowJXeb9aSZ1gV31NzNsocH
-        Dx/sT7bvz/ay7f3Zw4Pt7AHN0L2DvfN7D3bvz3Ye5HfrvKnW9TT/vK7Wq+bu8Yuf+vL5lyff3n5z
-        +vrN9k9+cZfm/rKYEc3uflFM66qpztvxSbVYrdv87ozwo26+PmmI9IABdvj8yUeP7u3gg6zN8D7x
-        2ve+T39XjccPU+m5fhGfFSJENlsUy6+avNaJm5TZnD4uMZ0n1fK8uFjXGegDcNR5Ninzl1nTXFX1
-        7HjdzvNlSxwlDc6zsskJhSanGWwNQsu8pcZvPaz0k7MlYXaeTSEmJDXf1JR0BxmdkheCwt0eKr3X
-        d+/vfvRLMI5ZkV0sq4aG61N4UlXtU/cNPsqXIBKNpq3XOVFDuPGruqDxzdt21Ty6a3tBJ5cLgH54
-        f3c8KavJeFrV+fiqWM6qq2ZM+N396JdQ7zwICCJxP+kBYnvSB+vpNM9n1BU1aIXN3RAN110WdbvO
-        yi9YcojWNLmVmbGPiHLtfEqTWGflGt+12QUGQQC/qfl4LxHpIGvpZGaDMFRG7X3zS0ak7WKa9+H+
-        vd0H92afbt+/nx+Q5n04257cn366fZ7t7d3/9P79ewfTc4K7SfM+yZpi+vsf71AnZj69Zt+k1h3v
-        fJDenU7R1lcqB7v3aID57NN759n+wf37k4Ps/vm9fG+SkXrZvTeld0laqYsveY4Jxjejb4lJxVh9
-        swoXw/v9B4TaMBGpKdKzX4MURGK8i0mP6tdf/FG5Jgrt9MmN1/Z+/+zhzsMH+Wx6nn366f75+f7B
-        9CA/oP89mD3Y29m5B9J1aH26WLXX+NjS+UW1RLv/b5EYf95i+CAntTT03d3Zu8eqdZPNulzs31/8
-        oulF9mD1trkqaJxdkwUc1vQnffX/YbOFUQxRfdhaLa5/8osXBXEuUIYZUTvkof01LVRA9SZjyl4u
-        /l9koj56ed3OKyIF6cZHH5213yXK4Gv38Z73OXX/Tc0U7Njv/552zEgK4adcaz8ZtFv70/u79853
-        P92e7d9/uL1PZNye7Oycb+/c38v37+/ezx/s3yd4m+wWTYNoiCd7C6aBTrXX9ps0Xh9kus7Xyykm
-        RQz6nLjVae5smu0e7GTTBzlp7t1sj9RMtrPzaT7jwOnTnzUj9rMTNNCcXG+vmE23MeqNnETKizQt
-        mqHDr0UcIj+ggCegdntmDbpjkwrud07E6GrhaVmtZ9M1kZHU0JIasMZ4X12sCqmZoy0z4vT3yq+B
-        JP2ZtfTxR3fn1SK/G3Z3d0yv3M0IWFXTKGe//1u8NPqIfjylgdJb9P123WTpMT1P7r34QXayez3d
-        O6W/jp8e/8TxE/r55PgnTvKdxdMns/MH9en01SdPftEnq+dvH65/8skPmvX91dmbB8+m3z746Yt7
-        9376/Pf5vV589+7dT356/YPv3r/7+xS79Xf33v7eZ235E7/3q2c/ebF++FXTvstXq1+0ejW9d3Lv
-        4e/9pHo5m/7kwZOLF198+fDFJ+3nv/fVfPrTD6tfdPGq+WJ9MHn9dmePnMx8srez/r1evpoef/Kd
-        J5Pn33m9e74z+/anrx/+4Ac/+cWnebP3RVOcPfjByf1f9OX+L2q/mnx+b3Wy//zJ7rPL2U+dXu0+
-        Pf+9njZf7O08+faz9sufqr64+n3uZm9/r/2vXv8+J9ffbb87zd8+fPnFp59+uffi2Xemv9fZu3bv
-        6uH1T5b3z55MJt95u/f8wSqf/fT15RfffvWDp1e7n+8dlJ98+qx6+ubu6tsHi+t7zy6ffvrF+f6z
-        B1ez2eTl+SfV5berpnn6E88u3hU/ffwTn+//Xg+/vHp9PH2+87pdvfty9/qLn357VfwUrBOx2M+t
-        fb2V0A0bWryCzp0MfLpLATlGQgxojKs3mq9pdoGmYIkeAfrg4YcFhoYOhMI3SM7jF09/n+2Xv8+b
-        b3/5YvvZVy9OouQ0OqxrDTE0dO2IeTd/1+ZLDINAHz99Xl0Uy2dVLSYCFvL/A3h/IQblbAaF1l6f
-        mm/cOL5PzosYlhv7IuXl+UBX1N+62aMP1fmheSWkuR/6y0B9fd20+eK4aYqLJU0+mKNYTotVVrJD
-        kT08z8g7n2xPdyc72/s72d72wUOi13728P75wcPZ+cN73AXx6bLlNx7snT88OJicbx98er67Tcbl
-        fPvhbjbZ3qNs5mxnd3c22X9A00O4UOO7/6+bHRqMWqfId7/k+7/k/wFcxa/2tRUAAA==
+        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFH+7v38/Ns9/72bH8y3d7feZhvT+7f39s+uH/vXr6f
+        7T/4dHL+0eijeVbPrrI6f1lX50VJ8ADgdfED+u2jJ1lTTH//452Pfsnoo6at6uzCb1Ys6O9X+Xle
+        58spf7JaT8qimec1vXuSLatlMc1K6qM6p0b02VeT9bJdv87rS/qTQL5d04e7n4539sc728/fvKbP
+        6JumqJb0eZm1edOi66p5WjRv0UHVvLleUVcfPS+W63fUfJkt8Od0iraXi9//S276++/+/vcfnk8e
+        nH+6Pz3Yvb//6X6W7U4ePtzd+/TeZHcnmz7I6N1pnVMXX65a6e9ZXS3OMCR8lU3nxfKCPn2VZ7Pv
+        1kWLTxfZkr6eoQcgoxQ5nk4rGpYi9rrNljMi6e///BWGU2Am7jbrSTOtC+6puZtlDw8ePtifbN+f
+        7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTrepp/XlfrVXMXw/v9Lxd3aaYvixnR6O4XxbSu
+        muq8HZ9Ui9W6ze/OCK/m7tcgBZEY72LSP3/y0aN7O/ggazO8TxxFDFauiUI7fXLjtb3ff2/v4afT
+        vQf3Pj2/P9l/MD04mNy7Nzt/MDvYnVDf558SHTq0Pl2s2mt8bOn8olr+f4/E+PMWwwc5qaWh7+7O
+        3r1f8n36sGo8aZpKF/ULIfHlYv/+4hdNL7IHq7fNVUHjzGaLYvlVk9c6CcBhTX/SVyWk4aRanhcX
+        6zoDCQCR+swmZf4ya5qrqp4dr9t5vmxJJKXBeVY2OWHR5DQ5LeYZOC3zlhq/9RDTT86WhNx5NoWO
+        IY74YVD9hfR8t4fB3cX1T37xoph+xGScFdnFsmpoZD49J1XVPnXf4KN8CXoQ4m29zmngwlxf1QUN
+        Zd62q+bR3bsB1ZuMKXu5GE/KajKeVnU+viqWs+qqGRNSdz/6JdQ9Yw6dRYxMrEmaglh0PZ3m+Yz6
+        ogatsK0bl+Gmy6Ju11n5BQsB0ZUmsjKz8xFRqZ1PacLqrFzjuza74FEssmL2+zfUEX0K/UQNiZzp
+        rMqbdFm16SLP23RVlcX0+lFKY1z9nns7uwd3dx7c3XlIYKZr+oxItvw6MOh/ewTjfL2cEjr0atF+
+        l2amwYfL/OoZPif03/jfgQTfFLe8OX395vf/yS+i3DJAVSutQDFjybGf/JIR2ayY7Tyf7e7tHhBG
+        09nB/e39/GB3e/Jp/nA7yw+yhw+yB9mn5xhydpkVZTYpyqK9fp23APCNjfT4yfGr519+d/vkyxdv
+        js9enL56ffrqJ89OTn//kxNQof/5d+nTr17vbaRNB+Hm7vHnpy/evPzyy+fbxz95fPb8+MnZ87M3
+        v8/r0zfb9+4/2HmwQ9NN07fJRyCWF2389PXe73/JzYlhIFhe62/SVeg5CvzpGAy68+neHjsrN3sM
+        bw+abcJp2a6qqrSD3d5xZvNgd3bw6e6DyYNP9w/2d/bzhzv5/qe7k9mnDx7eJx9qQrBIcZK8f8nT
+        TDC/GQ/iZZ0vivXim7Zu2SSry+pqe1ot24wEoybTcVlM899fpKH/+RV9um428xOZGLKH3wAtac4A
+        CzwFE9lzQaDnK1+9d8zlEApEwa7dnJbVekafs2p/X6OplqOZoy3z8PT3yq+BIf2ZtfTxR3fn1SK/
+        y73cHVPLuxnBqGoa2ez3f4u2o4/ox1MaHDWm77frJkuP6Xly78UPspPd6+neKf11/PT4J0gH0MfH
+        P3GybF5VB+3nz5ZffOf+/Pc5/s71J9XJwy+fl78o+8FF9erq8otZ07Ynp/ebk+VJ8eLkdOfVxU8v
+        fvrzL7/znQcXxcGXv/dPXD77qTdPdh9cTH5w7/d5WX3+e5//op9czo93m/qnfu+f2m0v755dfvng
+        fPLu4XfPi99nce/ty8ufeHH399r56a9+0U/9PtO31F3xU793c/+nHj5488myWZbHe8XnZZv99N7r
+        09Xl/vLlT+9PX704XX26bJ/M33yRP7ne/fJs+vTB3g8uzu7PJj/x6nh2fPxi9tV89fDg27tni5/4
+        qTeT7P7JF+ftg3f72Sfnv/d5vbv4iS+/WH/5e+8d1/W784Pn0+9effF7fbW7Pv7J3/uL3cvmq584
+        P3n+/Ac/dfZ7/96/6O0Xn3519Z03T3+fe6f57v5Xn1+cPP9FP3WRfXL5/Ce+ev6D9uHvfV69Kj6f
+        Hz//vS5ePH9y9tNvnr569Xs9uNhf7e1+dbWzuzqo59Nf9Pv89MsS3gOx1c+x//ONyuWwxzQgIKR2
+        SUiIELfwYwzm3ywBfnYMXdcJGBj+zt38XZsvMWpyFOTd47cN24onRUkq4oJG/v/LwTa5tOHpJ+9S
+        jM+NwEl7eU6q8iJ9SO4g8cUv/igjwMsLavmThKs0utwZ7z6kAD8jTU6GETaTvnjNdKGv6Y3tIYyp
+        fVVP59QLaegKfsHvtZ6QJs9JNB7tjg/Gu/vUBC+pHbBA6GNDe3z1en1+XryjBgY2ff9z58X+nHIB
+        BkkUoaEMtgDLU1d9v/jT/b1sf//+/vbDye4u5ZSm9Nvep7vb+f1PKZXw6Ww/J1tOJjd0MwHg/920
+        6yBMTY5fvzl99Q04xf9f84kXWUM2ww7Ud+L27k+n9x/sne9NDu7t753vHmTZ/qfn+acHDyf38vPd
+        ewSIhfubdogtMf+/5RF/CCVpugAI3BR1h3sZuWiH23k7nQEOUa0zM/+vTMD9sCfE0QfkpZ+G3nv3
+        P2WX6KaIoweRqPGjcONH4caPwo2YdJA5IwkhKpDHBmAwVaR7SJu0NPKP/n8Va3THHvre8uL/PwKN
+        zSOlKEMbYOYpTBALciNo0lo/S2GGouPwpcbvF2MIBPrM0Byf/zwNMIQWITXV8MW//iXf/yX/D5hz
+        NIm6HgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2101']
+      Content-Length: ['2286']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 07 Jun 2018 23:20:30 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [a7878aa3-ef73-465f-95ea-2d203dbde2b9]
-      x-ms-original-request-ids: [b7a66f0e-1df5-41d3-b556-3db675b2e483, c606f8ed-ec79-47d2-9715-561eee891c93]
-      x-ms-ratelimit-remaining-subscription-reads: ['14996']
-      x-ms-request-id: [a7878aa3-ef73-465f-95ea-2d203dbde2b9]
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232031Z:a7878aa3-ef73-465f-95ea-2d203dbde2b9']
+      x-ms-correlation-request-id: [f089a804-e600-4390-a03f-e93c20fe85b6]
+      x-ms-original-request-ids: [15e4fa4d-e377-4d47-83c6-6e7f962da710, 284addcb-aefe-49ea-a121-f3173791f6eb]
+      x-ms-ratelimit-remaining-subscription-reads: ['11997']
+      x-ms-request-id: [f089a804-e600-4390-a03f-e93c20fe85b6]
+      x-ms-routing-request-id: ['WESTUS2:20180802T221241Z:f089a804-e600-4390-a03f-e93c20fe85b6']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -76,38 +78,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 monitormanagementclient/0.4.0
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 azure-mgmt-monitor/0.5.2 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-05-31%2000%3A00%3A00%2F2018-06-01%2000%3A00%3A00&interval=P1D&metric=Network%20In&aggregation=total&api-version=2017-05-01-preview
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-08-01%2000%3A00%3A00%2F2018-08-02%2000%3A00%3A00&interval=P1D&aggregation=total&api-version=2018-01-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR9Oq
-        aT96tDP6qC0WebPKlh89+mhvZ/dge+f+9r3dNzs7j/h/P3VXPvx0e8f78KPRR8WyzevLrKTXXu4+
-        pQ/o93X+0aPv/eKPihl9eLdZT5ppXazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3
-        YPf+bOdBfrfOm2pdT/PP62q9au6+OX395vf/yS/ururqspjldXP3i2JaV0113o5PqsVq3eZ3L4u6
-        XWflF9l0Xizz5u502uZNe7mIvnS2bIqLedvcXeRtXUybuy/y9qqq36ZnSxpAe70i/D8abk5tltmC
-        2vxiM9iPAgBlNc3K4gf57Cf73/6S0UfrZUEU/+jJNWFIrZnueV3QHyAa9ZHNsjZjyPjo+6OP8Df9
-        9ou57es2W6zofZmPcJIArmoxGXsHB58ePNx7eDDe+SXf5//+H4DUpqfrAQAA
+        aT96tDP6qC0WebPKlh89+mhvZ/dge4f+t/tmZ+cR/++n7toP99yHH40+KpZtXl9mJb32cvcpfUC/
+        r/OPHn3vF39UzOjDu8160kzrYtUW1bK5m2UPDx4+2J9s35/tZdv7s4cH29mDg2z73sHe+b0Hu/dn
+        Ow/yu3XeVOt6mn9eV+tVc/fN6es3v/9PfnF3VVeXxSyvm7tfFNO6aqrzdnxSLVbrNr97WdTtOiu/
+        yKbzYpk3d6fTNm/ay0X0pbNlU1zM2+buIm/rYtrcfZlTb8s2u8jTk5df0SDa6xWN4aPhV6jNMltQ
+        m19sBvxRD0hZTbOy+EE++8l4i18y+mi9LIj65gt6h2chr4u8YRJSb9ksazPuAx99f/QR/qbffjG3
+        fd1mixVBsLPjTRnAVS2m5sHezv3x7s5DfQ4+/SXfx38yBpr0KbBzgx0gKsEzM1PnFzSd9BL92c6B
+        e52V6+ajX/L/AM2On51RAgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 07 Jun 2018 23:20:31 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:40 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: ['Accept-Encoding,Accept-Encoding']
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-red_MetricsMP_IN_5]
-      x-ms-correlation-request-id: [0ba21d0d-75c5-4967-a5d1-44cb46c403b3]
-      x-ms-ratelimit-remaining-subscription-reads: ['14996']
-      x-ms-request-id: ['{0ba21d0d-75c5-4967-a5d1-44cb46c403b3}']
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232031Z:0ba21d0d-75c5-4967-a5d1-44cb46c403b3']
+      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-black_MetricsMP_IN_4]
+      x-ms-correlation-request-id: [e8b630df-2afa-4b14-b0f2-28225b1eb6a3]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: ['{e8b630df-2afa-4b14-b0f2-28225b1eb6a3}']
+      x-ms-routing-request-id: ['WESTUS2:20180802T221241Z:e8b630df-2afa-4b14-b0f2-28225b1eb6a3']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_find_average.yaml
+++ b/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_find_average.yaml
@@ -5,69 +5,71 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 computemanagementclient/3.0.1
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 computemanagementclient/4.0.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2018-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFHswfTfPbw3r3thwcPZtv709397YefHmTbk4e7k8n9
-        7OHuLM8/Gn00z+rZVVbnL+vqvCgJHgC8Ln5Av330us2WM/r+93+y23z0S0YfNW1VZxd+02JBf7/K
-        z/M6X075k9V6UhbNPK/p/ZNsWS2LaVZSP9U5NaLPvpqsl+36dV5f0p8E8u2aPtz9dLyzv/38zWv6
-        hD5vimpJn5ZZmzctOq6ap0XzFuCr5s31ijr66HmxXL+j5stsgT+z5Q+qsprOt/HK9uXi9/+SX/n9
-        d3///P5Ofm+2O3kwOZ/sHxzcm9zfe/Bpnt+7l+/uzO7vPyQY0zqnrr5ctdLvs7panGFg+Cqbzovl
-        BX36Ks9m362LFp8usiV9PUMPQErpcjydVjQ4RfBlnS+K9eL3f/4KoyowJXeb9aSZ1gV31NzNsocH
-        Dx/sT7bvz/ay7f3Zw4Pt7AHN0L2DvfN7D3bvz3Ye5HfrvKnW9TT/vK7Wq+bu8Yuf+vL5lyff3n5z
-        +vrN9k9+cZfm/rKYEc3uflFM66qpztvxSbVYrdv87ozwo26+PmmI9IABdvj8yUeP7u3gg6zN8D7x
-        2ve+T39XjccPU+m5fhGfFSJENlsUy6+avNaJm5TZnD4uMZ0n1fK8uFjXGegDcNR5Ninzl1nTXFX1
-        7HjdzvNlSxwlDc6zsskJhSanGWwNQsu8pcZvPaz0k7MlYXaeTSEmJDXf1JR0BxmdkheCwt0eKr3X
-        d+/vfvRLMI5ZkV0sq4aG61N4UlXtU/cNPsqXIBKNpq3XOVFDuPGruqDxzdt21Ty6a3tBJ5cLgH54
-        f3c8KavJeFrV+fiqWM6qq2ZM+N396JdQ7zwICCJxP+kBYnvSB+vpNM9n1BU1aIXN3RAN110WdbvO
-        yi9YcojWNLmVmbGPiHLtfEqTWGflGt+12QUGQQC/qfl4LxHpIGvpZGaDMFRG7X3zS0ak7WKa9+H+
-        vd0H92afbt+/nx+Q5n04257cn366fZ7t7d3/9P79ewfTc4K7SfM+yZpi+vsf71AnZj69Zt+k1h3v
-        fJDenU7R1lcqB7v3aID57NN759n+wf37k4Ps/vm9fG+SkXrZvTeld0laqYsveY4Jxjejb4lJxVh9
-        swoXw/v9B4TaMBGpKdKzX4MURGK8i0mP6tdf/FG5Jgrt9MmN1/Z+/+zhzsMH+Wx6nn366f75+f7B
-        9CA/oP89mD3Y29m5B9J1aH26WLXX+NjS+UW1RLv/b5EYf95i+CAntTT03d3Zu8eqdZPNulzs31/8
-        oulF9mD1trkqaJxdkwUc1vQnffX/YbOFUQxRfdhaLa5/8osXBXEuUIYZUTvkof01LVRA9SZjyl4u
-        /l9koj56ed3OKyIF6cZHH5213yXK4Gv38Z73OXX/Tc0U7Njv/552zEgK4adcaz8ZtFv70/u79853
-        P92e7d9/uL1PZNye7Oycb+/c38v37+/ezx/s3yd4m+wWTYNoiCd7C6aBTrXX9ps0Xh9kus7Xyykm
-        RQz6nLjVae5smu0e7GTTBzlp7t1sj9RMtrPzaT7jwOnTnzUj9rMTNNCcXG+vmE23MeqNnETKizQt
-        mqHDr0UcIj+ggCegdntmDbpjkwrud07E6GrhaVmtZ9M1kZHU0JIasMZ4X12sCqmZoy0z4vT3yq+B
-        JP2ZtfTxR3fn1SK/G3Z3d0yv3M0IWFXTKGe//1u8NPqIfjylgdJb9P123WTpMT1P7r34QXayez3d
-        O6W/jp8e/8TxE/r55PgnTvKdxdMns/MH9en01SdPftEnq+dvH65/8skPmvX91dmbB8+m3z746Yt7
-        9376/Pf5vV589+7dT356/YPv3r/7+xS79Xf33v7eZ235E7/3q2c/ebF++FXTvstXq1+0ejW9d3Lv
-        4e/9pHo5m/7kwZOLF198+fDFJ+3nv/fVfPrTD6tfdPGq+WJ9MHn9dmePnMx8srez/r1evpoef/Kd
-        J5Pn33m9e74z+/anrx/+4Ac/+cWnebP3RVOcPfjByf1f9OX+L2q/mnx+b3Wy//zJ7rPL2U+dXu0+
-        Pf+9njZf7O08+faz9sufqr64+n3uZm9/r/2vXv8+J9ffbb87zd8+fPnFp59+uffi2Xemv9fZu3bv
-        6uH1T5b3z55MJt95u/f8wSqf/fT15RfffvWDp1e7n+8dlJ98+qx6+ubu6tsHi+t7zy6ffvrF+f6z
-        B1ez2eTl+SfV5berpnn6E88u3hU/ffwTn+//Xg+/vHp9PH2+87pdvfty9/qLn357VfwUrBOx2M+t
-        fb2V0A0bWryCzp0MfLpLATlGQgxojKs3mq9pdoGmYIkeAfrg4YcFhoYOhMI3SM7jF09/n+2Xv8+b
-        b3/5YvvZVy9OouQ0OqxrDTE0dO2IeTd/1+ZLDINAHz99Xl0Uy2dVLSYCFvL/A3h/IQblbAaF1l6f
-        mm/cOL5PzosYlhv7IuXl+UBX1N+62aMP1fmheSWkuR/6y0B9fd20+eK4aYqLJU0+mKNYTotVVrJD
-        kT08z8g7n2xPdyc72/s72d72wUOi13728P75wcPZ+cN73AXx6bLlNx7snT88OJicbx98er67Tcbl
-        fPvhbjbZ3qNs5mxnd3c22X9A00O4UOO7/6+bHRqMWqfId7/k+7/k/wFcxa/2tRUAAA==
+        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFH+7v38/Ns9/72bH8y3d7feZhvT+7f39s+uH/vXr6f
+        7T/4dHL+0eijeVbPrrI6f1lX50VJ8ADgdfED+u2jJ1lTTH//452Pfsnoo6at6uzCb1Ys6O9X+Xle
+        58spf7JaT8qimec1vXuSLatlMc1K6qM6p0b02VeT9bJdv87rS/qTQL5d04e7n4539sc728/fvKbP
+        6JumqJb0eZm1edOi66p5WjRv0UHVvLleUVcfPS+W63fUfJkt8Od0iraXi9//S276++/+/vcfnk8e
+        nH+6Pz3Yvb//6X6W7U4ePtzd+/TeZHcnmz7I6N1pnVMXX65a6e9ZXS3OMCR8lU3nxfKCPn2VZ7Pv
+        1kWLTxfZkr6eoQcgoxQ5nk4rGpYi9rrNljMi6e///BWGU2Am7jbrSTOtC+6puZtlDw8ePtifbN+f
+        7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTrepp/XlfrVXMXw/v9Lxd3aaYvixnR6O4XxbSu
+        muq8HZ9Ui9W6ze/OCK/m7tcgBZEY72LSP3/y0aN7O/ggazO8TxxFDFauiUI7fXLjtb3ff2/v4afT
+        vQf3Pj2/P9l/MD04mNy7Nzt/MDvYnVDf558SHTq0Pl2s2mt8bOn8olr+f4/E+PMWwwc5qaWh7+7O
+        3r1f8n36sGo8aZpKF/ULIfHlYv/+4hdNL7IHq7fNVUHjzGaLYvlVk9c6CcBhTX/SVyWk4aRanhcX
+        6zoDCQCR+swmZf4ya5qrqp4dr9t5vmxJJKXBeVY2OWHR5DQ5LeYZOC3zlhq/9RDTT86WhNx5NoWO
+        IY74YVD9hfR8t4fB3cX1T37xoph+xGScFdnFsmpoZD49J1XVPnXf4KN8CXoQ4m29zmngwlxf1QUN
+        Zd62q+bR3bsB1ZuMKXu5GE/KajKeVnU+viqWs+qqGRNSdz/6JdQ9Yw6dRYxMrEmaglh0PZ3m+Yz6
+        ogatsK0bl+Gmy6Ju11n5BQsB0ZUmsjKz8xFRqZ1PacLqrFzjuza74FEssmL2+zfUEX0K/UQNiZzp
+        rMqbdFm16SLP23RVlcX0+lFKY1z9nns7uwd3dx7c3XlIYKZr+oxItvw6MOh/ewTjfL2cEjr0atF+
+        l2amwYfL/OoZPif03/jfgQTfFLe8OX395vf/yS+i3DJAVSutQDFjybGf/JIR2ayY7Tyf7e7tHhBG
+        09nB/e39/GB3e/Jp/nA7yw+yhw+yB9mn5xhydpkVZTYpyqK9fp23APCNjfT4yfGr519+d/vkyxdv
+        js9enL56ffrqJ89OTn//kxNQof/5d+nTr17vbaRNB+Hm7vHnpy/evPzyy+fbxz95fPb8+MnZ87M3
+        v8/r0zfb9+4/2HmwQ9NN07fJRyCWF2389PXe73/JzYlhIFhe62/SVeg5CvzpGAy68+neHjsrN3sM
+        bw+abcJp2a6qqrSD3d5xZvNgd3bw6e6DyYNP9w/2d/bzhzv5/qe7k9mnDx7eJx9qQrBIcZK8f8nT
+        TDC/GQ/iZZ0vivXim7Zu2SSry+pqe1ot24wEoybTcVlM899fpKH/+RV9um428xOZGLKH3wAtac4A
+        CzwFE9lzQaDnK1+9d8zlEApEwa7dnJbVekafs2p/X6OplqOZoy3z8PT3yq+BIf2ZtfTxR3fn1SK/
+        y73cHVPLuxnBqGoa2ez3f4u2o4/ox1MaHDWm77frJkuP6Xly78UPspPd6+neKf11/PT4J0gH0MfH
+        P3GybF5VB+3nz5ZffOf+/Pc5/s71J9XJwy+fl78o+8FF9erq8otZ07Ynp/ebk+VJ8eLkdOfVxU8v
+        fvrzL7/znQcXxcGXv/dPXD77qTdPdh9cTH5w7/d5WX3+e5//op9czo93m/qnfu+f2m0v755dfvng
+        fPLu4XfPi99nce/ty8ufeHH399r56a9+0U/9PtO31F3xU793c/+nHj5488myWZbHe8XnZZv99N7r
+        09Xl/vLlT+9PX704XX26bJ/M33yRP7ne/fJs+vTB3g8uzu7PJj/x6nh2fPxi9tV89fDg27tni5/4
+        qTeT7P7JF+ftg3f72Sfnv/d5vbv4iS+/WH/5e+8d1/W784Pn0+9effF7fbW7Pv7J3/uL3cvmq584
+        P3n+/Ac/dfZ7/96/6O0Xn3519Z03T3+fe6f57v5Xn1+cPP9FP3WRfXL5/Ce+ev6D9uHvfV69Kj6f
+        Hz//vS5ePH9y9tNvnr569Xs9uNhf7e1+dbWzuzqo59Nf9Pv89MsS3gOx1c+x//ONyuWwxzQgIKR2
+        SUiIELfwYwzm3ywBfnYMXdcJGBj+zt38XZsvMWpyFOTd47cN24onRUkq4oJG/v/LwTa5tOHpJ+9S
+        jM+NwEl7eU6q8iJ9SO4g8cUv/igjwMsLavmThKs0utwZ7z6kAD8jTU6GETaTvnjNdKGv6Y3tIYyp
+        fVVP59QLaegKfsHvtZ6QJs9JNB7tjg/Gu/vUBC+pHbBA6GNDe3z1en1+XryjBgY2ff9z58X+nHIB
+        BkkUoaEMtgDLU1d9v/jT/b1sf//+/vbDye4u5ZSm9Nvep7vb+f1PKZXw6Ww/J1tOJjd0MwHg/920
+        6yBMTY5fvzl99Q04xf9f84kXWUM2ww7Ud+L27k+n9x/sne9NDu7t753vHmTZ/qfn+acHDyf38vPd
+        ewSIhfubdogtMf+/5RF/CCVpugAI3BR1h3sZuWiH23k7nQEOUa0zM/+vTMD9sCfE0QfkpZ+G3nv3
+        P2WX6KaIoweRqPGjcONH4caPwo2YdJA5IwkhKpDHBmAwVaR7SJu0NPKP/n8Va3THHvre8uL/PwKN
+        zSOlKEMbYOYpTBALciNo0lo/S2GGouPwpcbvF2MIBPrM0Byf/zwNMIQWITXV8MW//iXf/yX/D5hz
+        NIm6HgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2101']
+      Content-Length: ['2286']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 07 Jun 2018 23:20:31 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:41 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [af9146e7-705a-40c3-848f-64951f8184fd]
-      x-ms-original-request-ids: [77610469-3607-4045-b8c6-ae93e314249a, 777e8c31-993b-4fcb-8b5c-6b6ab1ee2175]
-      x-ms-ratelimit-remaining-subscription-reads: ['14995']
-      x-ms-request-id: [af9146e7-705a-40c3-848f-64951f8184fd]
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232032Z:af9146e7-705a-40c3-848f-64951f8184fd']
+      x-ms-correlation-request-id: [7bc6780d-7822-42ba-9844-f6749a485337]
+      x-ms-original-request-ids: [c6083e9e-4afb-44b1-84ce-7666fd83dc92, d5bccaf1-b377-4ec1-bcd4-ba6230825b73]
+      x-ms-ratelimit-remaining-subscription-reads: ['11997']
+      x-ms-request-id: [7bc6780d-7822-42ba-9844-f6749a485337]
+      x-ms-routing-request-id: ['WESTUS2:20180802T221242Z:7bc6780d-7822-42ba-9844-f6749a485337']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -76,38 +78,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 monitormanagementclient/0.4.0
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 azure-mgmt-monitor/0.5.2 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-05-31%2000%3A00%3A00%2F2018-06-01%2000%3A00%3A00&interval=P1D&metric=Percentage%20CPU&aggregation=average&api-version=2017-05-01-preview
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-08-01%2000%3A00%3A00%2F2018-08-02%2000%3A00%3A00&interval=P1D&aggregation=average&api-version=2018-01-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR9Oq
-        aT96tDP6qC0WebPKlh89+mhvZ/dge+f+9r3dNzs7j/h/P3VXPvx0e8f78KPRR8WyzevLrKTXXu4+
-        pQ/o93X+0aPv/eKPihl9eLdZT5ppXazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3
-        YPf+bOdBfrfOm2pdT/PP62q9au6+OX395vf/yS/ururqspjldXP3i2JaV0113o5PqsVq3eZ3L4u6
-        XWflF9l0Xizz5u502uZNe7mIvnS2bIqLedvcXeRtXUybuy9z6m3ZZhd5evLyKxpEe72iMXw0/Aq1
-        WWYLavOLzYA/6gEpq2lWFj/IZz8Zb/FLRh+tlwVR33xB7/As5HWRN0xC6i2bZW3GfeCj748+wt/0
-        2y/mtq/bbLEiCDI74ZQRuOwyr6m7jx7dG+/cv3//3u7B/s7+/oODT/f2fsn3+b//B9y3wDMCAgAA
+        aT96tDP6qC0WebPKlh89+mhvZ/dge4f+t/tmZ+cR/++n7toP99yHH40+KpZtXl9mJb32cvcpfUC/
+        r/OPHn3vF39UzOjDu8160kzrYtUW1bK5m2UPDx4+2J9s35/tZdv7s4cH29mDg2z73sHe+b0Hu/dn
+        Ow/yu3XeVOt6mn9eV+tVc/fN6es3v/9PfnF3VVeXxSyvm7tfFNO6aqrzdnxSLVbrNr97WdTtOiu/
+        yKbzYpk3d6fTNm/ay0X0pbNlU1zM2+buIm/rYtrcfZlTb8s2u8jTk5df0SDa6xWN4aPhV6jNMltQ
+        m19sBvxRD0hZTbOy+EE++8l4i18y+mi9LIj65gt6h2chr4u8YRJSb9ksazPuAx99f/QR/qbffjG3
+        fd1mixVBsLPjTRmByy7zmrr76NHe+D41ub+zv7O3d+/g/v4v+T7+k0HQrE+piTfaAaoSQDM1dX5B
+        80kv0Z/tHMjXWbluPvol/w9HAhkSUgIAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 07 Jun 2018 23:20:31 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:41 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: ['Accept-Encoding,Accept-Encoding']
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-black_MetricsMP_IN_6]
-      x-ms-correlation-request-id: [bfe2a35e-051a-441c-a5e9-53138670a428]
-      x-ms-ratelimit-remaining-subscription-reads: ['14995']
-      x-ms-request-id: ['{bfe2a35e-051a-441c-a5e9-53138670a428}']
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232032Z:bfe2a35e-051a-441c-a5e9-53138670a428']
+      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-black_MetricsMP_IN_7]
+      x-ms-correlation-request-id: [fe22c7d6-b831-46f0-a13f-3f863f5f7155]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: ['{fe22c7d6-b831-46f0-a13f-3f863f5f7155}']
+      x-ms-routing-request-id: ['WESTUS2:20180802T221242Z:fe22c7d6-b831-46f0-a13f-3f863f5f7155']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_not_find.yaml
+++ b/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_not_find.yaml
@@ -5,69 +5,71 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 computemanagementclient/3.0.1
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 computemanagementclient/4.0.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2018-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFHswfTfPbw3r3thwcPZtv709397YefHmTbk4e7k8n9
-        7OHuLM8/Gn00z+rZVVbnL+vqvCgJHgC8Ln5Av330us2WM/r+93+y23z0S0YfNW1VZxd+02JBf7/K
-        z/M6X075k9V6UhbNPK/p/ZNsWS2LaVZSP9U5NaLPvpqsl+36dV5f0p8E8u2aPtz9dLyzv/38zWv6
-        hD5vimpJn5ZZmzctOq6ap0XzFuCr5s31ijr66HmxXL+j5stsgT+z5Q+qsprOt/HK9uXi9/+SX/n9
-        d3///P5Ofm+2O3kwOZ/sHxzcm9zfe/Bpnt+7l+/uzO7vPyQY0zqnrr5ctdLvs7panGFg+Cqbzovl
-        BX36Ks9m362LFp8usiV9PUMPQErpcjydVjQ4RfBlnS+K9eL3f/4KoyowJXeb9aSZ1gV31NzNsocH
-        Dx/sT7bvz/ay7f3Zw4Pt7AHN0L2DvfN7D3bvz3Ye5HfrvKnW9TT/vK7Wq+bu8Yuf+vL5lyff3n5z
-        +vrN9k9+cZfm/rKYEc3uflFM66qpztvxSbVYrdv87ozwo26+PmmI9IABdvj8yUeP7u3gg6zN8D7x
-        2ve+T39XjccPU+m5fhGfFSJENlsUy6+avNaJm5TZnD4uMZ0n1fK8uFjXGegDcNR5Ninzl1nTXFX1
-        7HjdzvNlSxwlDc6zsskJhSanGWwNQsu8pcZvPaz0k7MlYXaeTSEmJDXf1JR0BxmdkheCwt0eKr3X
-        d+/vfvRLMI5ZkV0sq4aG61N4UlXtU/cNPsqXIBKNpq3XOVFDuPGruqDxzdt21Ty6a3tBJ5cLgH54
-        f3c8KavJeFrV+fiqWM6qq2ZM+N396JdQ7zwICCJxP+kBYnvSB+vpNM9n1BU1aIXN3RAN110WdbvO
-        yi9YcojWNLmVmbGPiHLtfEqTWGflGt+12QUGQQC/qfl4LxHpIGvpZGaDMFRG7X3zS0ak7WKa9+H+
-        vd0H92afbt+/nx+Q5n04257cn366fZ7t7d3/9P79ewfTc4K7SfM+yZpi+vsf71AnZj69Zt+k1h3v
-        fJDenU7R1lcqB7v3aID57NN759n+wf37k4Ps/vm9fG+SkXrZvTeld0laqYsveY4Jxjejb4lJxVh9
-        swoXw/v9B4TaMBGpKdKzX4MURGK8i0mP6tdf/FG5Jgrt9MmN1/Z+/+zhzsMH+Wx6nn366f75+f7B
-        9CA/oP89mD3Y29m5B9J1aH26WLXX+NjS+UW1RLv/b5EYf95i+CAntTT03d3Zu8eqdZPNulzs31/8
-        oulF9mD1trkqaJxdkwUc1vQnffX/YbOFUQxRfdhaLa5/8osXBXEuUIYZUTvkof01LVRA9SZjyl4u
-        /l9koj56ed3OKyIF6cZHH5213yXK4Gv38Z73OXX/Tc0U7Njv/552zEgK4adcaz8ZtFv70/u79853
-        P92e7d9/uL1PZNye7Oycb+/c38v37+/ezx/s3yd4m+wWTYNoiCd7C6aBTrXX9ps0Xh9kus7Xyykm
-        RQz6nLjVae5smu0e7GTTBzlp7t1sj9RMtrPzaT7jwOnTnzUj9rMTNNCcXG+vmE23MeqNnETKizQt
-        mqHDr0UcIj+ggCegdntmDbpjkwrud07E6GrhaVmtZ9M1kZHU0JIasMZ4X12sCqmZoy0z4vT3yq+B
-        JP2ZtfTxR3fn1SK/G3Z3d0yv3M0IWFXTKGe//1u8NPqIfjylgdJb9P123WTpMT1P7r34QXayez3d
-        O6W/jp8e/8TxE/r55PgnTvKdxdMns/MH9en01SdPftEnq+dvH65/8skPmvX91dmbB8+m3z746Yt7
-        9376/Pf5vV589+7dT356/YPv3r/7+xS79Xf33v7eZ235E7/3q2c/ebF++FXTvstXq1+0ejW9d3Lv
-        4e/9pHo5m/7kwZOLF198+fDFJ+3nv/fVfPrTD6tfdPGq+WJ9MHn9dmePnMx8srez/r1evpoef/Kd
-        J5Pn33m9e74z+/anrx/+4Ac/+cWnebP3RVOcPfjByf1f9OX+L2q/mnx+b3Wy//zJ7rPL2U+dXu0+
-        Pf+9njZf7O08+faz9sufqr64+n3uZm9/r/2vXv8+J9ffbb87zd8+fPnFp59+uffi2Xemv9fZu3bv
-        6uH1T5b3z55MJt95u/f8wSqf/fT15RfffvWDp1e7n+8dlJ98+qx6+ubu6tsHi+t7zy6ffvrF+f6z
-        B1ez2eTl+SfV5berpnn6E88u3hU/ffwTn+//Xg+/vHp9PH2+87pdvfty9/qLn357VfwUrBOx2M+t
-        fb2V0A0bWryCzp0MfLpLATlGQgxojKs3mq9pdoGmYIkeAfrg4YcFhoYOhMI3SM7jF09/n+2Xv8+b
-        b3/5YvvZVy9OouQ0OqxrDTE0dO2IeTd/1+ZLDINAHz99Xl0Uy2dVLSYCFvL/A3h/IQblbAaF1l6f
-        mm/cOL5PzosYlhv7IuXl+UBX1N+62aMP1fmheSWkuR/6y0B9fd20+eK4aYqLJU0+mKNYTotVVrJD
-        kT08z8g7n2xPdyc72/s72d72wUOi13728P75wcPZ+cN73AXx6bLlNx7snT88OJicbx98er67Tcbl
-        fPvhbjbZ3qNs5mxnd3c22X9A00O4UOO7/6+bHRqMWqfId7/k+7/k/wFcxa/2tRUAAA==
+        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFH+7v38/Ns9/72bH8y3d7feZhvT+7f39s+uH/vXr6f
+        7T/4dHL+0eijeVbPrrI6f1lX50VJ8ADgdfED+u2jJ1lTTH//452Pfsnoo6at6uzCb1Ys6O9X+Xle
+        58spf7JaT8qimec1vXuSLatlMc1K6qM6p0b02VeT9bJdv87rS/qTQL5d04e7n4539sc728/fvKbP
+        6JumqJb0eZm1edOi66p5WjRv0UHVvLleUVcfPS+W63fUfJkt8Od0iraXi9//S276++/+/vcfnk8e
+        nH+6Pz3Yvb//6X6W7U4ePtzd+/TeZHcnmz7I6N1pnVMXX65a6e9ZXS3OMCR8lU3nxfKCPn2VZ7Pv
+        1kWLTxfZkr6eoQcgoxQ5nk4rGpYi9rrNljMi6e///BWGU2Am7jbrSTOtC+6puZtlDw8ePtifbN+f
+        7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTrepp/XlfrVXMXw/v9Lxd3aaYvixnR6O4XxbSu
+        muq8HZ9Ui9W6ze/OCK/m7tcgBZEY72LSP3/y0aN7O/ggazO8TxxFDFauiUI7fXLjtb3ff2/v4afT
+        vQf3Pj2/P9l/MD04mNy7Nzt/MDvYnVDf558SHTq0Pl2s2mt8bOn8olr+f4/E+PMWwwc5qaWh7+7O
+        3r1f8n36sGo8aZpKF/ULIfHlYv/+4hdNL7IHq7fNVUHjzGaLYvlVk9c6CcBhTX/SVyWk4aRanhcX
+        6zoDCQCR+swmZf4ya5qrqp4dr9t5vmxJJKXBeVY2OWHR5DQ5LeYZOC3zlhq/9RDTT86WhNx5NoWO
+        IY74YVD9hfR8t4fB3cX1T37xoph+xGScFdnFsmpoZD49J1XVPnXf4KN8CXoQ4m29zmngwlxf1QUN
+        Zd62q+bR3bsB1ZuMKXu5GE/KajKeVnU+viqWs+qqGRNSdz/6JdQ9Yw6dRYxMrEmaglh0PZ3m+Yz6
+        ogatsK0bl+Gmy6Ju11n5BQsB0ZUmsjKz8xFRqZ1PacLqrFzjuza74FEssmL2+zfUEX0K/UQNiZzp
+        rMqbdFm16SLP23RVlcX0+lFKY1z9nns7uwd3dx7c3XlIYKZr+oxItvw6MOh/ewTjfL2cEjr0atF+
+        l2amwYfL/OoZPif03/jfgQTfFLe8OX395vf/yS+i3DJAVSutQDFjybGf/JIR2ayY7Tyf7e7tHhBG
+        09nB/e39/GB3e/Jp/nA7yw+yhw+yB9mn5xhydpkVZTYpyqK9fp23APCNjfT4yfGr519+d/vkyxdv
+        js9enL56ffrqJ89OTn//kxNQof/5d+nTr17vbaRNB+Hm7vHnpy/evPzyy+fbxz95fPb8+MnZ87M3
+        v8/r0zfb9+4/2HmwQ9NN07fJRyCWF2389PXe73/JzYlhIFhe62/SVeg5CvzpGAy68+neHjsrN3sM
+        bw+abcJp2a6qqrSD3d5xZvNgd3bw6e6DyYNP9w/2d/bzhzv5/qe7k9mnDx7eJx9qQrBIcZK8f8nT
+        TDC/GQ/iZZ0vivXim7Zu2SSry+pqe1ot24wEoybTcVlM899fpKH/+RV9um428xOZGLKH3wAtac4A
+        CzwFE9lzQaDnK1+9d8zlEApEwa7dnJbVekafs2p/X6OplqOZoy3z8PT3yq+BIf2ZtfTxR3fn1SK/
+        y73cHVPLuxnBqGoa2ez3f4u2o4/ox1MaHDWm77frJkuP6Xly78UPspPd6+neKf11/PT4J0gH0MfH
+        P3GybF5VB+3nz5ZffOf+/Pc5/s71J9XJwy+fl78o+8FF9erq8otZ07Ynp/ebk+VJ8eLkdOfVxU8v
+        fvrzL7/znQcXxcGXv/dPXD77qTdPdh9cTH5w7/d5WX3+e5//op9czo93m/qnfu+f2m0v755dfvng
+        fPLu4XfPi99nce/ty8ufeHH399r56a9+0U/9PtO31F3xU793c/+nHj5488myWZbHe8XnZZv99N7r
+        09Xl/vLlT+9PX704XX26bJ/M33yRP7ne/fJs+vTB3g8uzu7PJj/x6nh2fPxi9tV89fDg27tni5/4
+        qTeT7P7JF+ftg3f72Sfnv/d5vbv4iS+/WH/5e+8d1/W784Pn0+9effF7fbW7Pv7J3/uL3cvmq584
+        P3n+/Ac/dfZ7/96/6O0Xn3519Z03T3+fe6f57v5Xn1+cPP9FP3WRfXL5/Ce+ev6D9uHvfV69Kj6f
+        Hz//vS5ePH9y9tNvnr569Xs9uNhf7e1+dbWzuzqo59Nf9Pv89MsS3gOx1c+x//ONyuWwxzQgIKR2
+        SUiIELfwYwzm3ywBfnYMXdcJGBj+zt38XZsvMWpyFOTd47cN24onRUkq4oJG/v/LwTa5tOHpJ+9S
+        jM+NwEl7eU6q8iJ9SO4g8cUv/igjwMsLavmThKs0utwZ7z6kAD8jTU6GETaTvnjNdKGv6Y3tIYyp
+        fVVP59QLaegKfsHvtZ6QJs9JNB7tjg/Gu/vUBC+pHbBA6GNDe3z1en1+XryjBgY2ff9z58X+nHIB
+        BkkUoaEMtgDLU1d9v/jT/b1sf//+/vbDye4u5ZSm9Nvep7vb+f1PKZXw6Ww/J1tOJjd0MwHg/920
+        6yBMTY5fvzl99Q04xf9f84kXWUM2ww7Ud+L27k+n9x/sne9NDu7t753vHmTZ/qfn+acHDyf38vPd
+        ewSIhfubdogtMf+/5RF/CCVpugAI3BR1h3sZuWiH23k7nQEOUa0zM/+vTMD9sCfE0QfkpZ+G3nv3
+        P2WX6KaIoweRqPGjcONH4caPwo2YdJA5IwkhKpDHBmAwVaR7SJu0NPKP/n8Va3THHvre8uL/PwKN
+        zSOlKEMbYOYpTBALciNo0lo/S2GGouPwpcbvF2MIBPrM0Byf/zwNMIQWITXV8MW//iXf/yX/D5hz
+        NIm6HgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2101']
+      Content-Length: ['2286']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 07 Jun 2018 23:20:33 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:43 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [8dc3b953-eeb6-490f-a7d4-072b21ed60e9]
-      x-ms-original-request-ids: [8fdd3662-94fd-48ce-81de-d437c271d79a, 38444d95-203c-48a0-8716-4602b7b7bfff]
-      x-ms-ratelimit-remaining-subscription-reads: ['14996']
-      x-ms-request-id: [8dc3b953-eeb6-490f-a7d4-072b21ed60e9]
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232033Z:8dc3b953-eeb6-490f-a7d4-072b21ed60e9']
+      x-ms-correlation-request-id: [5ff6e37d-7330-4326-a785-a5a72a14c79e]
+      x-ms-original-request-ids: [bcc0459b-6c7b-4835-98ce-2e6dd5732d8f, d95f48db-1b40-4e23-bde6-e83d2b9ae59a]
+      x-ms-ratelimit-remaining-subscription-reads: ['11997']
+      x-ms-request-id: [5ff6e37d-7330-4326-a785-a5a72a14c79e]
+      x-ms-routing-request-id: ['WESTUS2:20180802T221243Z:5ff6e37d-7330-4326-a785-a5a72a14c79e']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -76,38 +78,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 monitormanagementclient/0.4.0
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 azure-mgmt-monitor/0.5.2 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-05-31%2000%3A00%3A00%2F2018-06-01%2000%3A00%3A00&interval=P1D&metric=Network%20In&aggregation=total&api-version=2017-05-01-preview
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-08-01%2000%3A00%3A00%2F2018-08-02%2000%3A00%3A00&interval=P1D&aggregation=total&api-version=2018-01-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR9Oq
-        aT96tDP6qC0WebPKlh89+mhvZ/dge+f+9r3dNzs7j/h/P3VXPvx0e8f78KPRR8WyzevLrKTXXu4+
-        pQ/o93X+0aPv/eKPihl9eLdZT5ppXazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3
-        YPf+bOdBfrfOm2pdT/PP62q9au6+OX395vf/yS/ururqspjldXP3i2JaV0113o5PqsVq3eZ3L4u6
-        XWflF9l0Xizz5u502uZNe7mIvnS2bIqLedvcXeRtXUybuy/y9qqq36ZnSxpAe70i/D8abk5tltmC
-        2vxiM9iPAgBlNc3K4gf57Cf73/6S0UfrZUEU/+jJNWFIrZnueV3QHyAa9ZHNsjZjyPjo+6OP8Df9
-        9ou57es2W6zofZmPcJIArmoxGXsHB58ePNx7eDDe+SXf5//+H4DUpqfrAQAA
+        aT96tDP6qC0WebPKlh89+mhvZ/dge4f+t/tmZ+cR/++n7toP99yHH40+KpZtXl9mJb32cvcpfUC/
+        r/OPHn3vF39UzOjDu8160kzrYtUW1bK5m2UPDx4+2J9s35/tZdv7s4cH29mDg2z73sHe+b0Hu/dn
+        Ow/yu3XeVOt6mn9eV+tVc/fN6es3v/9PfnF3VVeXxSyvm7tfFNO6aqrzdnxSLVbrNr97WdTtOiu/
+        yKbzYpk3d6fTNm/ay0X0pbNlU1zM2+buIm/rYtrcfZlTb8s2u8jTk5df0SDa6xWN4aPhV6jNMltQ
+        m19sBvxRD0hZTbOy+EE++8l4i18y+mi9LIj65gt6h2chr4u8YRJSb9ksazPuAx99f/QR/qbffjG3
+        fd1mixVBsLPjTRnAVS2m5sHezv3x7s5DfQ4+/SXfx38yBpr0KbBzgx0gKsEzM1PnFzSd9BL92c6B
+        e52V6+ajX/L/AM2On51RAgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 07 Jun 2018 23:20:33 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:43 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: ['Accept-Encoding,Accept-Encoding']
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-red_MetricsMP_IN_7]
-      x-ms-correlation-request-id: [d7720479-eea6-4626-91e8-880ea50d3f67]
-      x-ms-ratelimit-remaining-subscription-reads: ['14995']
-      x-ms-request-id: ['{d7720479-eea6-4626-91e8-880ea50d3f67}']
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232033Z:d7720479-eea6-4626-91e8-880ea50d3f67']
+      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-red_MetricsMP_IN_4]
+      x-ms-correlation-request-id: [47637fa2-9103-45f4-9b49-826e0b8b12c9]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: ['{47637fa2-9103-45f4-9b49-826e0b8b12c9}']
+      x-ms-routing-request-id: ['WESTUS2:20180802T221243Z:47637fa2-9103-45f4-9b49-826e0b8b12c9']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_not_find_average.yaml
+++ b/tools/c7n_azure/tests/cassettes/ArmResourceTest.test_metric_filter_not_find_average.yaml
@@ -5,69 +5,71 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 computemanagementclient/3.0.1
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 computemanagementclient/4.0.1 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2017-03-30
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Compute/virtualMachines?api-version=2018-06-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
-        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFHswfTfPbw3r3thwcPZtv709397YefHmTbk4e7k8n9
-        7OHuLM8/Gn00z+rZVVbnL+vqvCgJHgC8Ln5Av330us2WM/r+93+y23z0S0YfNW1VZxd+02JBf7/K
-        z/M6X075k9V6UhbNPK/p/ZNsWS2LaVZSP9U5NaLPvpqsl+36dV5f0p8E8u2aPtz9dLyzv/38zWv6
-        hD5vimpJn5ZZmzctOq6ap0XzFuCr5s31ijr66HmxXL+j5stsgT+z5Q+qsprOt/HK9uXi9/+SX/n9
-        d3///P5Ofm+2O3kwOZ/sHxzcm9zfe/Bpnt+7l+/uzO7vPyQY0zqnrr5ctdLvs7panGFg+Cqbzovl
-        BX36Ks9m362LFp8usiV9PUMPQErpcjydVjQ4RfBlnS+K9eL3f/4KoyowJXeb9aSZ1gV31NzNsocH
-        Dx/sT7bvz/ay7f3Zw4Pt7AHN0L2DvfN7D3bvz3Ye5HfrvKnW9TT/vK7Wq+bu8Yuf+vL5lyff3n5z
-        +vrN9k9+cZfm/rKYEc3uflFM66qpztvxSbVYrdv87ozwo26+PmmI9IABdvj8yUeP7u3gg6zN8D7x
-        2ve+T39XjccPU+m5fhGfFSJENlsUy6+avNaJm5TZnD4uMZ0n1fK8uFjXGegDcNR5Ninzl1nTXFX1
-        7HjdzvNlSxwlDc6zsskJhSanGWwNQsu8pcZvPaz0k7MlYXaeTSEmJDXf1JR0BxmdkheCwt0eKr3X
-        d+/vfvRLMI5ZkV0sq4aG61N4UlXtU/cNPsqXIBKNpq3XOVFDuPGruqDxzdt21Ty6a3tBJ5cLgH54
-        f3c8KavJeFrV+fiqWM6qq2ZM+N396JdQ7zwICCJxP+kBYnvSB+vpNM9n1BU1aIXN3RAN110WdbvO
-        yi9YcojWNLmVmbGPiHLtfEqTWGflGt+12QUGQQC/qfl4LxHpIGvpZGaDMFRG7X3zS0ak7WKa9+H+
-        vd0H92afbt+/nx+Q5n04257cn366fZ7t7d3/9P79ewfTc4K7SfM+yZpi+vsf71AnZj69Zt+k1h3v
-        fJDenU7R1lcqB7v3aID57NN759n+wf37k4Ps/vm9fG+SkXrZvTeld0laqYsveY4Jxjejb4lJxVh9
-        swoXw/v9B4TaMBGpKdKzX4MURGK8i0mP6tdf/FG5Jgrt9MmN1/Z+/+zhzsMH+Wx6nn366f75+f7B
-        9CA/oP89mD3Y29m5B9J1aH26WLXX+NjS+UW1RLv/b5EYf95i+CAntTT03d3Zu8eqdZPNulzs31/8
-        oulF9mD1trkqaJxdkwUc1vQnffX/YbOFUQxRfdhaLa5/8osXBXEuUIYZUTvkof01LVRA9SZjyl4u
-        /l9koj56ed3OKyIF6cZHH5213yXK4Gv38Z73OXX/Tc0U7Njv/552zEgK4adcaz8ZtFv70/u79853
-        P92e7d9/uL1PZNye7Oycb+/c38v37+/ezx/s3yd4m+wWTYNoiCd7C6aBTrXX9ps0Xh9kus7Xyykm
-        RQz6nLjVae5smu0e7GTTBzlp7t1sj9RMtrPzaT7jwOnTnzUj9rMTNNCcXG+vmE23MeqNnETKizQt
-        mqHDr0UcIj+ggCegdntmDbpjkwrud07E6GrhaVmtZ9M1kZHU0JIasMZ4X12sCqmZoy0z4vT3yq+B
-        JP2ZtfTxR3fn1SK/G3Z3d0yv3M0IWFXTKGe//1u8NPqIfjylgdJb9P123WTpMT1P7r34QXayez3d
-        O6W/jp8e/8TxE/r55PgnTvKdxdMns/MH9en01SdPftEnq+dvH65/8skPmvX91dmbB8+m3z746Yt7
-        9376/Pf5vV589+7dT356/YPv3r/7+xS79Xf33v7eZ235E7/3q2c/ebF++FXTvstXq1+0ejW9d3Lv
-        4e/9pHo5m/7kwZOLF198+fDFJ+3nv/fVfPrTD6tfdPGq+WJ9MHn9dmePnMx8srez/r1evpoef/Kd
-        J5Pn33m9e74z+/anrx/+4Ac/+cWnebP3RVOcPfjByf1f9OX+L2q/mnx+b3Wy//zJ7rPL2U+dXu0+
-        Pf+9njZf7O08+faz9sufqr64+n3uZm9/r/2vXv8+J9ffbb87zd8+fPnFp59+uffi2Xemv9fZu3bv
-        6uH1T5b3z55MJt95u/f8wSqf/fT15RfffvWDp1e7n+8dlJ98+qx6+ubu6tsHi+t7zy6ffvrF+f6z
-        B1ez2eTl+SfV5berpnn6E88u3hU/ffwTn+//Xg+/vHp9PH2+87pdvfty9/qLn357VfwUrBOx2M+t
-        fb2V0A0bWryCzp0MfLpLATlGQgxojKs3mq9pdoGmYIkeAfrg4YcFhoYOhMI3SM7jF09/n+2Xv8+b
-        b3/5YvvZVy9OouQ0OqxrDTE0dO2IeTd/1+ZLDINAHz99Xl0Uy2dVLSYCFvL/A3h/IQblbAaF1l6f
-        mm/cOL5PzosYlhv7IuXl+UBX1N+62aMP1fmheSWkuR/6y0B9fd20+eK4aYqLJU0+mKNYTotVVrJD
-        kT08z8g7n2xPdyc72/s72d72wUOi13728P75wcPZ+cN73AXx6bLlNx7snT88OJicbx98er67Tcbl
-        fPvhbjbZ3qNs5mxnd3c22X9A00O4UOO7/6+bHRqMWqfId7/k+7/k/wFcxa/2tRUAAA==
+        uc4/evS9X/zRqq5Wed0WefPRI/p8cTb76NFH+7v38/Ns9/72bH8y3d7feZhvT+7f39s+uH/vXr6f
+        7T/4dHL+0eijeVbPrrI6f1lX50VJ8ADgdfED+u2jJ1lTTH//452Pfsnoo6at6uzCb1Ys6O9X+Xle
+        58spf7JaT8qimec1vXuSLatlMc1K6qM6p0b02VeT9bJdv87rS/qTQL5d04e7n4539sc728/fvKbP
+        6JumqJb0eZm1edOi66p5WjRv0UHVvLleUVcfPS+W63fUfJkt8Od0iraXi9//S276++/+/vcfnk8e
+        nH+6Pz3Yvb//6X6W7U4ePtzd+/TeZHcnmz7I6N1pnVMXX65a6e9ZXS3OMCR8lU3nxfKCPn2VZ7Pv
+        1kWLTxfZkr6eoQcgoxQ5nk4rGpYi9rrNljMi6e///BWGU2Am7jbrSTOtC+6puZtlDw8ePtifbN+f
+        7WXb+7OHB9vZg4Ns+97B3vm9B7v3ZzsP8rt13lTrepp/XlfrVXMXw/v9Lxd3aaYvixnR6O4XxbSu
+        muq8HZ9Ui9W6ze/OCK/m7tcgBZEY72LSP3/y0aN7O/ggazO8TxxFDFauiUI7fXLjtb3ff2/v4afT
+        vQf3Pj2/P9l/MD04mNy7Nzt/MDvYnVDf558SHTq0Pl2s2mt8bOn8olr+f4/E+PMWwwc5qaWh7+7O
+        3r1f8n36sGo8aZpKF/ULIfHlYv/+4hdNL7IHq7fNVUHjzGaLYvlVk9c6CcBhTX/SVyWk4aRanhcX
+        6zoDCQCR+swmZf4ya5qrqp4dr9t5vmxJJKXBeVY2OWHR5DQ5LeYZOC3zlhq/9RDTT86WhNx5NoWO
+        IY74YVD9hfR8t4fB3cX1T37xoph+xGScFdnFsmpoZD49J1XVPnXf4KN8CXoQ4m29zmngwlxf1QUN
+        Zd62q+bR3bsB1ZuMKXu5GE/KajKeVnU+viqWs+qqGRNSdz/6JdQ9Yw6dRYxMrEmaglh0PZ3m+Yz6
+        ogatsK0bl+Gmy6Ju11n5BQsB0ZUmsjKz8xFRqZ1PacLqrFzjuza74FEssmL2+zfUEX0K/UQNiZzp
+        rMqbdFm16SLP23RVlcX0+lFKY1z9nns7uwd3dx7c3XlIYKZr+oxItvw6MOh/ewTjfL2cEjr0atF+
+        l2amwYfL/OoZPif03/jfgQTfFLe8OX395vf/yS+i3DJAVSutQDFjybGf/JIR2ayY7Tyf7e7tHhBG
+        09nB/e39/GB3e/Jp/nA7yw+yhw+yB9mn5xhydpkVZTYpyqK9fp23APCNjfT4yfGr519+d/vkyxdv
+        js9enL56ffrqJ89OTn//kxNQof/5d+nTr17vbaRNB+Hm7vHnpy/evPzyy+fbxz95fPb8+MnZ87M3
+        v8/r0zfb9+4/2HmwQ9NN07fJRyCWF2389PXe73/JzYlhIFhe62/SVeg5CvzpGAy68+neHjsrN3sM
+        bw+abcJp2a6qqrSD3d5xZvNgd3bw6e6DyYNP9w/2d/bzhzv5/qe7k9mnDx7eJx9qQrBIcZK8f8nT
+        TDC/GQ/iZZ0vivXim7Zu2SSry+pqe1ot24wEoybTcVlM899fpKH/+RV9um428xOZGLKH3wAtac4A
+        CzwFE9lzQaDnK1+9d8zlEApEwa7dnJbVekafs2p/X6OplqOZoy3z8PT3yq+BIf2ZtfTxR3fn1SK/
+        y73cHVPLuxnBqGoa2ez3f4u2o4/ox1MaHDWm77frJkuP6Xly78UPspPd6+neKf11/PT4J0gH0MfH
+        P3GybF5VB+3nz5ZffOf+/Pc5/s71J9XJwy+fl78o+8FF9erq8otZ07Ynp/ebk+VJ8eLkdOfVxU8v
+        fvrzL7/znQcXxcGXv/dPXD77qTdPdh9cTH5w7/d5WX3+e5//op9czo93m/qnfu+f2m0v755dfvng
+        fPLu4XfPi99nce/ty8ufeHH399r56a9+0U/9PtO31F3xU793c/+nHj5488myWZbHe8XnZZv99N7r
+        09Xl/vLlT+9PX704XX26bJ/M33yRP7ne/fJs+vTB3g8uzu7PJj/x6nh2fPxi9tV89fDg27tni5/4
+        qTeT7P7JF+ftg3f72Sfnv/d5vbv4iS+/WH/5e+8d1/W784Pn0+9effF7fbW7Pv7J3/uL3cvmq584
+        P3n+/Ac/dfZ7/96/6O0Xn3519Z03T3+fe6f57v5Xn1+cPP9FP3WRfXL5/Ce+ev6D9uHvfV69Kj6f
+        Hz//vS5ePH9y9tNvnr569Xs9uNhf7e1+dbWzuzqo59Nf9Pv89MsS3gOx1c+x//ONyuWwxzQgIKR2
+        SUiIELfwYwzm3ywBfnYMXdcJGBj+zt38XZsvMWpyFOTd47cN24onRUkq4oJG/v/LwTa5tOHpJ+9S
+        jM+NwEl7eU6q8iJ9SO4g8cUv/igjwMsLavmThKs0utwZ7z6kAD8jTU6GETaTvnjNdKGv6Y3tIYyp
+        fVVP59QLaegKfsHvtZ6QJs9JNB7tjg/Gu/vUBC+pHbBA6GNDe3z1en1+XryjBgY2ff9z58X+nHIB
+        BkkUoaEMtgDLU1d9v/jT/b1sf//+/vbDye4u5ZSm9Nvep7vb+f1PKZXw6Ww/J1tOJjd0MwHg/920
+        6yBMTY5fvzl99Q04xf9f84kXWUM2ww7Ud+L27k+n9x/sne9NDu7t753vHmTZ/qfn+acHDyf38vPd
+        ewSIhfubdogtMf+/5RF/CCVpugAI3BR1h3sZuWiH23k7nQEOUa0zM/+vTMD9sCfE0QfkpZ+G3nv3
+        P2WX6KaIoweRqPGjcONH4caPwo2YdJA5IwkhKpDHBmAwVaR7SJu0NPKP/n8Va3THHvre8uL/PwKN
+        zSOlKEMbYOYpTBALciNo0lo/S2GGouPwpcbvF2MIBPrM0Byf/zwNMIQWITXV8MW//iXf/yX/D5hz
+        NIm6HgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2101']
+      Content-Length: ['2286']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Thu, 07 Jun 2018 23:20:33 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:44 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [b53bbe68-5ab3-46aa-b405-248f84a83d0a]
-      x-ms-original-request-ids: [2aca6186-fe4a-4e8a-b761-39eacccd3e0b, cf5af7a2-e7ae-4b9b-973a-fd538e806b85]
-      x-ms-ratelimit-remaining-subscription-reads: ['14997']
-      x-ms-request-id: [b53bbe68-5ab3-46aa-b405-248f84a83d0a]
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232034Z:b53bbe68-5ab3-46aa-b405-248f84a83d0a']
+      x-ms-correlation-request-id: [d6e89962-ca89-4d7d-9181-555e2b61f22b]
+      x-ms-original-request-ids: [17dd0520-bd54-4e21-adae-e4eee9fd552c, 60d5c731-b131-4b9c-bf57-1350828bcc9e]
+      x-ms-ratelimit-remaining-subscription-reads: ['11996']
+      x-ms-request-id: [d6e89962-ca89-4d7d-9181-555e2b61f22b]
+      x-ms-routing-request-id: ['WESTUS2:20180802T221244Z:d6e89962-ca89-4d7d-9181-555e2b61f22b']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -76,38 +78,38 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/3.6.3 (Linux-4.13.0-41-generic-x86_64-with-Ubuntu-17.10-artful)
-          requests/2.18.4 msrest/0.4.29 msrest_azure/0.4.31 monitormanagementclient/0.4.0
-          Azure-SDK-For-Python]
+      User-Agent: [python/3.6.5 (Darwin-17.6.0-x86_64-i386-64bit) requests/2.19.1
+          msrest/0.5.4 msrest_azure/0.5.0 azure-mgmt-monitor/0.5.2 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-05-31%2000%3A00%3A00%2F2018-06-01%2000%3A00%3A00&interval=P1D&metric=Percentage%20CPU&aggregation=average&api-version=2017-05-01-preview
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resourceGroups/TEST_VM/providers/Microsoft.Compute/virtualMachines/cctestvm/providers/microsoft.insights/metrics?timespan=2018-08-01%2000%3A00%3A00%2F2018-08-02%2000%3A00%3A00&interval=P1D&aggregation=average&api-version=2018-01-01
   response:
     body:
       string: !!binary |
         H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
         VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR9Oq
-        aT96tDP6qC0WebPKlh89+mhvZ/dge+f+9r3dNzs7j/h/P3VXPvx0e8f78KPRR8WyzevLrKTXXu4+
-        pQ/o93X+0aPv/eKPihl9eLdZT5ppXazaolo2d7Ps4cHDB/uT7fuzvWx7f/bwYDt7cJBt3zvYO7/3
-        YPf+bOdBfrfOm2pdT/PP62q9au6+OX395vf/yS/ururqspjldXP3i2JaV0113o5PqsVq3eZ3L4u6
-        XWflF9l0Xizz5u502uZNe7mIvnS2bIqLedvcXeRtXUybuy9z6m3ZZhd5evLyKxpEe72iMXw0/Aq1
-        WWYLavOLzYA/6gEpq2lWFj/IZz8Zb/FLRh+tlwVR33xB7/As5HWRN0xC6i2bZW3GfeCj748+wt/0
-        2y/mtq/bbLEiCDI74ZQRuOwyr6m7jx7dG+/cv3//3u7B/s7+/oODT/f2fsn3+b//B9y3wDMCAgAA
+        aT96tDP6qC0WebPKlh89+mhvZ/dge4f+t/tmZ+cR/++n7toP99yHH40+KpZtXl9mJb32cvcpfUC/
+        r/OPHn3vF39UzOjDu8160kzrYtUW1bK5m2UPDx4+2J9s35/tZdv7s4cH29mDg2z73sHe+b0Hu/dn
+        Ow/yu3XeVOt6mn9eV+tVc/fN6es3v/9PfnF3VVeXxSyvm7tfFNO6aqrzdnxSLVbrNr97WdTtOiu/
+        yKbzYpk3d6fTNm/ay0X0pbNlU1zM2+buIm/rYtrcfZlTb8s2u8jTk5df0SDa6xWN4aPhV6jNMltQ
+        m19sBvxRD0hZTbOy+EE++8l4i18y+mi9LIj65gt6h2chr4u8YRJSb9ksazPuAx99f/QR/qbffjG3
+        fd1mixVBsLPjTRmByy7zmrr76NHe+D41ub+zv7O3d+/g/v4v+T7+k0HQrE+piTfaAaoSQDM1dX5B
+        80kv0Z/tHMjXWbluPvol/w9HAhkSUgIAAA==
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
       Content-Type: [application/json]
-      Date: ['Thu, 07 Jun 2018 23:20:34 GMT']
+      Date: ['Thu, 02 Aug 2018 22:12:43 GMT']
       Server: [Microsoft-IIS/8.5]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: ['Accept-Encoding,Accept-Encoding']
       X-AspNet-Version: [4.0.30319]
       X-Content-Type-Options: [nosniff]
       X-Powered-By: [ASP.NET]
-      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-red_MetricsMP_IN_2]
-      x-ms-correlation-request-id: [3707651b-e3b7-4a0e-8aae-e5d872c05397]
-      x-ms-ratelimit-remaining-subscription-reads: ['14995']
-      x-ms-request-id: ['{3707651b-e3b7-4a0e-8aae-e5d872c05397}']
-      x-ms-routing-request-id: ['SOUTHCENTRALUS:20180607T232034Z:3707651b-e3b7-4a0e-8aae-e5d872c05397']
+      __HandlingServerId__: [shoeboxproxyustwo_shoeboxproxyustwo-red_MetricsMP_IN_9]
+      x-ms-correlation-request-id: [af31350c-d5f2-46c7-8a43-6b4dd6d0d2c9]
+      x-ms-ratelimit-remaining-subscription-reads: ['11998']
+      x-ms-request-id: ['{af31350c-d5f2-46c7-8a43-6b4dd6d0d2c9}']
+      x-ms-routing-request-id: ['WESTUS2:20180802T221244Z:af31350c-d5f2-46c7-8a43-6b4dd6d0d2c9']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/test_armresource.py
+++ b/tools/c7n_azure/tests/test_armresource.py
@@ -22,7 +22,7 @@ from mock import patch
 
 class ArmResourceTest(BaseTest):
 
-    TEST_DATE = datetime(2018, 6, 1, 0, 0, 0)
+    TEST_DATE = datetime(2018, 8, 2, 0, 0, 0)
 
     def setUp(self):
         super(ArmResourceTest, self).setUp()


### PR DESCRIPTION
msrestazure requires adal > 0.6.0 so bumped up package to latest
Tests were failing from breaking changes from azure (new rest endpoints for metrics and new client name for data lake) 