### PR TITLE
tools/omnissm - small refactor of lambda code

### DIFF
--- a/tools/omnissm/functions/enrich-registrations/main.go
+++ b/tools/omnissm/functions/enrich-registrations/main.go
@@ -103,19 +103,21 @@ func main() {
 							}
 							tags[k] = v
 						}
-						if err := omni.SQS.Send(ctx, &omnissm.DeferredActionMessage{
+						err := omni.SQS.Send(ctx, &omnissm.DeferredActionMessage{
 							Type: omnissm.AddTagsToResource,
 							Value: &ssm.ResourceTags{
 								ManagedId: entry.ManagedId,
 								Tags:      tags,
 							},
-						}); err != nil {
+						})
+						if err == nil {
+							i++
+						} else {
 							log.Info().Err(err).Msg("unable to defer AddTagsToResource")
 						}
-						i++
 					}
 					if !entry.IsInventoried {
-						if err := omni.SQS.Send(ctx, &omnissm.DeferredActionMessage{
+						err := omni.SQS.Send(ctx, &omnissm.DeferredActionMessage{
 							Type: omnissm.PutInventory,
 							Value: &ssm.CustomInventory{
 								TypeName:    "Custom:CloudInfo",
@@ -123,16 +125,20 @@ func main() {
 								CaptureTime: ci.ConfigurationItemCaptureTime,
 								Content:     configservice.ConfigurationItemContentMap(*ci),
 							},
-						}); err != nil {
+						})
+						if err == nil {
+							j++
+						} else {
 							log.Info().Err(err).Msg("unable to defer PutInventory")
 						}
-						j++
 					}
 				}
-				log.Info().Str("accountId", accountId).
-					Int("AddTagsToResource", i).
-					Int("PutInventory", j).
-					Msg("enqueued deferred actions")
+				if i+j > 0 {
+					log.Info().Str("accountId", accountId).
+						Int("AddTagsToResource", i).
+						Int("PutInventory", j).
+						Msg("enqueued deferred actions")
+				}
 			}(omni.Config.Copy().WithRegion(region), accountId, entries)
 		}
 		wg.Wait()

--- a/tools/omnissm/functions/handle-registrations/main.go
+++ b/tools/omnissm/functions/handle-registrations/main.go
@@ -18,14 +18,12 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
-	"time"
 
 	"github.com/aws/aws-lambda-go/events"
-	"github.com/aws/aws-sdk-go/aws/request"
-	"github.com/pkg/errors"
 	"github.com/rs/zerolog/log"
 
 	"github.com/capitalone/cloud-custodian/tools/omnissm/pkg/aws/lambda"
+	"github.com/capitalone/cloud-custodian/tools/omnissm/pkg/aws/ssm"
 	"github.com/capitalone/cloud-custodian/tools/omnissm/pkg/omnissm"
 )
 
