### PR TITLE
azure - Implement extended whitelist option

### DIFF
--- a/docs/source/azure/policy/resources/keyvault.rst
+++ b/docs/source/azure/policy/resources/keyvault.rst
@@ -12,9 +12,12 @@ Filters
     - Tag Filter - Filter on tag presence and/or values
     - Marked-For-Op Filter - Filter on tag that indicates a scheduled operation for a resource
 - Whitelist filter - Filter on whitelist of Service Principals allowed to have a KeyVault access or Service Principals with specified access permissions
-    - You can use `objectId`, `displayName`, `principal_name` for the key
-    - You can specify allowed set of permissions for keys, secrets and certificates
-    - Note: if you use `display_name` or `principal_name`, you need to use azure cli authentication
+    - You can use `objectId`, `displayName`, `principalName` for the key
+    - You can specify allowed set of permissions for keys, secrets and certificates (case insensitive)
+    - Keys permissions: `Get`, `Create`, `Delete`, `List`, `Update`, `Import`, `Backup`, `Restore`, `Recover`, `Decrypt`, `UnwrapKey`, `Encrypt`, `WrapKey`, `Verify`, `Sign`, `Purge`
+    - Secret permissions: `Get`, `List`, `Set`, `Delete`, `Backup`, `Restore`, `Recover`, `Purge`
+    - Certificate permissions: `Get`, `List`, `Delete`, `Create`, `Import`, `Update`, `ManageContacts`, `GetIssuers`, `ListIssuers`, `SetIssuers`, `DeleteIssuers`, `ManageIssuers`, `Recover`, `Backup`, `Restore`, `Purge`
+    - Note: if you use `displayName` or `principalName`, you need to use azure cli authentication
 
 Actions
 -------

--- a/docs/source/azure/policy/resources/keyvault.rst
+++ b/docs/source/azure/policy/resources/keyvault.rst
@@ -11,8 +11,9 @@ Filters
     - Metric Filter - Filter on metrics from Azure Monitor - (see `Key Vault Supported Metrics <https://docs.microsoft.com/en-us/azure/monitoring-and-diagnostics/monitoring-supported-metrics#microsoftkeyvaultvaults/>`_)
     - Tag Filter - Filter on tag presence and/or values
     - Marked-For-Op Filter - Filter on tag that indicates a scheduled operation for a resource
-- Whitelist filter - Filter on whitelist of Service Principals allowed to have a KeyVault access
-    - You can use object_id, `display_name`, `principal_name` for the key
+- Whitelist filter - Filter on whitelist of Service Principals allowed to have a KeyVault access or Service Principals with specified access permissions
+    - You can use `objectId`, `displayName`, `principal_name` for the key
+    - You can specify allowed set of permissions for keys, secrets and certificates
     - Note: if you use `display_name` or `principal_name`, you need to use azure cli authentication
 
 Actions
@@ -73,19 +74,26 @@ This policy will find all KeyVaults with 10 or less API Hits over the last 72 ho
               - type: asq
                 queue: https://accountname.queue.core.windows.net/queuename
 
-This policy will find all KeyVaults with an access of Service Principals not in the white list
+This policy will find all KeyVaults with an access of Service Principals not in the white list that exceed read-only access
 
 .. code-block:: yaml
 
     policies:
         - name: policy
           description:
-            Adds a tag to all virtual machines
+            Ensure only authorized people have an access
           resource: azure.keyvault
           filters:
-            - type: whitelist
-              key: accessPolicies[].principalName
-              op: difference
-              value:
-                - account1@sample.com
-                - account2@sample.com
+            - not:
+              - type: whitelist
+                key: principalName
+                users:
+                  - account1@sample.com
+                  - account2@sample.com
+                permissions:
+                  keys:
+                    - get
+                  secrets:
+                    - get
+                  certificates:
+                    - get

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -76,12 +76,12 @@ class WhiteListFilter(Filter):
         #   - Permissions don't exceed allowed permissions
         for p in i['accessPolicies']:
             if p[self.key] not in self.users:
-                if not self.compare_policies(p['permissions'], self.permissions):
+                if not self.compare_permissions(p['permissions'], self.permissions):
                     return False
         return True
 
     @staticmethod
-    def compare_policies(user_permissions, permissions):
+    def compare_permissions(user_permissions, permissions):
         for v in user_permissions.keys():
             if user_permissions[v]:
                 if v not in permissions.keys():

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -16,7 +16,7 @@ from azure.graphrbac import GraphRbacManagementClient
 from c7n_azure.provider import resources
 from c7n_azure.session import Session
 
-from c7n.filters import ValueFilter
+from c7n.filters import Filter
 from c7n.utils import type_schema
 from c7n_azure.utils import GraphHelper
 
@@ -33,13 +33,23 @@ class KeyVault(ArmResourceManager):
 
 
 @KeyVault.filter_registry.register('whitelist')
-class WhiteListFilter(ValueFilter):
-    schema = type_schema('whitelist', rinherit=ValueFilter.schema)
+class WhiteListFilter(Filter):
+    schema = type_schema('whitelist', rinherit=None,
+                          required=['key'],
+                          key={'type': 'string'},
+                          users={'type':'array'},
+                          permissions={
+                              'certificates': {'type': 'array'},
+                              'secrets': {'type': 'array'},
+                              'keys': {'type': 'array'}})
     graph_client = None
 
     def __init__(self, data, manager=None):
         super(WhiteListFilter, self).__init__(data, manager)
