### PR TITLE
Creating lambdaerrorsnotify.rst As Lambda Errors Notify Usecase

### DIFF
--- a/docs/source/usecases/lambdaerrorsnotify.rst
+++ b/docs/source/usecases/lambdaerrorsnotify.rst
@@ -8,8 +8,7 @@ The policies filters will check each Lambdas CloudWatch Metrics for errors.  If 
 in an hour period and the Lambda function is not tagged with **Custodian_Lambda_Error_Exclude**
 then the policy will take the action of notifying the Lambda function owner and the cloud team.  These
 notifications can help developers by informing them if unexpected errors occur so they can be quickly
-addressed.  Following the notify action, the policy will write a metric of the Sum of Lambda errors
-to CloudWatch Metrics
+addressed.
 For the notify action in the policy to work you must have setup the c7n_mailer tool:
 https://github.com/capitalone/cloud-custodian/tree/master/tools/c7n_mailer
 
@@ -64,11 +63,6 @@ https://devops4solutions.com/cloud-custodian-configure-email/
              type: sqs
              queue: https://sqs.us-east-1.amazonaws.com/1234567890/cloud-custodian-mailer
              region: us-east-1
-         - type: put-metric
-           key: FunctionName
-           namespace: CloudCustodian
-           metric_name: Lambda-Functions-With-Errors-Reported
-           op: count
-           units: Count
+
     
     

--- a/docs/source/usecases/lambdaerrorsnotify.rst
+++ b/docs/source/usecases/lambdaerrorsnotify.rst
@@ -1,0 +1,74 @@
+.. _lambdaerrorsnotify:
+
+Lambda - Notify On Lambda Errors 
+=====================================================
+
+The following example policy will run hourly as a CloudWatch Scheduled Event triggered Lambda function.
+The policies filters will check each Lambdas CloudWatch Metrics for errors.  If there are any errors
+in an hour period and the Lambda function is not tagged with **Custodian_Lambda_Error_Exclude**
+then the policy will take the action of notifying the Lambda function owner and the cloud team.  These
+notifications can help developers by informing them if unexpected errors occur so they can be quickly
+addressed.  Following the notify action, the policy will write a metric of the Sum of Lambda errors
+to CloudWatch Metrics
+For the notify action in the policy to work you must have setup the c7n_mailer tool:
+https://github.com/capitalone/cloud-custodian/tree/master/tools/c7n_mailer
+
+Mailer Setup Guide:
+https://devops4solutions.com/cloud-custodian-configure-email/
+
+
+
+.. code-block:: yaml
+
+   policies:
+
+ 
+     - name: lambda-invocation-errors
+       resource: lambda
+       description: |
+          Hourly check that finds any Lambda functions that have any
+          errors within the last hour and notifies the customer and Cloud Team.
+       mode:
+         type: periodic
+         schedule: "rate(1 hour)"
+         timeout: 300
+         tags:
+               ResourceContact: "cloudteam@company.com"
+               ResourcePurpose: "Created by Cloud Custodian Automated Fleet Management"
+               Environment: prd
+       filters:
+         - type: metrics
+           name: Errors
+           days: 0.068
+           period: 3600
+           statistics: Sum
+           op: greater-than
+           value: 0
+         - not:
+             - "tag:Custodian_Lambda_Error_Exclude": present      
+       actions:
+         - type: notify
+           template: default.html
+           priority_header: 1
+           subject: "Lambda Function Errors Occuring! - [custodian {{ account }} - {{ region }}]"
+           violation_desc: |
+              "There has been one or more code errors occuring on this lambda function in the last hour:"
+           action_desc: |
+              "Actions Taken:  Please investigate this lambda function as errors reported.
+              To exclude the below function from this scan please add a tag with a Key called
+              Custodian_Lambda_Error_Exclude with any value to the lambda function.
+           to:
+             - CloudCustodian@Company.com
+             - resource-owner
+           transport:
+             type: sqs
+             queue: https://sqs.us-east-1.amazonaws.com/1234567890/cloud-custodian-mailer
+             region: us-east-1
+         - type: put-metric
+           key: FunctionName
+           namespace: CloudCustodian
+           metric_name: Lambda-Functions-With-Errors-Reported
+           op: count
+           units: Count
+    
+    


### PR DESCRIPTION
This policy is a good usecase for proactively notifying developers when their lambda functions error out.  It also demonstrates creating tags with the Lambda function as well as reading and writing metrics with policies.