### PR TITLE
S3 bucket ACL schema bug

### DIFF
--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -664,7 +664,7 @@ class GlobalGrantsFilter(Filter):
         permissions={
             'type': 'array', 'items': {
                 'type': 'string', 'enum': [
-                    'READ', 'WRITE', 'WRITE_ACP', 'READ', 'READ_ACP']}})
+                    'READ', 'WRITE', 'WRITE_ACP', 'READ_ACP', 'FULL_CONTROL']}})
 
     GLOBAL_ALL = "http://acs.amazonaws.com/groups/global/AllUsers"
     AUTH_ALL = "http://acs.amazonaws.com/groups/global/AuthenticatedUsers"


### PR DESCRIPTION
The bug in ACL validation causes policy written to look for buckets with FULL_CONTROL to fail as  there is a repeated 'READ' but there is no 'FULL_CONTROL' causing exception below.

```
 File "/var/task/c7n/commands.py", line 66, in _load_policies
    collection = policy_load(options, fp, validate=validate, vars=vars)
  File "/var/task/c7n/policy.py", line 72, in load
    errors[1], errors[0]))
Exception: Failed to validate on policy s3
'FULL_CONTROL' is not one of ['READ', 'WRITE', 'WRITE_ACP', 'READ', 'READ_ACP']

Failed validating 'enum' in schema[5]['properties']['permissions']['items']:
    {'enum': ['READ', 'WRITE', 'WRITE_ACP', 'READ', 'READ_ACP'],
     'type': 'string'}

On instance['permissions'][4]:
    'FULL_CONTROL'
```