### PR TITLE
metrics output compatibility for boolean config

### DIFF
--- a/c7n/output.py
+++ b/c7n/output.py
@@ -56,6 +56,9 @@ class MetricsOutput(object):
     def select(metrics_selector):
         if not metrics_selector:
             return NullMetricsOutput
+        # Compatibility for boolean configuration
+        if isinstance(metrics_selector, bool):
+            metrics_selector = 'aws'
         for k in metrics_outputs.keys():
             if k.startswith(metrics_selector):
                 return metrics_outputs[k]

--- a/tests/test_output.py
+++ b/tests/test_output.py
@@ -21,9 +21,15 @@ import shutil
 import os
 
 from c7n.ctx import ExecutionContext
-from c7n.output import S3Output, DirectoryOutput
+from c7n.output import S3Output, DirectoryOutput, MetricsOutput
 
 from .common import Bag, BaseTest, TestConfig as Config
+
+
+class MetricsTest(BaseTest):
+
+    def test_boolean_config_compatibility(self):
+        self.assertEqual(MetricsOutput.select(True), MetricsOutput)
 
 
 class DirOutputTest(BaseTest):


### PR DESCRIPTION

preserve compatibility with boolean configuration for metrics, fixes #2871 