### PR TITLE
tags - global resources in resourcegroupstaggingapi must use us-east-1

### DIFF
--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -80,8 +80,16 @@ def universal_augment(self, resources):
     if not resources:
         return resources
 
+    # For global resources, tags don't populate in the get_resources call
+    # unless the call is being made to us-east-1
+    if hasattr(self.resource_type, 'global_resource') \
+       and self.resource_type.global_resource:
+        region = 'us-east-1'
+    else:
+        region = self.region
+
     client = utils.local_session(
-        self.session_factory).client('resourcegroupstaggingapi')
+        self.session_factory).client('resourcegroupstaggingapi', region)
 
     paginator = client.get_paginator('get_resources')
     resource_type = getattr(self.get_model(), 'resource_type', None)

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -82,14 +82,10 @@ def universal_augment(self, resources):
 
     # For global resources, tags don't populate in the get_resources call
     # unless the call is being made to us-east-1
-    if hasattr(self.resource_type, 'global_resource') \
-       and self.resource_type.global_resource:
-        region = 'us-east-1'
-    else:
-        region = self.region
+    region = getattr(self.resource_type, 'global_resource', None) and 'us-east-1' or self.region
 
     client = utils.local_session(
-        self.session_factory).client('resourcegroupstaggingapi', region)
+        self.session_factory).client('resourcegroupstaggingapi', region_name=region)
 
     paginator = client.get_paginator('get_resources')
     resource_type = getattr(self.get_model(), 'resource_type', None)

--- a/tests/data/placebo/test_cloudfront_multi_region/cloudfront.ListDistributions_1.json
+++ b/tests/data/placebo/test_cloudfront_multi_region/cloudfront.ListDistributions_1.json
@@ -1,0 +1,126 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "744a98b8-9ccb-11e8-9b38-89d7b2509a9a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "744a98b8-9ccb-11e8-9b38-89d7b2509a9a",
+                "content-type": "text/xml",
+                "content-length": "2420",
+                "vary": "Accept-Encoding",
+                "date": "Fri, 10 Aug 2018 18:30:26 GMT"
+            },
+            "RetryAttempts": 0
+        },
+        "DistributionList": {
+            "Marker": "",
+            "MaxItems": 100,
+            "IsTruncated": false,
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "E3U7J4TIDRMINY",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E3U7J4TIDRMINY",
+                    "Status": "Deployed",
+                    "LastModifiedTime": {
+                        "__class__": "datetime",
+                        "year": 2018,
+                        "month": 7,
+                        "day": 31,
+                        "hour": 20,
+                        "minute": 33,
+                        "second": 32,
+                        "microsecond": 39000
+                    },
+                    "DomainName": "d1lsmfj2r7hkch.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 0
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "S3-ktravis-test-oscon",
+                                "DomainName": "ktravis-test-oscon.s3.amazonaws.com",
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                }
+                            }
+                        ]
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "S3-ktravis-test-oscon",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "allow-all",
+                        "MinTTL": 0,
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "DefaultTTL": 86400,
+                        "MaxTTL": 31536000,
+                        "Compress": false,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": ""
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 0
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "Comment": "",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": false,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "WebACLId": "",
+                    "HttpVersion": "HTTP2",
+                    "IsIPV6Enabled": true
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_cloudfront_multi_region/cloudfront.ListDistributions_2.json
+++ b/tests/data/placebo/test_cloudfront_multi_region/cloudfront.ListDistributions_2.json
@@ -1,0 +1,126 @@
+{
+    "status_code": 200,
+    "data": {
+        "ResponseMetadata": {
+            "RequestId": "74907bc4-9ccb-11e8-b128-5353f973601a",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "74907bc4-9ccb-11e8-b128-5353f973601a",
+                "content-type": "text/xml",
+                "content-length": "2420",
+                "vary": "Accept-Encoding",
+                "date": "Fri, 10 Aug 2018 18:30:27 GMT"
+            },
+            "RetryAttempts": 0
+        },
+        "DistributionList": {
+            "Marker": "",
+            "MaxItems": 100,
+            "IsTruncated": false,
+            "Quantity": 1,
+            "Items": [
+                {
+                    "Id": "E3U7J4TIDRMINY",
+                    "ARN": "arn:aws:cloudfront::644160558196:distribution/E3U7J4TIDRMINY",
+                    "Status": "Deployed",
+                    "LastModifiedTime": {
+                        "__class__": "datetime",
+                        "year": 2018,
+                        "month": 7,
+                        "day": 31,
+                        "hour": 20,
+                        "minute": 33,
+                        "second": 32,
+                        "microsecond": 39000
+                    },
+                    "DomainName": "d1lsmfj2r7hkch.cloudfront.net",
+                    "Aliases": {
+                        "Quantity": 0
+                    },
+                    "Origins": {
+                        "Quantity": 1,
+                        "Items": [
+                            {
+                                "Id": "S3-ktravis-test-oscon",
+                                "DomainName": "ktravis-test-oscon.s3.amazonaws.com",
+                                "OriginPath": "",
+                                "CustomHeaders": {
+                                    "Quantity": 0
+                                },
+                                "S3OriginConfig": {
+                                    "OriginAccessIdentity": ""
+                                }
+                            }
+                        ]
+                    },
+                    "DefaultCacheBehavior": {
+                        "TargetOriginId": "S3-ktravis-test-oscon",
+                        "ForwardedValues": {
+                            "QueryString": false,
+                            "Cookies": {
+                                "Forward": "none"
+                            },
+                            "Headers": {
+                                "Quantity": 0
+                            },
+                            "QueryStringCacheKeys": {
+                                "Quantity": 0
+                            }
+                        },
+                        "TrustedSigners": {
+                            "Enabled": false,
+                            "Quantity": 0
+                        },
+                        "ViewerProtocolPolicy": "allow-all",
+                        "MinTTL": 0,
+                        "AllowedMethods": {
+                            "Quantity": 2,
+                            "Items": [
+                                "HEAD",
+                                "GET"
+                            ],
+                            "CachedMethods": {
+                                "Quantity": 2,
+                                "Items": [
+                                    "HEAD",
+                                    "GET"
+                                ]
+                            }
+                        },
+                        "SmoothStreaming": false,
+                        "DefaultTTL": 86400,
+                        "MaxTTL": 31536000,
+                        "Compress": false,
+                        "LambdaFunctionAssociations": {
+                            "Quantity": 0
+                        },
+                        "FieldLevelEncryptionId": ""
+                    },
+                    "CacheBehaviors": {
+                        "Quantity": 0
+                    },
+                    "CustomErrorResponses": {
+                        "Quantity": 0
+                    },
+                    "Comment": "",
+                    "PriceClass": "PriceClass_All",
+                    "Enabled": false,
+                    "ViewerCertificate": {
+                        "CloudFrontDefaultCertificate": true,
+                        "MinimumProtocolVersion": "TLSv1",
+                        "CertificateSource": "cloudfront"
+                    },
+                    "Restrictions": {
+                        "GeoRestriction": {
+                            "RestrictionType": "none",
+                            "Quantity": 0
+                        }
+                    },
+                    "WebACLId": "",
+                    "HttpVersion": "HTTP2",
+                    "IsIPV6Enabled": true
+                }
+            ]
+        }
+    }
+}

