### PR TITLE
policy - resource limit as percent

### DIFF
--- a/c7n/exceptions.py
+++ b/c7n/exceptions.py
@@ -52,12 +52,13 @@ class PolicyExecutionError(CustodianError):
 class ResourceLimitExceeded(PolicyExecutionError):
     """The policy would have affected more resources than its limit.
     """
-    def __init__(self, msg, limit, selection_count, population_count=None):
+    def __init__(self, msg, limit_type, limit, selection_count, population_count):
         msg = msg.format(
             limit=limit,
             selection_count=selection_count,
             population_count=population_count)
         super(ResourceLimitExceeded, self).__init__(msg)
         self.limit = limit
+        self.limit_type = limit
         self.selection_count = selection_count
         self.population_count = population_count

--- a/c7n/exceptions.py
+++ b/c7n/exceptions.py
@@ -47,3 +47,17 @@ class DeprecationError(PolicySyntaxError):
 class PolicyExecutionError(CustodianError):
     """Error running a Policy.
     """
+
+
+class ResourceLimitExceeded(PolicyExecutionError):
+    """The policy would have affected more resources than its limit.
+    """
+    def __init__(self, msg, limit, selection_count, population_count=None):
+        msg = msg.format(
+            limit=limit,
+            selection_count=selection_count,
+            population_count=population_count)
+        super(ResourceLimitExceeded, self).__init__(msg)
+        self.limit = limit
+        self.selection_count = selection_count
+        self.population_count = population_count

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -29,7 +29,7 @@ import six
 from c7n.actions import EventAction
 from c7n.cwe import CloudWatchEvents
 from c7n.ctx import ExecutionContext
-from c7n.exceptions import PolicyValidationError, ClientError
+from c7n.exceptions import PolicyValidationError, ClientError, ResourceLimitExceeded
 from c7n.output import DEFAULT_NAMESPACE
 from c7n.resources import load_resources
 from c7n.registry import PluginRegistry
@@ -238,7 +238,17 @@ class PullMode(PolicyExecutionMode):
                 version)
 
             s = time.time()
-            resources = self.policy.resource_manager.resources()
+            try:
+                resources = self.policy.resource_manager.resources()
+            except ResourceLimitExceeded as e:
+                self.policy.log.error(
+                    "policy: %s resource:%s resource limit:%s exceeded %d",
+                    self.policy.name, self.policy.resource_type, e.limit,
+                    e.selection_count)
+                self.policy.ctx.metrics.put_metric(
+                    'ResourceLimitExceeded', e.selection_count, "Count", Scope="Policy")
+                raise
+
             rt = time.time() - s
             self.policy.log.info(
                 "policy: %s resource:%s region:%s count:%d time:%0.2f" % (
@@ -255,13 +265,6 @@ class PullMode(PolicyExecutionMode):
 
             if not resources:
                 return []
-            elif (self.policy.max_resources is not None and
-                  len(resources) > self.policy.max_resources):
-                msg = "policy %s matched %d resources max resources %s" % (
-                    self.policy.name, len(resources),
-                    self.policy.max_resources)
-                self.policy.log.warning(msg)
-                raise RuntimeError(msg)
 
             if self.policy.options.dryrun:
                 self.policy.log.debug("dryrun: skipping actions")
@@ -734,6 +737,10 @@ class Policy(object):
     @property
     def max_resources(self):
         return self.data.get('max-resources')
+
+    @property
+    def max_resources_percent(self):
+        return self.data.get('max-resources-percent')
 
     @property
     def tags(self):

--- a/c7n/policy.py
+++ b/c7n/policy.py
@@ -241,12 +241,9 @@ class PullMode(PolicyExecutionMode):
             try:
                 resources = self.policy.resource_manager.resources()
             except ResourceLimitExceeded as e:
-                self.policy.log.error(
-                    "policy: %s resource:%s resource limit:%s exceeded %d",
-                    self.policy.name, self.policy.resource_type, e.limit,
-                    e.selection_count)
+                self.policy.log.error(str(e))
                 self.policy.ctx.metrics.put_metric(
-                    'ResourceLimitExceeded', e.selection_count, "Count", Scope="Policy")
+                    'ResourceLimitExceeded', e.selection_count, "Count")
                 raise
 
             rt = time.time() - s

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -439,7 +439,8 @@ class QueryResourceManager(ResourceManager):
                  "found: {selection_count}") % p.name,
                 p.max_resources, selection_count, population_count)
         elif p.max_resources_percent:
