### PR TITLE
[tools/omnissm] Change omnissm methods to accept context

### DIFF
--- a/tools/omnissm/Gopkg.lock
+++ b/tools/omnissm/Gopkg.lock
@@ -2,23 +2,28 @@
 
 
 [[projects]]
+  digest = "1:e92f5581902c345eb4ceffdcd4a854fb8f73cf436d47d837d1ec98ef1fe0a214"
   name = "github.com/StackExchange/wmi"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5d049714c4a64225c3c79a7cf7d02f7fb5b96338"
   version = "1.0.0"
 
 [[projects]]
+  digest = "1:fedbb8a7f59025e3022a54965ed1f730b912acb655e503fecbf79fc9df55e304"
   name = "github.com/aws/aws-lambda-go"
   packages = [
     "events",
     "lambda",
     "lambda/messages",
-    "lambdacontext"
+    "lambdacontext",
   ]
-  revision = "4d30d0ff60440c2d0480a15747c96ee71c3c53d4"
-  version = "v1.2.0"
+  pruneopts = "UT"
+  revision = "2d482ef09017ae953b1e8d5a6ddac5b696663a3c"
+  version = "v1.6.0"
 
 [[projects]]
+  digest = "1:8ebe0f06e2a8214e655803ad765899e9ba9b778d2d950705958740ca9b3c53f6"
   name = "github.com/aws/aws-sdk-go"
   packages = [
     "aws",
@@ -31,6 +36,7 @@
     "aws/credentials/ec2rolecreds",
     "aws/credentials/endpointcreds",
     "aws/credentials/stscreds",
+    "aws/csm",
     "aws/defaults",
     "aws/ec2metadata",
     "aws/endpoints",
@@ -39,8 +45,11 @@
     "aws/signer/v4",
     "internal/sdkio",
     "internal/sdkrand",
+    "internal/sdkuri",
     "internal/shareddefaults",
     "private/protocol",
+    "private/protocol/eventstream",
+    "private/protocol/eventstream/eventstreamapi",
     "private/protocol/json/jsonutil",
     "private/protocol/jsonrpc",
     "private/protocol/query",
@@ -61,12 +70,14 @@
     "service/sqs/sqsiface",
     "service/ssm",
     "service/ssm/ssmiface",
-    "service/sts"
+    "service/sts",
   ]
-  revision = "95ba34afe9f6b3e8e10a38c81a51cdffc34f9443"
-  version = "v1.13.51"
+  pruneopts = "UT"
+  revision = "66974140c322f22c1daaf95a18930ea6a9e4d21e"
+  version = "v1.15.16"
 
 [[projects]]
+  digest = "1:0c9d027e6d99e2ad29bde7d311c0c5495fb383550d3020e53ee254df61779043"
   name = "github.com/aws/aws-xray-sdk-go"
   packages = [
     "header",
@@ -76,70 +87,88 @@
     "strategy/ctxmissing",
     "strategy/exception",
     "strategy/sampling",
-    "xray"
+    "xray",
   ]
-  revision = "32670489212454717deeafb8da5dbb1da0299749"
-  version = "v0.9.4"
+  pruneopts = "UT"
+  revision = "9aa851be74b8ccb817f886c4c43cf8da3b0fc61e"
+  version = "v1.0.0-rc.5"
 
 [[projects]]
+  digest = "1:50e893a85575fa48dc4982a279e50e2fd8b74e4f7c587860c1e25c77083b8125"
   name = "github.com/cihub/seelog"
   packages = ["."]
+  pruneopts = "UT"
   revision = "d2c6e5aa9fbfdd1c624e140287063c7730654115"
   version = "v2.6"
 
 [[projects]]
+  digest = "1:abeb38ade3f32a92943e5be54f55ed6d6e3b6602761d74b4aab4c9dd45c18abd"
   name = "github.com/fsnotify/fsnotify"
   packages = ["."]
+  pruneopts = "UT"
   revision = "c2828203cd70a50dcccfb2761f8b1f8ceef9a8e9"
   version = "v1.4.7"
 
 [[projects]]
+  digest = "1:fe8a03a8222d5b913f256972933d26d24ad7c8286692a42943bc01633cc8fce3"
   name = "github.com/go-ini/ini"
   packages = ["."]
-  revision = "6529cf7c58879c08d927016dde4477f18a0634cb"
-  version = "v1.36.0"
+  pruneopts = "UT"
+  revision = "358ee7663966325963d4e8b2e1fbd570c5195153"
+  version = "v1.38.1"
 
 [[projects]]
