### PR TITLE
azure - generate session for function mode from policy context

### DIFF
--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -17,7 +17,6 @@ import logging
 
 from c7n_azure.function_package import FunctionPackage
 from c7n_azure.functionapp_utils import FunctionAppUtilities
-from c7n_azure.session import Session
 from c7n_azure.template_utils import TemplateUtilities
 from c7n_azure.constants import CONST_DOCKER_VERSION, CONST_FUNCTIONS_EXT_VERSION
 
@@ -51,7 +50,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
     def __init__(self, policy):
         self.policy = policy
         self.log = logging.getLogger('custodian.azure.AzureFunctionMode')
-        s = local_session(Session)
+        s = local_session(self.policy.session_factory)
         self.client = s.client('azure.mgmt.web.WebSiteManagementClient')
 
     def run(self, event=None, lambda_context=None):

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -177,4 +177,4 @@ class Session(object):
             'subscription': self.subscription_id
         }
 
-        return json.dumps(auth)
+        return json.dumps(auth, indent=2)


### PR DESCRIPTION
When running in `AzureFunctionMode`, the session needs the auth file information and that context is passed in from the policy's session factory.