### PR TITLE
Add support for policy-specific Slack webhooks in c7n_mailer

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -66,6 +66,11 @@ class SlackDelivery(object):
                             self.logger, 'slack_template', 'slack_default')
                 self.logger.debug(
                     "Generating messages for recipient list produced by resource owner resolution.")
+            elif target.startswith('https://hooks.slack.com/'):
+                slack_messages[target] = get_rendered_jinja(
+                    target, sqs_message,
+                    resource_list,
+                    self.logger, 'slack_template', 'slack_default')
             elif target.startswith('slack://webhook/#') and self.config.get('slack_webhook'):
                 webhook_target = self.config.get('slack_webhook')
                 slack_messages[webhook_target] = get_rendered_jinja(
@@ -100,7 +105,7 @@ class SlackDelivery(object):
                 sqs_message['policy']['resource'],
                 str(len(sqs_message['resources'])),
                 sqs_message['action'].get('slack_template', 'slack_default'),
-                json.loads(payload, strict=False)["channel"])
+                key)
             )
 
             self.send_slack_msg(key, payload)

--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -11,7 +11,6 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-import json
 import time
 
 from botocore.vendored import requests

--- a/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py
@@ -166,7 +166,8 @@ class MailerSqsQueueProcessor(object):
         sns_delivery.deliver_sns_messages(sns_message_packages, sqs_message)
 
         # this section sends a notification to the resource owner via Slack
-        if any(e.startswith('slack') for e in sqs_message.get('action', ()).get('to')):
+        if any(e.startswith('slack') or e.startswith('https')
+                for e in sqs_message.get('action', ()).get('to')):
             from .slack_delivery import SlackDelivery
             slack_delivery = SlackDelivery(self.config, self.session, self.logger)
             slack_messages = slack_delivery.get_to_addrs_slack_messages_map(sqs_message)

--- a/tools/c7n_mailer/msg-templates/slack_default.j2
+++ b/tools/c7n_mailer/msg-templates/slack_default.j2
@@ -30,6 +30,8 @@
          ]
       }
    ],
+   {%- if not recipient.startswith('https://') %}
    "channel":"{{ recipient }}",
+   {%- endif -%}
    "username":"Custodian"
 }


### PR DESCRIPTION
This PR resolves #2774 by providing more flexible support for Slack webhooks in the mailer.

Right now if you are using webhooks, the mailer requires a single webhook defined in the `mailer.yaml`.

This PR allows you to specify a webhook as a recipient, so you have the flexibility to have different webhooks on different policies.