+  digest = "1:9a91b5e00a46e89442a3cba936266a94e112a8818b4a6b68449ceab93651ce81"
   name = "github.com/go-ole/go-ole"
   packages = [
     ".",
-    "oleutil"
+    "oleutil",
   ]
+  pruneopts = "UT"
   revision = "a41e3c4b706f6ae8dfbff342b06e40fa4d2d0506"
   version = "v1.2.1"
 
 [[projects]]
   branch = "master"
+  digest = "1:c9e7a4b4d47c0ed205d257648b0e5b0440880cb728506e318f8ac7cd36270bc4"
   name = "github.com/golang/time"
   packages = ["rate"]
+  pruneopts = "UT"
   revision = "fbb02b2291d28baffd63558aa44b4b56f178d650"
 
 [[projects]]
+  digest = "1:b787093a6b46cbdb290b2b304d12352eeff1bf7870852c3a0636acf87128c32b"
   name = "github.com/google/go-cmp"
   packages = [
     "cmp",
     "cmp/cmpopts",
     "cmp/internal/diff",
     "cmp/internal/function",
-    "cmp/internal/value"
+    "cmp/internal/value",
   ]
+  pruneopts = "UT"
   revision = "3af367b6b30c263d47e8895973edcca9a49cf029"
   version = "v0.2.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:d1971637b21871ec2033a44ca87c99c5608a7340cb34ec75fab8d2ab503276c9"
   name = "github.com/hashicorp/errwrap"
   packages = ["."]
-  revision = "7554cd9344cec97297fa6649b055a8c98c2a1e55"
+  pruneopts = "UT"
+  revision = "d6c0cd88035724dd42e0f335ae30161c20575ecc"
 
 [[projects]]
   branch = "master"
+  digest = "1:46fb6a9f1b9667f32ac93e08b1da118b2c666991424ea12e848b05d4fe5155ef"
   name = "github.com/hashicorp/go-multierror"
   packages = ["."]
-  revision = "b7773ae218740a7be65057fc60b366a49b538a44"
+  pruneopts = "UT"
+  revision = "3d5d8f294aa03d8e98859feac328afbdf1ae0703"
 
 [[projects]]
   branch = "master"
+  digest = "1:ac64f01acc5eeea9dde40e326de6b6471e501392ec06524c3b51033aa50789bc"
   name = "github.com/hashicorp/hcl"
   packages = [
     ".",
@@ -151,57 +180,73 @@
     "hcl/token",
     "json/parser",
     "json/scanner",
-    "json/token"
+    "json/token",
   ]
+  pruneopts = "UT"
   revision = "ef8a98b0bbce4a65b5aa4c368430a80ddc533168"
 
 [[projects]]
+  digest = "1:870d441fe217b8e689d7949fef6e43efbc787e50f200cb1e70dbca9204a1d6be"
   name = "github.com/inconshreveable/mousetrap"
   packages = ["."]
+  pruneopts = "UT"
   revision = "76626ae9c91c4f2a10f34cad8ce83ea42c93bb75"
   version = "v1.0"
 
 [[projects]]
+  digest = "1:e22af8c7518e1eab6f2eab2b7d7558927f816262586cd6ed9f349c97a6c285c4"
   name = "github.com/jmespath/go-jmespath"
   packages = ["."]
+  pruneopts = "UT"
   revision = "0b12d6b5"
 
 [[projects]]
+  digest = "1:c568d7727aa262c32bdf8a3f7db83614f7af0ed661474b24588de635c20024c7"
   name = "github.com/magiconair/properties"
   packages = ["."]
-  revision = "c3beff4c2358b44d0493c7dda585e7db7ff28ae6"
-  version = "v1.7.6"
+  pruneopts = "UT"
+  revision = "c2353362d570a7bfa228149c62842019201cfb71"
+  version = "v1.8.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:5ab79470a1d0fb19b041a624415612f8236b3c06070161a910562f2b2d064355"
   name = "github.com/mitchellh/mapstructure"
   packages = ["."]
-  revision = "bb74f1db0675b241733089d5a1faa5dd8b0ef57b"
+  pruneopts = "UT"
+  revision = "f15292f7a699fcc1a38a80977f80a046874ba8ac"
 
 [[projects]]
+  digest = "1:95741de3af260a92cc5c7f3f3061e85273f5a81b5db20d4bd68da74bd521675e"
   name = "github.com/pelletier/go-toml"
   packages = ["."]
