### PR TITLE
Fix deprecated iteritems func in slack notifier

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/slack_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/slack_delivery.py
@@ -59,7 +59,7 @@ class SlackDelivery(object):
                     if not resolved_addrs:
                         continue
 
-                    for address, slack_target in resolved_addrs.iteritems():
+                    for address, slack_target in resolved_addrs.items():
                         slack_messages[address] = get_rendered_jinja(
                             slack_target, sqs_message, resources,
                             self.logger, 'slack_template', 'slack_default')
@@ -81,7 +81,7 @@ class SlackDelivery(object):
             elif target.startswith('slack://') and self.email_handler.target_is_email(
                     target.split('slack://', 1)[1]):
                 resolved_addrs = self.retrieve_user_im([target.split('slack://', 1)[1]])
-                for address, slack_target in resolved_addrs.iteritems():
+                for address, slack_target in resolved_addrs.items():
                     slack_messages[address] = get_rendered_jinja(
                         slack_target, sqs_message, resource_list,
                         self.logger, 'slack_template', 'slack_default')
@@ -97,7 +97,7 @@ class SlackDelivery(object):
         return slack_messages
 
     def slack_handler(self, sqs_message, slack_messages):
-        for key, payload in slack_messages.iteritems():
+        for key, payload in slack_messages.items():
             self.logger.info("Sending account:%s policy:%s %s:%s slack:%s to %s" % (
                 sqs_message.get('account', ''),
                 sqs_message['policy']['name'],


### PR DESCRIPTION
When running the slack notifier function using the provided docker image, the use of `iteritems()` means the following error is thrown:

```
Traceback (most recent call last):
  File "/cloud-custodian/tools/c7n_mailer/c7n_mailer/sqs_queue_processor.py", line 175, in process_sqs_message
    slack_delivery.slack_handler(sqs_message, slack_messages)
  File "/cloud-custodian/tools/c7n_mailer/c7n_mailer/slack_delivery.py", line 100, in slack_handler
    for key, payload in slack_messages.iteritems():
AttributeError: 'dict' object has no attribute 'iteritems'
```

[As is suggested](https://legacy.python.org/dev/peps/pep-0469/#id9), I replaced `iteritems()` with `items()`.

This is known to work on both python3 and python2