--- a/tests/data/placebo/test_cloudfront_multi_region/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_cloudfront_multi_region/tagging.GetResources_1.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::644160558196:distribution/E3U7J4TIDRMINY",
+                "Tags": [
+                    {
+                        "Key": "tag",
+                        "Value": "value"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "7474b5e0-9ccb-11e8-b4df-27f7fb5e5118",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "7474b5e0-9ccb-11e8-b4df-27f7fb5e5118",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "167",
+                "date": "Fri, 10 Aug 2018 18:30:27 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_cloudfront_multi_region/tagging.GetResources_2.json
+++ b/tests/data/placebo/test_cloudfront_multi_region/tagging.GetResources_2.json
@@ -1,0 +1,28 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudfront::644160558196:distribution/E3U7J4TIDRMINY",
+                "Tags": [
+                    {
+                        "Key": "tag",
+                        "Value": "value"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "74b170c1-9ccb-11e8-b4df-27f7fb5e5118",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "74b170c1-9ccb-11e8-b4df-27f7fb5e5118",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "167",
+                "date": "Fri, 10 Aug 2018 18:30:27 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}


### PR DESCRIPTION
Global resources only return with the resourcegroupstaggingapi if the region is us-east-1, I wasn't able to find documentation showing this explicitly but I also tested this with hostedzones as well. Hosted Zones and other route53 resources are supported with universal_taggable but actually use a separate tagging function so those tags show up as expected.

```python
Python 3.6.5 (default, Mar 30 2018, 06:41:53)
[GCC 4.2.1 Compatible Apple LLVM 9.0.0 (clang-900.0.39.2)] on darwin
Type "help", "copyright", "credits" or "license" for more information.
>>> import boto3
>>> east_client = boto3.client('resourcegroupstaggingapi', 'us-east-1')
>>> west_client = boto3.client('resourcegroupstaggingapi', 'us-west-2')
>>> east_client.get_resources(ResourceTypeFilters=['cloudfront:distribution'])
{'PaginationToken': '', 'ResourceTagMappingList': [{'ResourceARN': 'arn:aws:cloudfront::644160558196:distribution/E3U7J4TIDRMINY', 'Tags': [{'Key': 'tag', 'Value': 'value'}]}], 'ResponseMetadata': {'RequestId': '2ea4f233-9c18-11e8-ba1c-8f62c9af18e9', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '2ea4f233-9c18-11e8-ba1c-8f62c9af18e9', 'content-type': 'application/x-amz-json-1.1', 'content-length': '167', 'date': 'Thu, 09 Aug 2018 21:07:11 GMT'}, 'RetryAttempts': 0}}
>>> west_client.get_resources(ResourceTypeFilters=['cloudfront:distribution'])
{'PaginationToken': '', 'ResourceTagMappingList': [], 'ResponseMetadata': {'RequestId': '32958d86-9c18-11e8-ba01-b917e4702ba6', 'HTTPStatusCode': 200, 'HTTPHeaders': {'x-amzn-requestid': '32958d86-9c18-11e8-ba01-b917e4702ba6', 'content-type': 'application/x-amz-json-1.1', 'content-length': '50', 'date': 'Thu, 09 Aug 2018 21:07:17 GMT'}, 'RetryAttempts': 0}}
```