-  revision = "acdc4509485b587f5e675510c4f2c63e90ff68a8"
-  version = "v1.1.0"
+  pruneopts = "UT"
+  revision = "c01d1270ff3e442a8a57cddc1c92dc1138598194"
+  version = "v1.2.0"
 
 [[projects]]
+  digest = "1:40e195917a951a8bf867cd05de2a46aaf1806c50cf92eebf4c16f78cd196f747"
   name = "github.com/pkg/errors"
   packages = ["."]
+  pruneopts = "UT"
   revision = "645ef00459ed84a119197bfb8d8205042c6df63d"
   version = "v0.8.0"
 
 [[projects]]
+  digest = "1:980859d742d8c0066b562951ed7016e7d0a0c475e333830658f5979d19fd9ce0"
   name = "github.com/rs/zerolog"
   packages = [
     ".",
     "internal/cbor",
     "internal/json",
-    "log"
+    "log",
   ]
-  revision = "05eafee0eb17d0150591a8f30f0fa592cc9b7471"
-  version = "v1.6.0"
+  pruneopts = "UT"
+  revision = "77db4b4f350e31be66a57c332acb7721cf9ff9bb"
+  version = "v1.8.0"
 
 [[projects]]
+  digest = "1:f4a9e438baff16c141330596e5595c43d315daf37fa34136114e1f0c23e9a704"
   name = "github.com/shirou/gopsutil"
   packages = [
     "cpu",
@@ -209,78 +254,100 @@
     "internal/common",
     "mem",
     "net",
-    "process"
+    "process",
   ]
-  revision = "c95755e4bcd7a62bb8bd33f3a597a7c7f35e2cf3"
-  version = "v2.18.04"
+  pruneopts = "UT"
+  revision = "8048a2e9c5773235122027dd585cf821b2af1249"
+  version = "v2.18.07"
 
 [[projects]]
   branch = "master"
+  digest = "1:99c6a6dab47067c9b898e8c8b13d130c6ab4ffbcc4b7cc6236c2cd0b1e344f5b"
   name = "github.com/shirou/w32"
   packages = ["."]
+  pruneopts = "UT"
   revision = "bb4de0191aa41b5507caa14b0650cdbddcd9280b"
 
 [[projects]]
+  digest = "1:37ace7f35375adec11634126944bdc45a673415e2fcc07382d03b75ec76ea94c"
   name = "github.com/spf13/afero"
   packages = [
     ".",
-    "mem"
+    "mem",
   ]
-  revision = "63644898a8da0bc22138abf860edaf5277b6102e"
-  version = "v1.1.0"
+  pruneopts = "UT"
+  revision = "787d034dfe70e44075ccc060d346146ef53270ad"
+  version = "v1.1.1"
 
 [[projects]]
+  digest = "1:516e71bed754268937f57d4ecb190e01958452336fa73dbac880894164e91c1f"
   name = "github.com/spf13/cast"
   packages = ["."]
+  pruneopts = "UT"
   revision = "8965335b8c7107321228e3e3702cab9832751bac"
   version = "v1.2.0"
 
 [[projects]]
+  digest = "1:872fa275c31e1f9db31d66fa9b1d4a7bb9a080ff184e6977da01f36bfbe07f11"
   name = "github.com/spf13/cobra"
   packages = ["."]
-  revision = "a1f051bc3eba734da4772d60e2d677f47cf93ef4"
-  version = "v0.0.2"
+  pruneopts = "UT"
+  revision = "ef82de70bb3f60c65fb8eebacbb2d122ef517385"
+  version = "v0.0.3"
 
 [[projects]]
   branch = "master"
+  digest = "1:8a020f916b23ff574845789daee6818daf8d25a4852419aae3f0b12378ba432a"
   name = "github.com/spf13/jwalterweatherman"
   packages = ["."]
-  revision = "7c0cea34c8ece3fbeb2b27ab9b59511d360fb394"
+  pruneopts = "UT"
+  revision = "14d3d4c518341bea657dd8a226f5121c0ff8c9f2"
 
 [[projects]]
+  digest = "1:dab83a1bbc7ad3d7a6ba1a1cc1760f25ac38cdf7d96a5cdd55cd915a4f5ceaf9"
   name = "github.com/spf13/pflag"
   packages = ["."]
