### PR TITLE
variable interpolation handle regex index via pass through

### DIFF
--- a/c7n/utils.py
+++ b/c7n/utils.py
@@ -481,7 +481,7 @@ def set_value_from_jmespath(source, expression, value, is_first=True):
     source[current_key] = value
 
 
-def format_string_values(obj, *args, **kwargs):
+def format_string_values(obj, err_fallback=(IndexError,), *args, **kwargs):
     """
     Format all string values in an object.
     Return the updated object
@@ -497,7 +497,10 @@ def format_string_values(obj, *args, **kwargs):
             new.append(format_string_values(item, *args, **kwargs))
         return new
     elif isinstance(obj, six.string_types):
-        return obj.format(*args, **kwargs)
+        try:
+            return obj.format(*args, **kwargs)
+        except err_fallback as e:
+            return obj
     else:
         return obj
 

--- a/tests/test_utils.py
+++ b/tests/test_utils.py
@@ -390,3 +390,9 @@ class UtilTest(unittest.TestCase):
         self.assertEqual(fmt["Key3"], "aa")
         self.assertEqual(fmt["Key4"][2], "aa")
         self.assertEqual(fmt["Key4"][1]["K"], "bb")
+
+        self.assertEqual(
+            utils.format_string_values(
+                {'k': '{1}'}),
+            {'k': '{1}'})
+                


### PR DESCRIPTION
the universal/generic variable interpolation caused some issues with value filter regex expressions in a few contexts, handle those by returning the non interpolated value as a fallback.