-        self.op = 'difference'
+        self.key = self.data['key']
+        # If not specified, initialize with empty list or dictionary.
+        self.users = self.data.get('users', [])
+        self.permissions = self.data.get('permissions', {})
 
     def __call__(self, i):
         if 'accessPolicies' not in i:
@@ -58,9 +68,33 @@ class WhiteListFilter(ValueFilter):
                         'certificates': policy.permissions.certificates
                     }
                 })
-            # Enhance access policies with display_name, object_type and principal_name
+            # Enhance access policies with displayName, aadType and principalName
             i['accessPolicies'] = self.enhance_policies(access_policies)
-        return super(WhiteListFilter, self).__call__(i)
+
+        # Ensure each policy is
+        #   - User is whitelisted
+        #   - Permissions don't exceed allowed permissions
+        for p in i['accessPolicies']:
+            if p[self.key] not in self.users:
+                if not self.compare_policies(p['permissions'], self.permissions):
+                    return False
+        return True
+
+    @staticmethod
+    def compare_policies(user_permissions, permissions):
+        for v in user_permissions.keys():
+            if user_permissions[v]:
+                if v not in permissions.keys():
+                    # If user_permissions is not empty, but allowed permissions is empty -- Failed.
+                    return False
+                # User lowercase to compare sets
+                lower_user_perm = set([x.lower() for x in user_permissions[v]])
+                lower_perm = set([x.lower() for x in permissions[v]])
+                if lower_user_perm.difference(lower_perm):
+                    # If user has more permissions than allowed -- Failed
+                    return False
+
+        return True
 
     def enhance_policies(self, access_policies):
         if self.graph_client is None:

--- a/tools/c7n_azure/c7n_azure/resources/key_vault.py
+++ b/tools/c7n_azure/c7n_azure/resources/key_vault.py
@@ -35,13 +35,13 @@ class KeyVault(ArmResourceManager):
 @KeyVault.filter_registry.register('whitelist')
 class WhiteListFilter(Filter):
     schema = type_schema('whitelist', rinherit=None,
-                          required=['key'],
-                          key={'type': 'string'},
-                          users={'type':'array'},
-                          permissions={
-                              'certificates': {'type': 'array'},
-                              'secrets': {'type': 'array'},
-                              'keys': {'type': 'array'}})
+                         required=['key'],
+                         key={'type': 'string'},
+                         users={'type': 'array'},
+                         permissions={
+                             'certificates': {'type': 'array'},
+                             'secrets': {'type': 'array'},
+                             'keys': {'type': 'array'}})
     graph_client = None
 
     def __init__(self, data, manager=None):

--- a/tools/c7n_azure/tests/test_keyvault.py
+++ b/tools/c7n_azure/tests/test_keyvault.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from azure_common import BaseTest, arm_template
+from c7n_azure.resources.key_vault import WhiteListFilter
 
 
 class KeyVaultTest(BaseTest):
@@ -34,3 +35,28 @@ class KeyVaultTest(BaseTest):
         })
         resources = p.run()
         self.assertEqual(len(resources), 1)
+
+    def test_compare_permissions(self):
+        p1 = {"keys": ['get'], "secrets": ['get'], "certificates": ['get']}
+        p2 = {"keys": ['Get', 'List'], "secrets": ['Get', 'List'], "certificates": ['Get', 'List']}
+        self.assertTrue(WhiteListFilter.compare_permissions(p1, p2))
+
+        p1 = {"keys": ['delete']}
+        p2 = {"keys": ['Get', 'List'], "secrets": ['Get', 'List'], "certificates": ['Get', 'List']}
+        self.assertFalse(WhiteListFilter.compare_permissions(p1, p2))
+
+        p1 = {"secrets": ['delete']}
+        p2 = {"keys": ['Get', 'List'], "secrets": ['Get', 'List'], "certificates": ['Get', 'List']}
+        self.assertFalse(WhiteListFilter.compare_permissions(p1, p2))
+
+        p1 = {"certificates": ['delete']}
+        p2 = {"keys": ['Get', 'List'], "secrets": ['Get', 'List'], "certificates": ['Get', 'List']}
+        self.assertFalse(WhiteListFilter.compare_permissions(p1, p2))
+
+        p1 = {}
+        p2 = {"keys": ['Get', 'List'], "secrets": ['Get', 'List'], "certificates": ['Get', 'List']}
+        self.assertTrue(WhiteListFilter.compare_permissions(p1, p2))
+
+        p1 = {"keys": ['get'], "secrets": ['get'], "certificates": ['get']}
+        p2 = {}
+        self.assertFalse(WhiteListFilter.compare_permissions(p1, p2))


### PR DESCRIPTION
Add support for minimal allowed permissions level.

Example:
```
policies:
    - name: my-first-policy
      description: |
        Ensure only authorized people have an access
      resource: azure.keyvault
      filters:
          - type: whitelist
            key: principalName
            users: 
              - example@example.com
            permissions:
                keys:
                  - get
                secrets:
                  - get
                certificates:
                  - getn b
```