-  revision = "583c0c0531f06d5278b7d917446061adc344b5cd"
-  version = "v1.0.1"
-
-[[projects]]
-  name = "github.com/spf13/viper"
-  packages = ["."]
-  revision = "b5e8006cbee93ec955a89ab31e0e3ce3204f3736"
+  pruneopts = "UT"
+  revision = "9a97c102cda95a86cec2345a6f09f55a939babf5"
   version = "v1.0.2"
 
 [[projects]]
-  branch = "master"
-  name = "golang.org/x/net"
-  packages = ["context"]
-  revision = "db08ff08e8622530d9ed3a0e8ac279f6d4c02196"
+  digest = "1:4fc8a61287ccfb4286e1ca5ad2ce3b0b301d746053bf44ac38cf34e40ae10372"
+  name = "github.com/spf13/viper"
+  packages = ["."]
+  pruneopts = "UT"
+  revision = "907c19d40d9a6c9bb55f040ff4ae45271a4754b9"
+  version = "v1.1.0"
 
 [[projects]]
   branch = "master"
+  digest = "1:76ee51c3f468493aff39dbacc401e8831fbb765104cbf613b89bef01cf4bad70"
+  name = "golang.org/x/net"
+  packages = ["context"]
+  pruneopts = "UT"
+  revision = "922f4815f713f213882e8ef45e0d315b164d705c"
+
+[[projects]]
+  branch = "master"
+  digest = "1:39ebcc2b11457b703ae9ee2e8cca0f68df21969c6102cb3b705f76cca0ea0239"
   name = "golang.org/x/sync"
   packages = ["errgroup"]
+  pruneopts = "UT"
   revision = "1d60e4601c6fd243af51cc01ddf169918a5407ca"
 
 [[projects]]
   branch = "master"
+  digest = "1:a24bb054be8b6c178245bff34e3178e24c97b3ee1f285dab5c71d0f1373a4f7f"
   name = "golang.org/x/sys"
   packages = [
     "unix",
-    "windows"
+    "windows",
   ]
-  revision = "d0faeb539838e250bd0a9db4182d48d4a1915181"
+  pruneopts = "UT"
+  revision = "3b58ed4ad3395d483fc92d5d14123ce2c3581fec"
 
 [[projects]]
+  digest = "1:038003d098ffc345c4c5c6d47bcc6920b2649ee0c0d557162e54e75c76cadf8b"
   name = "golang.org/x/text"
   packages = [
     "internal/gen",
@@ -288,20 +355,57 @@
     "internal/ucd",
     "transform",
     "unicode/cldr",
-    "unicode/norm"
+    "unicode/norm",
   ]
+  pruneopts = "UT"
   revision = "f21a4dfb5e38f5895301dc265a8def02365cc3d0"
   version = "v0.3.0"
 
 [[projects]]
+  digest = "1:342378ac4dcb378a5448dd723f0784ae519383532f5e70ade24132c4c8693202"
   name = "gopkg.in/yaml.v2"
   packages = ["."]
+  pruneopts = "UT"
   revision = "5420a8b6744d3b0345ab293f6fcba19c978f1183"
   version = "v2.2.1"
 
 [solve-meta]
   analyzer-name = "dep"
   analyzer-version = 1
-  inputs-digest = "d32c52836e203055c7e9af6f85bc7698ce8ff9c2b9a0a64f4c935543952063b2"
+  input-imports = [
+    "github.com/aws/aws-lambda-go/events",
+    "github.com/aws/aws-lambda-go/lambda",
+    "github.com/aws/aws-sdk-go/aws",
+    "github.com/aws/aws-sdk-go/aws/awserr",
+    "github.com/aws/aws-sdk-go/aws/credentials/stscreds",
+    "github.com/aws/aws-sdk-go/aws/request",
+    "github.com/aws/aws-sdk-go/aws/session",
+    "github.com/aws/aws-sdk-go/service/configservice",
+    "github.com/aws/aws-sdk-go/service/configservice/configserviceiface",
+    "github.com/aws/aws-sdk-go/service/dynamodb",
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbattribute",
+    "github.com/aws/aws-sdk-go/service/dynamodb/dynamodbiface",
+    "github.com/aws/aws-sdk-go/service/s3",
+    "github.com/aws/aws-sdk-go/service/s3/s3iface",
+    "github.com/aws/aws-sdk-go/service/sns",
+    "github.com/aws/aws-sdk-go/service/sns/snsiface",
+    "github.com/aws/aws-sdk-go/service/sqs",
+    "github.com/aws/aws-sdk-go/service/sqs/sqsiface",
+    "github.com/aws/aws-sdk-go/service/ssm",
+    "github.com/aws/aws-sdk-go/service/ssm/ssmiface",
+    "github.com/aws/aws-xray-sdk-go/xray",
+    "github.com/golang/time/rate",
+    "github.com/google/go-cmp/cmp",
+    "github.com/google/go-cmp/cmp/cmpopts",
+    "github.com/hashicorp/go-multierror",
+    "github.com/pkg/errors",
+    "github.com/rs/zerolog",
+    "github.com/rs/zerolog/log",
+    "github.com/shirou/gopsutil/process",
+    "github.com/spf13/cobra",
+    "github.com/spf13/viper",
+    "golang.org/x/sync/errgroup",
+    "gopkg.in/yaml.v2",
+  ]
   solver-name = "gps-cdcl"
   solver-version = 1

