### PR TITLE
azure - change azure-functions docker image pinned tag

### DIFF
--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -1,2 +1,2 @@
-CONST_DOCKER_VERSION = 'DOCKER|microsoft/azure-functions-python3.6:v2.0.11933-alpha'
+CONST_DOCKER_VERSION = 'DOCKER|mcr.microsoft.com/azure-functions/python:latest'
 CONST_FUNCTIONS_EXT_VERSION = 'beta'

--- a/tools/c7n_azure/c7n_azure/constants.py
+++ b/tools/c7n_azure/c7n_azure/constants.py
@@ -1,2 +1,3 @@
+# Docker image versions available at https://hub.docker.com/r/microsoft/azure-functions/
 CONST_DOCKER_VERSION = 'DOCKER|mcr.microsoft.com/azure-functions/python:latest'
 CONST_FUNCTIONS_EXT_VERSION = 'beta'

--- a/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.parameters.json
+++ b/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.parameters.json
@@ -27,7 +27,7 @@
             "value": "B1"
         },
         "dockerVersion": {
-            "value": "DOCKER|microsoft/azure-functions-python3.6:v2.0.11933-alpha"
+            "value": "DOCKER|mcr.microsoft.com/azure-functions/python:latest"
         },
         "functionsExtVersion": {
             "value": "beta"

--- a/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.test.parameters.json
+++ b/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.test.parameters.json
@@ -27,7 +27,7 @@
             "value": "B1"
         },
         "dockerVersion": {
-            "value": "DOCKER|microsoft/azure-functions-python3.6:v2.0.11933-alpha"
+            "value": "DOCKER|mcr.microsoft.com/azure-functions/python:latest"
         },
         "functionsExtVersion": {
             "value": "beta"


### PR DESCRIPTION
- Need to use the `latest` docker image tag from MCR registry because pinned version tags were being deleted.
- https://hub.docker.com/r/microsoft/azure-functions/