### PR TITLE
tools/omnissm - fix config event unmarshaling issue

### DIFF
--- a/tools/omnissm/pkg/aws/configservice/configitem.go
+++ b/tools/omnissm/pkg/aws/configservice/configitem.go
@@ -101,7 +101,6 @@ type ConfigurationState string
 
 func (s *ConfigurationState) UnmarshalJSON(b []byte) (err error) {
 	var st struct {
-		Code int    `json:"code"`
 		Name string `json:"name"`
 	}
 	err = json.Unmarshal(b, &st)

--- a/tools/omnissm/pkg/aws/configservice/configitem_test.go
+++ b/tools/omnissm/pkg/aws/configservice/configitem_test.go
@@ -17,6 +17,7 @@ package configservice
 import (
 	"encoding/json"
 	"testing"
+	"time"
 )
 
 var oversizedConfigurationItem = `{
@@ -81,7 +82,7 @@ var configurationItemChange = `{
                 "keyName": "my-key-name",
                 "launchTime": "2018-05-02T16:18:05.000Z",
                 "state": {
-                    "code": 16,
+                    "code": 16.0,
                     "name": "running"
                 },
                 "subnetId": "subnet-12345678",
@@ -175,6 +176,97 @@ func TestConfigurationStateNull(t *testing.T) {
 		t.Fatal(err)
 	}
 	if ev.Detail.ConfigurationItem.Configuration.State != "" {
-		t.Error("expected \"\", received: %#V", ev.Detail.ConfigurationItem.Configuration.State)
+		t.Errorf("expected \"\", received: %#v", ev.Detail.ConfigurationItem.Configuration.State)
+	}
+}
+
+var configurationItemChangeStateString = `{
+    "version": "0",
+    "id": "11111111-2222-3333-4444-555555555555",
+    "detail-type": "Config Configuration Item Change",
+    "source": "aws.config",
+    "account": "123456789012",
+    "time": "2018-05-02T16:20:56Z",
+    "region": "us-east-1",
+    "resources": [
+        "arn:aws:ec2:us-east-1:123456789012:instance/i-12345678901234567"
+    ],
+    "detail": {
+        "recordVersion": "1.3",
+        "messageType": "ConfigurationItemChangeNotification",
+        "configurationItemDiff": {
+            "changedProperties": {},
+            "changeType": "CREATE"
+        },
+        "notificationCreationTime": "2018-05-02T16:20:56.017Z",
+        "configurationItem": {
+            "configuration": {
+                "imageId": "ami-12345678",
+                "instanceId": "i-12345678901234567",
+				"platform": "Linux",
+                "instanceType": "t2.small",
+                "keyName": "my-key-name",
+                "launchTime": "2018-05-02T16:18:05.000Z",
+				"state": "state-string",
+                "subnetId": "subnet-12345678",
+                "vpcId": "vpc-12345678",
+                "iamInstanceProfile": {
+                    "arn": "arn:aws:iam::123456789012:instance-profile/EC2InstanceProfileRole",
+                    "id": "ABCDEFGHIJKLMNOPQSTUV"
+                }
+            },
+            "supplementaryConfiguration": {},
+            "tags": {
+                "Name": "ec2-instance-name"
+            },
+            "configurationItemVersion": "1.3",
+            "configurationItemCaptureTime": "2018-05-02T16:20:55.108Z",
+            "configurationStateId": 1525278055108,
+            "awsAccountId": "123456789012",
+            "configurationItemStatus": "ResourceDiscovered",
+            "resourceType": "AWS::EC2::Instance",
+            "resourceId": "i-12345678901234567",
+            "ARN": "arn:aws:ec2:us-east-1:123456789012:instance/i-12345678901234567",
+            "awsRegion": "us-east-1",
+            "availabilityZone": "us-east-1b",
+            "configurationStateMd5Hash": "",
+            "resourceCreationTime": "2018-05-02T16:18:05.000Z"
+        }
+    }
+}`
+
+func TestConfigurationStateString(t *testing.T) {
+	var ev struct {
+		Detail CloudWatchEventDetail `json:"detail"`
+	}
+	err := json.Unmarshal([]byte(configurationItemChangeStateString), &ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := ConfigurationState("state-string")
+	if ev.Detail.ConfigurationItem.Configuration.State != expected {
+		t.Errorf("expected %#v, received: %#v", expected, ev.Detail.ConfigurationItem.Configuration.State)
+	}
+}
+
+func TestConfigurationStateObject(t *testing.T) {
+	var ev struct {
+		Version    string                `json:"version"`
+		ID         string                `json:"id"`
+		DetailType string                `json:"detail-type"`
+		Source     string                `json:"source"`
+		AccountId  string                `json:"account"`
+		Time       time.Time             `json:"time"`
+		Region     string                `json:"region"`
+		Resources  []string              `json:"resources"`
+		Detail     CloudWatchEventDetail `json:"detail"`
+	}
+	err := json.Unmarshal([]byte(configurationItemChange), &ev)
+	if err != nil {
+		t.Fatal(err)
+	}
+	expected := ConfigurationState("running")
+	if ev.Detail.ConfigurationItem.Configuration.State != expected {
+		t.Errorf("expected %#v, received: %#v", expected, ev.Detail.ConfigurationItem.Configuration.State)
 	}
 }


### PR DESCRIPTION
ConfigurationItem events already needed special handling because the
"state" field could be either null, a string, or an object containing
fields "code" and "name". However, the object's "code" field could also
be present in the event payload as a float (i.e. "16.0" rather than
"16") - this caused an unclear error message to be generated during
function startup when the event body was unmarshaled. Because the "code"
field is not currently being used, it has been removed from the
intermediary struct type.