--- a/tools/omnissm/Gopkg.toml
+++ b/tools/omnissm/Gopkg.toml
@@ -30,6 +30,10 @@
   version = "1.2.0"
 
 [[constraint]]
+  name = "github.com/aws/aws-xray-sdk-go"
+  version = "1.0.0-rc.1"
+
+[[constraint]]
   name = "github.com/pkg/errors"
   version = "0.8.0"
 

--- a/tools/omnissm/pkg/aws/configservice/configservice.go
+++ b/tools/omnissm/pkg/aws/configservice/configservice.go
@@ -57,9 +57,9 @@ func New(config *Config) *ConfigService {
 	return c
 }
 
-func (c *ConfigService) GetLatestResourceConfig(resourceType, resourceId string) (*ConfigurationItem, error) {
-	c.configServiceRate.Wait(context.TODO())
-	resp, err := c.ConfigServiceAPI.GetResourceConfigHistoryWithContext(context.TODO(), &configservice.GetResourceConfigHistoryInput{
+func (c *ConfigService) GetLatestResourceConfig(ctx context.Context, resourceType, resourceId string) (*ConfigurationItem, error) {
+	c.configServiceRate.Wait(ctx)
+	resp, err := c.ConfigServiceAPI.GetResourceConfigHistoryWithContext(ctx, &configservice.GetResourceConfigHistoryInput{
 		ResourceId:   aws.String(resourceId),
 		ResourceType: aws.String(resourceType),
 		Limit:        aws.Int64(1),
@@ -100,7 +100,7 @@ func min(a, b int) int {
 	return b
 }
 
-func (c *ConfigService) BatchGetResourceConfig(resources map[string]string) ([]*ConfigurationItem, error) {
+func (c *ConfigService) BatchGetResourceConfig(ctx context.Context, resources map[string]string) ([]*ConfigurationItem, error) {
 	resourceKeys := make([]*configservice.ResourceKey, 0)
 	for k, v := range resources {
 		resourceKeys = append(resourceKeys, &configservice.ResourceKey{ResourceId: aws.String(k), ResourceType: aws.String(v)})
@@ -111,7 +111,7 @@ func (c *ConfigService) BatchGetResourceConfig(resources map[string]string) ([]*
 	for i := 0; i < len(resourceKeys); i += 100 {
 		batchResourceKeys := resourceKeys[i:min(i+100, len(resourceKeys))]
 		g.Go(func() error {
-			configurationItems, err := c.batchGetResourceConfig(batchResourceKeys)
+			configurationItems, err := c.batchGetResourceConfig(ctx, batchResourceKeys)
 			if err != nil {
 				return err
 			}
@@ -127,9 +127,9 @@ func (c *ConfigService) BatchGetResourceConfig(resources map[string]string) ([]*
 	return items, nil
 }
 
-func (c *ConfigService) batchGetResourceConfig(resourceKeys []*configservice.ResourceKey) ([]*ConfigurationItem, error) {
-	c.configServiceRate.Wait(context.TODO())
-	resp, err := c.ConfigServiceAPI.BatchGetResourceConfigWithContext(context.TODO(), &configservice.BatchGetResourceConfigInput{
+func (c *ConfigService) batchGetResourceConfig(ctx context.Context, resourceKeys []*configservice.ResourceKey) ([]*ConfigurationItem, error) {
+	c.configServiceRate.Wait(ctx)
+	resp, err := c.ConfigServiceAPI.BatchGetResourceConfigWithContext(ctx, &configservice.BatchGetResourceConfigInput{
 		ResourceKeys: resourceKeys,
 	})
 	if err != nil {

--- a/tools/omnissm/pkg/aws/s3/s3.go
+++ b/tools/omnissm/pkg/aws/s3/s3.go
@@ -51,13 +51,13 @@ func New(config *Config) *S3 {
 	return s
 }
 
-func (s *S3) GetObject(path string) ([]byte, error) {
+func (s *S3) GetObject(ctx context.Context, path string) ([]byte, error) {
 	u, err := ParseURL(path)
 	if err != nil {
 		return nil, err
 	}
-	s.getRate.Wait(context.TODO())
-	resp, err := s.S3API.GetObjectWithContext(context.TODO(), &s3.GetObjectInput{
+	s.getRate.Wait(ctx)
+	resp, err := s.S3API.GetObjectWithContext(ctx, &s3.GetObjectInput{
 		Bucket: aws.String(u.Bucket),
 		Key:    aws.String(u.Path),
 	})

--- a/tools/omnissm/pkg/aws/sns/sns.go
+++ b/tools/omnissm/pkg/aws/sns/sns.go
@@ -52,8 +52,8 @@ func New(config *Config) *SNS {
 	return s
 }
 
-func (s *SNS) Publish(topicArn string, msg []byte) error {
-	_, err := s.SNSAPI.PublishWithContext(context.TODO(), &sns.PublishInput{
+func (s *SNS) Publish(ctx context.Context, topicArn string, msg []byte) error {
+	_, err := s.SNSAPI.PublishWithContext(ctx, &sns.PublishInput{
 		Message:  aws.String(string(msg)),
 		TopicArn: aws.String(topicArn),
 	})

--- a/tools/omnissm/pkg/aws/sqs/sqs.go
+++ b/tools/omnissm/pkg/aws/sqs/sqs.go
@@ -58,12 +58,12 @@ func New(config *Config) (*SQS, error) {
 	return s, nil
 }
 
-func (s *SQS) Send(m json.Marshaler) error {
+func (s *SQS) Send(ctx context.Context, m json.Marshaler) error {
 	data, err := json.Marshal(m)
 	if err != nil {
 		return errors.Wrap(err, "cannot marshal SQS message")
 	}
-	_, err = s.SQSAPI.SendMessageWithContext(context.TODO(), &sqs.SendMessageInput{
+	_, err = s.SQSAPI.SendMessageWithContext(ctx, &sqs.SendMessageInput{
 		MessageBody: aws.String(string(data)),
 		QueueUrl:    aws.String(s.config.QueueURL),
 	})
@@ -91,8 +91,8 @@ func parseUnixTime(s string) time.Time {
 	return time.Unix(0, ms*int64(time.Millisecond))
 }
 
-func (s *SQS) Receive() ([]*Message, error) {
-	resp, err := s.SQSAPI.ReceiveMessageWithContext(context.TODO(), &sqs.ReceiveMessageInput{
+func (s *SQS) Receive(ctx context.Context) ([]*Message, error) {
+	resp, err := s.SQSAPI.ReceiveMessageWithContext(ctx, &sqs.ReceiveMessageInput{
 
 		AttributeNames:      aws.StringSlice([]string{"All"}),
 		QueueUrl:            aws.String(s.config.QueueURL),
@@ -122,8 +122,8 @@ func (s *SQS) Receive() ([]*Message, error) {
 	return messages, nil
 }
 
-func (s *SQS) Delete(receiptHandle string) error {
-	_, err := s.SQSAPI.DeleteMessageWithContext(context.TODO(), &sqs.DeleteMessageInput{
+func (s *SQS) Delete(ctx context.Context, receiptHandle string) error {
+	_, err := s.SQSAPI.DeleteMessageWithContext(ctx, &sqs.DeleteMessageInput{
 		QueueUrl:      aws.String(s.config.QueueURL),
 		ReceiptHandle: aws.String(receiptHandle),
 	})

--- a/tools/omnissm/pkg/omnissm/config.go
+++ b/tools/omnissm/pkg/omnissm/config.go
@@ -15,6 +15,7 @@
 package omnissm
 
 import (
+	"context"
 	"fmt"
 	"io/ioutil"
 	"os"
@@ -30,6 +31,8 @@ const DefaultSSMServiceRole = "service-role/AmazonEC2RunCommandRoleForManagedIns
 
 type Config struct {
 	*aws.Config
+
+	Context context.Context
 
 	// A whitelist of accounts allowed to register with SSM
 	AccountWhitelist []string `yaml:"accountWhitelist"`


### PR DESCRIPTION
For AWS X-Ray to work in a lambda function, the context provided to the handler must be passed in to all tracked AWS SDK calls, by default if context values are not present, the function will panic when tracing is enabled.