### PR TITLE
s3 aws tags - handle incompatible api behavior change

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -513,9 +513,7 @@ def modify_bucket_tags(session_factory, buckets, add_tags=(), remove_tags=()):
 
         new_tags = {t['Key']: t['Value'] for t in add_tags}
         for t in bucket.get('Tags', ()):
-            if (t['Key'] not in new_tags and
-                    not t['Key'].startswith('aws') and
-                    t['Key'] not in remove_tags):
+            if (t['Key'] not in new_tags and t['Key'] not in remove_tags):
                 new_tags[t['Key']] = t['Value']
         tag_set = [{'Key': k, 'Value': v} for k, v in new_tags.items()]
 


### PR DESCRIPTION
handle behavior change on put bucket tags for s3, previously it would not accept `aws:` prefixed tags, it now requires them if extant.

closes #2834 