### PR TITLE
Dockerize c7n_mailer

### DIFF
--- a/tools/c7n_mailer/Dockerfile
+++ b/tools/c7n_mailer/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.6-alpine
+
+RUN apk add --no-cache git
+RUN git clone https://github.com/capitalone/cloud-custodian --depth=1 && \
+    cd cloud-custodian && \
+    pip install -e .
+RUN cd cloud-custodian/tools/c7n_mailer && \
+    pip install -r ./requirements.txt && \
+    pip install -e .
+ENTRYPOINT ["c7n-mailer"]

--- a/tools/c7n_mailer/README-docker.md
+++ b/tools/c7n_mailer/README-docker.md
@@ -1,0 +1,27 @@
+
+# Cloud Custodian Mailer
+
+The Cloud Custodian [`c7n_mailer`](https://github.com/capitalone/cloud-custodian/tree/master/tools/c7n_mailer) is a simple tool for sending notifications with [Cloud Custodian](https://github.com/capitalone/cloud-custodian). This image allows you to run the `c7n_mailer` purely in a Docker container, avoiding the need to install Python requirements.
+
+# How to use this image
+
+The basic command *without Docker* is:
+
+```console
+$ c7n-mailer --update-lambda -c /tmp/mailer.yaml
+```
+
+So all we need to do is:
+
+* Map a volume for the `mailer.yaml`
+* Make sure we pass AWS credentials
+
+## Run c7n-mailer
+
+This single command passes both `~/.aws` and environment variables for AWS credentials. You can pick one or the other, but it's just convenient to pass both.
+
+```console
+$ run --rm --env AWS_SESSION_TOKEN=$AWS_SESSION_TOKEN --env AWS_DEFAULT_REGION=$AWS_DEFAULT_REGION --env AWS_ACCESS_KEY_ID=$AWS_ACCESS_KEY_ID --env AWS_SECRET_ACCESS_KEY=$AWS_SECRET_ACCESS_KEY -v ~/.aws:/root/.aws -v /tmp:/tmp troylar/c7n-mailer:latest --update-lambda -c /tmp/mailer.yaml
+```
+
+> NOTE: The path doesn't have to be `/tmp`. That's just an example. Just replace `/tmp` with your actual path in `-v /tmp:/tmp`.

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -18,7 +18,7 @@ should be cross-account enabled for sending between accounts.
 Our goal in starting out with the Custodian mailer is to install the mailer,
 and run a policy that triggers an email to your inbox.
 
-1. [Install](#developer-install-os-x-el-capitan) the mailer on your laptop.
+1. [Install](#developer-install-os-x-el-capitan) the mailer on your laptop (if you are not running as a [Docker container](https://hub.docker.com/r/troylar/c7n-mailer/))
 1. In your text editor, create a `mailer.yml` file to hold your mailer config.
 1. In the AWS console, create a new standard SQS queue (quick create is fine).
    Copy the queue URL to `queue_url` in `mailer.yml`.

--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -4,6 +4,7 @@ A mailer implementation for Custodian. Outbound mail delivery is still somewhat
 organization-specific, so this at the moment serves primarily as an example
 implementation.
 
+> The Cloud Custodian Mailer can now be easily run in a Docker container. Click [here](https://hub.docker.com/r/troylar/c7n-mailer/) for details.
 
 ## Message Relay
 


### PR DESCRIPTION
This PR resolves #2812 by providing a Dockerfile for c7n-mailer, so that it can run without installing requirements.

I've also created a Docker Hub repo here with instructions:

https://hub.docker.com/r/troylar/c7n-mailer/
