### PR TITLE
azure - fix 'validate' for actions with tags

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -29,7 +29,8 @@ from c7n.filters import FilterValidationError
 from c7n.filters.core import PolicyValidationError
 from c7n.filters.offhours import Time
 from c7n.resolver import ValuesFrom
-from c7n.utils import local_session, type_schema
+from c7n.utils import type_schema
+
 
 class TagHelper:
 
@@ -158,6 +159,7 @@ class RemoveTag(BaseAction):
     def process_resource(self, resource):
         tags_to_delete = self.data.get('tags')
         TagHelper.remove_tags(self, resource, tags_to_delete)
+
 
 class AutoTagUser(BaseAction):
     """Attempts to tag a resource with the first user who created/modified it.
@@ -348,8 +350,7 @@ class TagTrim(BaseAction):
 
         if self.space:
             # Free up slots to fit
-            remove = len(candidates) - (
-                    self.max_tag_count - (self.space + len(tags_to_preserve)))
+            remove = len(candidates) - (self.max_tag_count - (self.space + len(tags_to_preserve)))
             candidates = list(sorted(candidates))[:remove]
 
         if not candidates:

--- a/tools/c7n_azure/c7n_azure/function.py
+++ b/tools/c7n_azure/c7n_azure/function.py
@@ -23,7 +23,7 @@ from c7n_azure import handler, entry
 
 try:
     import azure.functions as func
-    from azure.worker.bindings.http import HttpRequest
+    from azure.functions_worker.bindings.http import HttpRequest
 except ImportError:
     pass
 

--- a/tools/c7n_azure/c7n_azure/query.py
+++ b/tools/c7n_azure/c7n_azure/query.py
@@ -95,11 +95,14 @@ class QueryResourceManager(ResourceManager):
     def get_source(self, source_type):
         return sources.get(source_type)(self)
 
+    def get_session(self):
+        return local_session(self.session_factory)
+
     def get_client(self, service=None):
         if not service:
-            return local_session(self.session_factory).client(
+            return self.get_session().client(
                 "%s.%s" % (self.resource_type.service, self.resource_type.client))
-        return local_session(self.session_factory).client(service)
+        return self.get_session().client(service)
 
     def get_cache_key(self, query):
         return {'source_type': self.source_type, 'query': query}


### PR DESCRIPTION
#2691

-Tag related actions/filters they were initializing a session. This is not possible during a `validation` flow. I moved all of the session initialization into the `process` method instead.
-In addition, I made some refactoring to pull out common add and remove tag logic so that multiple sessions would need to be initialized when we parallelize the tag update calls. Consequently, AutoTag and TrimTag will no longer use the Tag and Untag actions internally.