-            if (population_count * (p.max_resources_percent/100.0) < selection_count):
+            if (population_count * (
+                    p.max_resources_percent / 100.0) < selection_count):
                 raise ResourceLimitExceeded(
                     ("policy: %s exceeding resource percent "
                      "limit: {limit} found: {selection_count} "

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -437,15 +437,14 @@ class QueryResourceManager(ResourceManager):
             raise ResourceLimitExceeded(
                 ("policy: %s exceeding resource limit: {limit} "
                  "found: {selection_count}") % p.name,
-                p.max_resources, selection_count, population_count)
+                "max-resources", p.max_resources, selection_count, population_count)
         elif p.max_resources_percent:
             if (population_count * (
                     p.max_resources_percent / 100.0) < selection_count):
                 raise ResourceLimitExceeded(
-                    ("policy: %s exceeding resource percent "
-                     "limit: {limit} found: {selection_count} "
-                     "total: {population_count}") % p.name,
-                    p.max_resources_percent, selection_count, population_count)
+                    ("policy: %s exceeding resource limit: {limit}%% "
+                     "found: {selection_count} total: {population_count}") % p.name,
+                    "max-percent", p.max_resources_percent, selection_count, population_count)
         return True
 
     def _get_cached_resources(self, ids):

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -29,7 +29,7 @@ import six
 from botocore.paginate import set_value_from_jmespath
 
 from c7n.actions import ActionRegistry
-from c7n.exceptions import ClientError
+from c7n.exceptions import ClientError, ResourceLimitExceeded
 from c7n.filters import FilterRegistry, MetricsFilter
 from c7n.manager import ResourceManager
 from c7n.registry import PluginRegistry
@@ -418,8 +418,34 @@ class QueryResourceManager(ResourceManager):
             query = {}
 
         resources = self.augment(self.source.resources(query))
+        resource_count = len(resources)
         self._cache.save(key, resources)
