### PR TITLE
docs - clarify output directory is required, fix cloudwatch logs docs

### DIFF
--- a/c7n/cli.py
+++ b/c7n/cli.py
@@ -98,7 +98,7 @@ def _default_options(p, blacklist=""):
 
     if 'output-dir' not in blacklist:
         p.add_argument("-s", "--output-dir", required=True,
-                       help="Directory or S3 URL For policy output")
+                       help="[REQUIRED] Directory or S3 URL For policy output")
 
     if 'cache' not in blacklist:
         p.add_argument(

--- a/docs/source/quickstart/index.rst
+++ b/docs/source/quickstart/index.rst
@@ -190,7 +190,7 @@ You can generate metrics by specifying the boolean metrics flag::
 
 You can also upload Cloud Custodian logs to CloudWatch logs::
 
-  $ custodian run --log-group=/cloud-custodian/<dev-account>/<region> <policyfile>.yml
+  $ custodian run --log-group=/cloud-custodian/<dev-account>/<region> -s <output_directory> <policyfile>.yml
 
 And you can output logs and resource records to S3::
 


### PR DESCRIPTION
resolves: https://github.com/capitalone/cloud-custodian/issues/2694