@@ -34,59 +32,26 @@ type registrationHandler struct {
 }
 
 func (r *registrationHandler) RequestActivation(ctx context.Context, req *omnissm.RegistrationRequest) (*omnissm.RegistrationResponse, error) {
-	logger := log.With().Str("handler", "CreateRegistration").Logger()
+	logger := log.With().Str("handler", "RequestActivation").Logger()
 	logger.Info().Interface("identity", req.Identity()).Msg("new registration request")
-	entry, err, ok := r.OmniSSM.Registrations.Get(ctx, req.Identity().Hash())
+	resp, err := r.OmniSSM.RequestActivation(ctx, req)
 	if err != nil {
 		return nil, err
 	}
-	if ok {
-		logger.Info().Interface("entry", entry).Msg("existing registration entry found")
-		return &omnissm.RegistrationResponse{RegistrationEntry: *entry, Region: req.Identity().Region}, nil
+	if resp.Existing() {
+		logger.Info().Interface("entry", resp).Msg("existing registration entry found")
+	} else {
+		logger.Info().Interface("entry", resp).Msg("new registration entry created")
 	}
-	activation, err := r.SSM.CreateActivation(ctx, req.Identity().Name())
-	if err != nil {
-		if r.OmniSSM.SQS != nil && request.IsErrorThrottle(err) || request.IsErrorRetryable(err) {
-			sqsErr := r.OmniSSM.SQS.Send(ctx, &omnissm.DeferredActionMessage{
-				Type:  omnissm.CreateActivation,
-				Value: req.Identity(),
-			})
-			if sqsErr != nil {
-				return nil, sqsErr
-			}
-			return nil, errors.Wrapf(err, "deferred action to SQS queue: %#v", r.OmniSSM.Config.QueueName)
-		}
-		return nil, err
-	}
-	entry = &omnissm.RegistrationEntry{
-		Id:         req.Identity().Hash(),
-		CreatedAt:  time.Now().UTC(),
-		AccountId:  req.Identity().AccountId,
-		Region:     req.Identity().Region,
-		InstanceId: req.Identity().InstanceId,
-		Activation: *activation,
-		ManagedId:  "-",
-	}
-	if err := r.OmniSSM.Registrations.Put(ctx, entry); err != nil {
-		if r.OmniSSM.SQS != nil && request.IsErrorThrottle(err) || request.IsErrorRetryable(err) {
-			sqsErr := r.OmniSSM.SQS.Send(ctx, &omnissm.DeferredActionMessage{
-				Type:  omnissm.PutRegistrationEntry,
-				Value: entry,
-			})
-			if sqsErr != nil {
-				return nil, sqsErr
-			}
-			return nil, errors.Wrapf(err, "deferred action to SQS queue: %#v", r.OmniSSM.Config.QueueName)
-		}
-		return nil, err
-	}
-	logger.Info().Interface("entry", entry).Msg("new registration entry created")
-	return &omnissm.RegistrationResponse{RegistrationEntry: *entry, Region: req.Identity().Region}, nil
+	return resp, nil
 }
 
 func (r *registrationHandler) UpdateRegistration(ctx context.Context, req *omnissm.RegistrationRequest) (*omnissm.RegistrationResponse, error) {
 	logger := log.With().Str("handler", "UpdateRegistration").Logger()
 	logger.Info().Interface("identity", req.Identity()).Msg("update registration request")
+	if !ssm.IsManagedInstance(req.ManagedId) {
+		return nil, lambda.BadRequestError{fmt.Sprintf("invalid managedId %#v", req.ManagedId)}
+	}
 	id := req.Identity().Hash()
 	entry, err, ok := r.OmniSSM.Registrations.Get(ctx, id)
 	if err != nil {
@@ -94,16 +59,14 @@ func (r *registrationHandler) UpdateRegistration(ctx context.Context, req *omnis
 	}
 	if !ok {
 		logger.Info().Str("instanceName", req.Identity().Name()).Str("id", id).Msg("registration entry not found")
-		return nil, errors.Wrapf(err, "entry not found: %#v", id)
+		return nil, lambda.NotFoundError{"entry not found: " + id}
 	}
 	logger.Info().Interface("entry", entry).Msg("registration entry found")
-	if req.ManagedId != "" && req.ManagedId != "-" {
-		entry.ManagedId = req.ManagedId
-		if err := r.OmniSSM.Registrations.Update(ctx, entry); err != nil {
-			return nil, err
-		}
-		logger.Info().Interface("entry", entry).Msg("registration entry updated")
+	entry.ManagedId = req.ManagedId
+	if err := r.OmniSSM.Registrations.Update(ctx, entry); err != nil {
+		return nil, err
 	}
+	logger.Info().Interface("entry", entry).Msg("registration entry updated")
 	if t := r.OmniSSM.Config.ResourceRegisteredSNSTopic; t != "" {
 		if data, err := json.Marshal(entry); err == nil {
 			if err := r.OmniSSM.SNS.Publish(ctx, t, data); err != nil {
@@ -131,13 +94,15 @@ func main() {
 		case "/register":
 			var registerReq omnissm.RegistrationRequest
 			if err := json.Unmarshal([]byte(req.Body), &registerReq); err != nil {
-				return nil, err
+				log.Error().Err(err).Msg("cannot unmarshal request body")
+				return nil, lambda.BadRequestError{}
 			}
 			if err := registerReq.Verify(); err != nil {
-				return nil, err
+				log.Error().Err(err).Msg("cannot verify request")
+				return nil, lambda.BadRequestError{}
 			}
-			if !config.IsAuthorized(registerReq.Identity().AccountId) {
-				return nil, errors.Errorf("account not authorized: %#v", registerReq.Identity().AccountId)
+			if a := registerReq.Identity().AccountId; !config.IsAuthorized(a) {
+				return nil, lambda.UnauthorizedError{"account not authorized: " + a}
 			}
 			switch req.HTTPMethod {
 			case "POST":

--- a/tools/omnissm/functions/handle-registrations/main.go
+++ b/tools/omnissm/functions/handle-registrations/main.go
@@ -59,7 +59,7 @@ func (r *registrationHandler) UpdateRegistration(ctx context.Context, req *omnis
 	}
 	if !ok {
 		logger.Info().Str("instanceName", req.Identity().Name()).Str("id", id).Msg("registration entry not found")
-		return nil, lambda.NotFoundError{"entry not found: " + id}
+		return nil, lambda.NotFoundError{fmt.Sprintf("entry not found: %#v", id)}
 	}
 	logger.Info().Interface("entry", entry).Msg("registration entry found")
 	entry.ManagedId = req.ManagedId
@@ -102,7 +102,7 @@ func main() {
 				return nil, lambda.BadRequestError{}
 			}
 			if a := registerReq.Identity().AccountId; !config.IsAuthorized(a) {
-				return nil, lambda.UnauthorizedError{"account not authorized: " + a}
+				return nil, lambda.UnauthorizedError{fmt.Sprintf("account not authorized: %#v", a)}
 			}
 			switch req.HTTPMethod {
 			case "POST":

--- a/tools/omnissm/pkg/aws/lambda/error.go
+++ b/tools/omnissm/pkg/aws/lambda/error.go
@@ -20,6 +20,18 @@ type APIGatewayError interface {
 	StatusCode() int
 }
 
+type BadRequestError struct {
+	Message string
+}
+
+func (e BadRequestError) Error() string {
+	if e.Message == "" {
+		return "bad request"
+	}
+	return e.Message
+}
+func (BadRequestError) StatusCode() int { return http.StatusBadRequest }
+
 type NotFoundError struct {
 	Message string
 }
@@ -28,3 +40,12 @@ func (e NotFoundError) Error() string {
 	return e.Message
 }
 func (NotFoundError) StatusCode() int { return http.StatusNotFound }
+
+type UnauthorizedError struct {
+	Message string
+}
+
+func (e UnauthorizedError) Error() string {
+	return e.Message
+}
+func (UnauthorizedError) StatusCode() int { return http.StatusUnauthorized }

--- a/tools/omnissm/pkg/omnissm/deferred_message.go
+++ b/tools/omnissm/pkg/omnissm/deferred_message.go
@@ -16,6 +16,7 @@ package omnissm
 
 import (
 	"encoding/json"
+	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -25,10 +26,11 @@ type DeferredActionType int
 const (
 	InvalidActionType DeferredActionType = iota
 	AddTagsToResource
-	CreateActivation
-	DeregisterManagedInstance
+	RequestActivation
+	DeregisterInstance
 	PutInventory
 	PutRegistrationEntry
+	DeleteRegistrationEntry
 )
 
 type DeferredActionMessage struct {
@@ -60,4 +62,17 @@ func (d *DeferredActionMessage) UnmarshalJSON(data []byte) error {
 	}
 	*d = DeferredActionMessage{msg.Type, msg.Value}
 	return nil
+}
+
+type DeferError struct {
+	cause error
+	queue string
+}
+
+func (e *DeferError) Error() string {
+	return fmt.Sprintf("deferred action to SQS queue (%s): %v", e.queue, e.cause)
+}
+
+func (e *DeferError) Cause() error {
+	return e.cause
 }

--- a/tools/omnissm/pkg/omnissm/deferred_message.go
+++ b/tools/omnissm/pkg/omnissm/deferred_message.go
@@ -16,7 +16,6 @@ package omnissm
 
 import (
 	"encoding/json"
-	"fmt"
 
 	"github.com/pkg/errors"
 )
@@ -62,17 +61,4 @@ func (d *DeferredActionMessage) UnmarshalJSON(data []byte) error {
 	}
 	*d = DeferredActionMessage{msg.Type, msg.Value}
 	return nil
-}
-
-type DeferError struct {
-	cause error
-	queue string
-}
-
-func (e *DeferError) Error() string {
-	return fmt.Sprintf("deferred action to SQS queue (%s): %v", e.queue, e.cause)
-}
-
-func (e *DeferError) Cause() error {
-	return e.cause
 }

--- a/tools/omnissm/pkg/omnissm/omnissm.go
+++ b/tools/omnissm/pkg/omnissm/omnissm.go
@@ -15,6 +15,11 @@
 package omnissm
 
 import (
+	"context"
+	"encoding/json"
+	"time"
+
+	"github.com/aws/aws-sdk-go/aws/request"
 	"github.com/pkg/errors"
 
 	"github.com/capitalone/cloud-custodian/tools/omnissm/pkg/aws/s3"
@@ -70,4 +75,75 @@ func New(config *Config) (*OmniSSM, error) {
 	}
 
 	return o, nil
+}
+
+func (o *OmniSSM) RequestActivation(ctx context.Context, req *RegistrationRequest) (*RegistrationResponse, error) {
+	entry, err, ok := o.Registrations.Get(ctx, req.Identity().Hash())
+	if err != nil {
+		return nil, err
+	}
+	if ok && (ssm.IsManagedInstance(entry.ManagedId) || time.Now().Sub(entry.CreatedAt) < 12*time.Hour) {
+		// duplicate request
+		return &RegistrationResponse{RegistrationEntry: *entry, Region: req.Identity().Region, existing: true}, nil
+	}
+	activation, err := o.SSM.CreateActivation(ctx, req.Identity().Name())
+	if err != nil {
+		// if we fail here, defer starting over
+		return nil, o.tryDefer(ctx, err, RequestActivation, req)
+	}
+	entry = &RegistrationEntry{
+		Id:         req.Identity().Hash(),
+		CreatedAt:  time.Now().UTC(),
+		AccountId:  req.Identity().AccountId,
+		Region:     req.Identity().Region,
+		InstanceId: req.Identity().InstanceId,
+		Activation: *activation,
+		ManagedId:  "-",
+	}
+	if err := o.Registrations.Put(ctx, entry); err != nil {
+		// if we fail here, defer saving the created activation to alleviate
+		// pressure on SSM to create it again
+		return nil, o.tryDefer(ctx, err, PutRegistrationEntry, entry)
+	}
+	return &RegistrationResponse{RegistrationEntry: *entry, Region: req.Identity().Region}, nil
+}
+
+func (o *OmniSSM) DeregisterInstance(ctx context.Context, entry *RegistrationEntry) error {
+	if err := o.SSM.DeregisterManagedInstance(ctx, entry.ManagedId); err != nil {
+		// if we fail here, defer starting over
+		return o.tryDefer(ctx, err, DeregisterInstance, entry)
+	}
+	if err := o.Registrations.Delete(ctx, entry.Id); err != nil {
+		// if we fail here, defer starting over
+		return o.tryDefer(ctx, err, DeleteRegistrationEntry, entry.Id)
+	}
+	if o.Config.ResourceDeletedSNSTopic != "" {
+		data, err := json.Marshal(map[string]interface{}{
+			"ManagedId":    entry.ManagedId,
+			"ResourceId":   entry.InstanceId,
+			"AWSAccountId": entry.AccountId,
+			"AWSRegion":    entry.Region,
+		})
+		if err != nil {
+			return errors.Wrap(err, "cannot marshal SNS message")
+		}
+		if err := o.SNS.Publish(ctx, o.Config.ResourceDeletedSNSTopic, data); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (o *OmniSSM) tryDefer(ctx context.Context, err error, t DeferredActionType, value interface{}) error {
+	if o.SQS != nil && request.IsErrorThrottle(err) || request.IsErrorRetryable(err) {
+		sqsErr := o.SQS.Send(ctx, &DeferredActionMessage{
+			Type:  t,
+			Value: value,
+		})
+		if sqsErr != nil {
+			return errors.Wrapf(sqsErr, "could not defer message (original error: %v)", err)
+		}
+		return &DeferError{err, o.Config.QueueName}
+	}
+	return err
 }

--- a/tools/omnissm/pkg/omnissm/omnissm.go
+++ b/tools/omnissm/pkg/omnissm/omnissm.go
@@ -143,7 +143,7 @@ func (o *OmniSSM) tryDefer(ctx context.Context, err error, t DeferredActionType,
 		if sqsErr != nil {
 			return errors.Wrapf(sqsErr, "could not defer message (original error: %v)", err)
 		}
-		return &DeferError{err, o.Config.QueueName}
+		return errors.Wrapf(err, "deferred action to SQS queue (%s)", o.Config.QueueName)
 	}
 	return err
 }

--- a/tools/omnissm/pkg/omnissm/response.go
+++ b/tools/omnissm/pkg/omnissm/response.go
@@ -21,10 +21,16 @@ import (
 type RegistrationResponse struct {
 	RegistrationEntry
 
-	Region string `json:"region,omitempty"`
+	Region   string `json:"region,omitempty"`
+	existing bool
 }
 
 func (r *RegistrationResponse) MarshalJSON() ([]byte, error) {
 	type alias RegistrationResponse
 	return json.Marshal((*alias)(r))
+}
+
+// Used for logging
+func (r *RegistrationResponse) Existing() bool {
+	return r.existing
 }


### PR DESCRIPTION
Clarify failure paths and separate "true" errors from behavioral error
responses (i.e. 4XX errors). Moved core API functions out of lambda main
to make queueing of deferred execution easier.