### PR TITLE
Improve owner email handling

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/cli.py
+++ b/tools/c7n_mailer/c7n_mailer/cli.py
@@ -20,6 +20,7 @@ CONFIG_SCHEMA = {
         'queue_url': {'type': 'string'},
         'from_address': {'type': 'string'},
         'contact_tags': {'type': 'array', 'items': {'type': 'string'}},
+        'org_domain': {'type': 'string'},
 
         # Standard Lambda Function Config
         'region': {'type': 'string'},

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -103,9 +103,7 @@ class EmailDelivery(object):
         return emails
 
     def get_event_owner_email(self, targets, event):
-        self.logger.debug('getting owner email')
         if 'event-owner' in targets:
-            self.logger.debug('event owner field in targets')
             aws_username = self.get_aws_username_from_event(event)
             if aws_username:
                 # is using SSO, the target might already be an email
@@ -113,13 +111,11 @@ class EmailDelivery(object):
                     return [aws_username]
                 # if the LDAP config is set, lookup in ldap
                 elif self.config.get('ldap_uri', False):
-                    self.logger.debug('ldap_uri is: %s.', self.config.get('ldap_uri', False))
                     return self.ldap_lookup.get_email_to_addrs_from_uid(aws_username)
                 # the org_domain setting is configured, append the org_domain
                 # to the username from AWS
                 elif self.config.get('org_domain', False):
                     org_domain = self.config.get('org_domain', False)
-                    self.logger.debug('org_domain is: %s.', org_domain)
                     self.logger.info('adding email %s to targets.', aws_username + '@' + org_domain)
                     return [aws_username + '@' + org_domain]
                 else:

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -104,16 +104,22 @@ class EmailDelivery(object):
 
     def get_event_owner_email(self, targets, event):
         self.logger.debug('getting owner email')
-        if 'event-owner' in targets and self.config.get('ldap_uri', False):
-            self.logger.debug('ldap_uri is: %s.', self.config.get('ldap_uri', False))
+        if 'event-owner' in targets:
+            self.logger.debug('event owner field in targets')
             aws_username = self.get_aws_username_from_event(event)
             if aws_username:
-                return self.ldap_lookup.get_email_to_addrs_from_uid(aws_username)
-        elif 'event-owner' in targets and self.config.get('org_domain', False):
-            self.logger.debug('org_domain is: %s.', self.config.get('org_domain', False))
-            aws_username = self.get_aws_username_from_event(event)
-            if aws_username:
-                ['aws_username'+ self.config.get('org_domain', False)]
+                if self.config.get('ldap_uri', False):
+                    self.logger.debug('ldap_uri is: %s.', self.config.get('ldap_uri', False))
+                    return self.ldap_lookup.get_email_to_addrs_from_uid(aws_username)
+                elif self.config.get('org_domain', False):
+                    org_domain = self.config.get('org_domain', False)
+                    self.logger.debug('org_domain is: %s.', org_domain)
+                    self.logger.info('adding email %s to targets.', aws_username+'@'+org_domain)
+                    return [aws_username+'@'+org_domain]
+                else:
+                    self.logger.warning('unable to lookup owner email. Please configure LDAP or org_domain')
+            else:
+                self.logger.info('no aws username in event')
         return []
 
     def get_ldap_emails_from_resource(self, sqs_message, resource):

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -103,10 +103,17 @@ class EmailDelivery(object):
         return emails
 
     def get_event_owner_email(self, targets, event):
+        self.logger.debug('getting owner email')
         if 'event-owner' in targets and self.config.get('ldap_uri', False):
+            self.logger.debug('ldap_uri is: %s.', self.config.get('ldap_uri', False))
             aws_username = self.get_aws_username_from_event(event)
             if aws_username:
                 return self.ldap_lookup.get_email_to_addrs_from_uid(aws_username)
+        elif 'event-owner' in targets and self.config.get('org_domain', False):
+            self.logger.debug('org_domain is: %s.', self.config.get('org_domain', False))
+            aws_username = self.get_aws_username_from_event(event)
+            if aws_username:
+                ['aws_username'+ self.config.get('org_domain', False)]
         return []
 
     def get_ldap_emails_from_resource(self, sqs_message, resource):

--- a/tools/c7n_mailer/c7n_mailer/email_delivery.py
+++ b/tools/c7n_mailer/c7n_mailer/email_delivery.py
@@ -108,16 +108,23 @@ class EmailDelivery(object):
             self.logger.debug('event owner field in targets')
             aws_username = self.get_aws_username_from_event(event)
             if aws_username:
-                if self.config.get('ldap_uri', False):
+                # is using SSO, the target might already be an email
+                if self.target_is_email(aws_username):
+                    return [aws_username]
+                # if the LDAP config is set, lookup in ldap
+                elif self.config.get('ldap_uri', False):
                     self.logger.debug('ldap_uri is: %s.', self.config.get('ldap_uri', False))
                     return self.ldap_lookup.get_email_to_addrs_from_uid(aws_username)
+                # the org_domain setting is configured, append the org_domain
+                # to the username from AWS
                 elif self.config.get('org_domain', False):
                     org_domain = self.config.get('org_domain', False)
                     self.logger.debug('org_domain is: %s.', org_domain)
-                    self.logger.info('adding email %s to targets.', aws_username+'@'+org_domain)
-                    return [aws_username+'@'+org_domain]
+                    self.logger.info('adding email %s to targets.', aws_username + '@' + org_domain)
+                    return [aws_username + '@' + org_domain]
                 else:
-                    self.logger.warning('unable to lookup owner email. Please configure LDAP or org_domain')
+                    self.logger.warning('unable to lookup owner email. \
+                            Please configure LDAP or org_domain')
             else:
                 self.logger.info('no aws username in event')
         return []

--- a/tools/c7n_mailer/example.yml
+++ b/tools/c7n_mailer/example.yml
@@ -43,3 +43,9 @@ ldap_bind_password: "base64_encoded_ciphertext_password"
 # For sending to sns topics we need to assume back into the target account
 cross_accounts:
   '991119991111': 'arn:aws:iam::991119991111:role/MyDeliveryRole'
+
+# if your usernames match email addresses
+# you can set an org domain here which is appended to the username
+# to send to
+org_domain: example.com
+


### PR DESCRIPTION
Currently, the only way to lookup an owner email address is via an OwnerContact tag or via LDAP.

This might be overkill in 2 scenarios:

- An org uses SSO. In this case, the owner might already be an email address. This PR uses the existing `target_is_email` method to determine if an event-owner is already an email address, and if it is, use that address as the owner
- Org AWS usernames match the email address for a user. This PR adds a configuration option, `org_domain` which will be appended to the `aws_username` with `@` for the owner contact.