-        return self.filter_resources(resources)
+        resources = self.filter_resources(resources)
+
+        # Check if we're out of a policies execution limits.
+        self.check_resource_limit(len(resources), resource_count)
+        return resources
+
+    def check_resource_limit(self, selection_count, population_count):
+        """Check if policy's execution affects more resources then its limit.
+
+        Ideally this would be at a higher level but we've hidden
+        filtering behind the resource manager facade for default usage.
+        """
+        p = self.ctx.policy
+        if p.max_resources and p.max_resources > selection_count:
+            raise ResourceLimitExceeded(
+                ("policy: %s exceeding resource limit: {limit} "
+                 "found: {selection_count}") % p.name,
+                p.max_resources, selection_count, population_count)
+        elif p.max_resources_percent:
+            if (population_count * (p.max_resources_percent/100.0) < selection_count):
+                raise ResourceLimitExceeded(
+                    ("policy: %s exceeding resource percent "
+                     "limit: {limit} found: {selection_count} "
+                     "total: {population_count}") % p.name,
+                    p.max_resources_percent, selection_count, population_count)
+        return True
 
     def _get_cached_resources(self, ids):
         key = self.get_cache_key(None)

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -435,14 +435,14 @@ class QueryResourceManager(ResourceManager):
         p = self.ctx.policy
         if p.max_resources and p.max_resources > selection_count:
             raise ResourceLimitExceeded(
-                ("policy: %s exceeding resource limit: {limit} "
+                ("policy: %s exceeded resource limit: {limit} "
                  "found: {selection_count}") % p.name,
                 "max-resources", p.max_resources, selection_count, population_count)
         elif p.max_resources_percent:
             if (population_count * (
                     p.max_resources_percent / 100.0) < selection_count):
                 raise ResourceLimitExceeded(
-                    ("policy: %s exceeding resource limit: {limit}%% "
+                    ("policy: %s exceeded resource limit: {limit}%% "
                      "found: {selection_count} total: {population_count}") % p.name,
                     "max-percent", p.max_resources_percent, selection_count, population_count)
         return True

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -190,7 +190,7 @@ def generate(resource_types=()):
                 'end': {'format': 'date-time'},
                 'resource': {'type': 'string'},
                 'max-resources': {'type': 'integer'},
-                'max-resources-percent': {'type': 'number'},
+                'max-resources-percent': {'type': 'number', 'minimum': 0, 'maximum': 100},
                 'comment': {'type': 'string'},
                 'comments': {'type': 'string'},
                 'description': {'type': 'string'},

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -190,7 +190,7 @@ def generate(resource_types=()):
                 'end': {'format': 'date-time'},
                 'resource': {'type': 'string'},
                 'max-resources': {'type': 'integer'},
-                'max-resources-percent': {'type': 'float'},
+                'max-resources-percent': {'type': 'number'},
                 'comment': {'type': 'string'},
                 'comments': {'type': 'string'},
                 'description': {'type': 'string'},

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -190,6 +190,7 @@ def generate(resource_types=()):
                 'end': {'format': 'date-time'},
                 'resource': {'type': 'string'},
                 'max-resources': {'type': 'integer'},
+                'max-resources-percent': {'type': 'float'},
                 'comment': {'type': 'string'},
                 'comments': {'type': 'string'},
                 'description': {'type': 'string'},

--- a/docs/source/quickstart/advanced.rst
+++ b/docs/source/quickstart/advanced.rst
@@ -6,6 +6,7 @@ Advanced Usage
 * :ref:`run-multiple-regions`
 * :ref:`report-multiple-regions`
 * :ref:`report-custom-fields`
+* :ref:`policy_resource_limits`
 
 .. _run-multiple-regions:
 
@@ -120,6 +121,49 @@ If no ``tz`` attribute is specified, UTC is set by default.
       actions:
         - start
 
+.. _policy_resource_limits:
+
+Limiting how many resources custodian affects
+---------------------------------------------
+
+Custodian by default will operate on as many resources exist within an
+environment that match a policy's filters. Custodian also allows policy
+authors to stop policy execution if a policy affects more resources then
+expected, either as a number of resources or as a percentage of total extant
+resources.
+
+.. code-block:: yaml
+
+  policies:
+
+    - name: log-delete
+      description: |
+        This policy will delete all log groups
+	that haven't been written to in 5 days.
+
+	As a safety belt, it will stop execution
+	if the number of log groups that would
+	be affected is more than 5% of the total
+        log groups in the account's region.
+      resource: aws.log-group
+      max-resources-percent: 5
+      filters:
+        - type: last-write
+	  days: 5
+      actions:
+        - delete
+
+
+Max resources can also be specified as an absolute number using
+`max-resources` specified on a policy. When executing if the limit
+is exceeded, policy execution is stopped before taking any actions::
+
+  $ custodian run -s out policy.yml
+  custodian.commands:ERROR policy: log-delete exceeded resource limit: 2.5% found: 1 total: 1
+
+If metrics are being published ('-m/--metrics-enabled') then an additional
+metric named `ResourceLimitExceeded` will be published with the number
+of resources that matched the policy.
 
 .. _report-custom-fields:
 

--- a/tests/data/placebo/test_policy_resource_limits/logs.DescribeLogGroups_1.json
+++ b/tests/data/placebo/test_policy_resource_limits/logs.DescribeLogGroups_1.json
@@ -1,0 +1,25 @@
+{
+    "status_code": 200,
+    "data": {
+        "logGroups": [
+            {
+                "logGroupName": "/aws/lambda/myIOTFunction",
+                "creationTime": 1505170021374,
+                "metricFilterCount": 0,
+                "arn": "arn:aws:logs:us-west-2:644160558196:log-group:/aws/lambda/myIOTFunction:*",
+                "storedBytes": 3264526
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "db6a7859-abdd-11e8-8855-79ef72683170",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "db6a7859-abdd-11e8-8855-79ef72683170",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "215",
+                "date": "Wed, 29 Aug 2018 22:49:58 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_policy_resource_limits/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_policy_resource_limits/tagging.GetResources_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [],
+        "ResponseMetadata": {
+            "RequestId": "dbbfc3f9-abdd-11e8-b5cc-0904cd16a011",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "dbbfc3f9-abdd-11e8-b5cc-0904cd16a011",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "50",
+                "date": "Wed, 29 Aug 2018 22:49:59 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -495,7 +495,7 @@ class TestPolicy(BaseTest):
         self.assertRaises(ResourceLimitExceeded, p.run)
         self.assertEqual(
             output.getvalue().strip(),
-            "policy: log-delete resource:log-group resource limit:2.5 exceeded 1")
+            "policy: log-delete exceeding resource limit: 2.5% found: 1 total: 1")
         self.assertEqual(
             p.ctx.metrics.buf[0]['MetricName'], 'ResourceLimitExceeded')
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -495,7 +495,7 @@ class TestPolicy(BaseTest):
         self.assertRaises(ResourceLimitExceeded, p.run)
         self.assertEqual(
             output.getvalue().strip(),
-            "policy: log-delete exceeding resource limit: 2.5% found: 1 total: 1")
+            "policy: log-delete exceeded resource limit: 2.5% found: 1 total: 1")
         self.assertEqual(
             p.ctx.metrics.buf[0]['MetricName'], 'ResourceLimitExceeded')
 

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -15,11 +15,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from datetime import datetime, timedelta
 import json
+import logging
 import mock
 import shutil
 import tempfile
 
 from c7n import policy, manager
+from c7n.exceptions import ResourceLimitExceeded
 from c7n.resources.aws import AWS
 from c7n.resources.ec2 import EC2
 from c7n.utils import dumps
@@ -477,6 +479,25 @@ class TestPolicy(BaseTest):
                 ],
             },
         )
+
+    def test_policy_resource_limits(self):
+        session_factory = self.record_flight_data(
+            "test_policy_resource_limits")
+        p = self.load_policy(
+            {
+                "name": "log-delete",
+                "resource": "log-group",
+                "max-resources-percent": 2.5,
+            },
+            session_factory=session_factory)
+        p.ctx.metrics.flush = mock.MagicMock()
+        output = self.capture_logging('custodian.policy', level=logging.ERROR)
+        self.assertRaises(ResourceLimitExceeded, p.run)
+        self.assertEqual(
+            output.getvalue().strip(),
+            "policy: log-delete resource:log-group resource limit:2.5 exceeded 1")
+        self.assertEqual(
+            p.ctx.metrics.buf[0]['MetricName'], 'ResourceLimitExceeded')
 
     def test_policy_metrics(self):
         session_factory = self.replay_flight_data("test_policy_metrics")

--- a/tests/test_policy.py
+++ b/tests/test_policy.py
@@ -481,7 +481,7 @@ class TestPolicy(BaseTest):
         )
 
     def test_policy_resource_limits(self):
-        session_factory = self.record_flight_data(
+        session_factory = self.replay_flight_data(
             "test_policy_resource_limits")
         p = self.load_policy(
             {


### PR DESCRIPTION
extend policy safety belt semantics to also allow for a percent of total resources affected, in addition to a cardinality count.

closes #2828 