### PR TITLE
metrics - self.buffer_size typo

### DIFF
--- a/c7n/output.py
+++ b/c7n/output.py
@@ -108,7 +108,7 @@ class MetricsOutput(object):
 
     def _put_metrics(self, ns, metrics):
         watch = local_session(self.ctx.session_factory).client('cloudwatch')
-        for metric_values in chunks(metrics, self.BUF_SIZE):
+        for metric_values in chunks(metrics, self.BUFFER_SIZE):
             return self.retry(
                 watch.put_metric_data, Namespace=ns, MetricData=metrics)
 


### PR DESCRIPTION
getting the following traceback when running with `-m`

```shell
Traceback (most recent call last):
File "/src/c7n/commands.py", line 231, in run
policy()
File "/src/c7n/policy.py", line 866, in __call__
resources = mode.run()
File "/src/c7n/policy.py", line 285, in run
return resources
File "/src/c7n/ctx.py", line 61, in __exit__
self.metrics.flush()
File "/src/c7n/output.py", line 83, in flush
self._put_metrics(self.namespace, self.buf)
File "/src/c7n/output.py", line 111, in _put_metrics
for metric_values in chunks(metrics, self.BUF_SIZE):
AttributeError: 'MetricsOutput' object has no attribute 'BUF_SIZE'
```