### PR TITLE
aws.emr - fix for metrics filter use legacy cluster id dimension key

### DIFF
--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -20,7 +20,7 @@ import six
 
 from c7n.actions import ActionRegistry, BaseAction
 from c7n.exceptions import PolicyValidationError
-from c7n.filters import FilterRegistry
+from c7n.filters import FilterRegistry, MetricsFilter
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
 from c7n.utils import (
@@ -47,7 +47,6 @@ class EMRCluster(QueryResourceManager):
         enum_spec = ('list_clusters', 'Clusters', {'ClusterStates': cluster_states})
         name = 'Name'
         id = 'Id'
-        dimension = 'ClusterId'
         date = "Status.Timeline.CreationDateTime"
         filter_name = None
 
@@ -118,6 +117,14 @@ class EMRCluster(QueryResourceManager):
                 client.describe_cluster, ClusterId=r['Id'])['Cluster']
             result.append(cluster)
         return result
+
+
+@EMRCluster.filter_registry.register('metrics')
+class EMRMetrics(MetricsFilter):
+
+    def get_dimensions(self, resource):
+        # Job flow id is legacy name for cluster id
+        return [{'Name': 'JobFlowId', 'Value': resource['Id']}]
 
 
 @actions.register('mark-for-op')

--- a/c7n/resources/emr.py
+++ b/c7n/resources/emr.py
@@ -49,6 +49,7 @@ class EMRCluster(QueryResourceManager):
         id = 'Id'
         date = "Status.Timeline.CreationDateTime"
         filter_name = None
+        dimension = None
 
     action_registry = actions
     filter_registry = filters


### PR DESCRIPTION
fixes #2699