### PR TITLE
gcp serverless policy fixes

### DIFF
--- a/c7n/logs_support.py
+++ b/c7n/logs_support.py
@@ -21,13 +21,13 @@ import io
 import logging
 import re
 import time
-from botocore.exceptions import ClientError
 from concurrent.futures import as_completed
 from datetime import datetime
 from dateutil import parser
 from dateutil import tz
 from gzip import GzipFile
 
+from c7n.exceptions import ClientError
 from c7n.executor import ThreadPoolExecutor
 from c7n.utils import local_session
 

--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -39,7 +39,7 @@ from c7n.logs_support import _timestamp_from_string
 from c7n.utils import parse_s3, local_session
 
 
-log = logging.getLogger('custodian.lambda')
+log = logging.getLogger('custodian.serverless')
 
 
 class PythonPackageArchive(object):
@@ -190,7 +190,7 @@ class PythonPackageArchive(object):
         self._closed = True
         self._zip_file.close()
         log.debug(
-            "Created custodian lambda archive size: %0.2fmb",
+            "Created custodian serverless archive size: %0.2fmb",
             (os.path.getsize(self._temp_archive_file.name) / (
                 1024.0 * 1024.0)))
         return self
@@ -204,7 +204,7 @@ class PythonPackageArchive(object):
         """Return the b64 encoded sha256 checksum of the archive."""
         assert self._closed, "Archive not closed"
         with open(self._temp_archive_file.name, 'rb') as fh:
-            return encoder(checksum(fh, hasher()))
+            return encoder(checksum(fh, hasher())).decode('ascii')
 
     def get_bytes(self):
         """Return the entire zip file as a byte string. """

--- a/c7n/query.py
+++ b/c7n/query.py
@@ -26,7 +26,6 @@ from concurrent.futures import as_completed
 import jmespath
 import six
 
-from botocore.paginate import set_value_from_jmespath
 
 from c7n.actions import ActionRegistry
 from c7n.exceptions import ClientError, ResourceLimitExceeded
@@ -35,7 +34,8 @@ from c7n.manager import ResourceManager
 from c7n.registry import PluginRegistry
 from c7n.tags import register_ec2_tags, register_universal_tags
 from c7n.utils import (
-    local_session, generate_arn, get_retry, chunks, camelResource)
+    local_session, generate_arn, get_retry, chunks, camelResource,
+    set_value_from_jmespath)
 
 
 class ResourceQuery(object):

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -306,7 +306,7 @@ class PolicyLambdaProvision(BaseTest):
             Config.empty(),
         )
 
-        output = self.capture_logging("custodian.lambda", level=logging.DEBUG)
+        output = self.capture_logging("custodian.serverless", level=logging.DEBUG)
         result2 = mgr.publish(PolicyLambda(p), "Dev", role=ROLE)
 
         lines = output.getvalue().strip().split("\n")

--- a/tools/c7n_gcp/c7n_gcp/actions.py
+++ b/tools/c7n_gcp/c7n_gcp/actions.py
@@ -49,10 +49,12 @@ class MethodAction(Action):
         resources = [r for r in resources if r.get(attr_name) in valid_enum]
         if len(resources) != rcount:
             self.log.warning(
-                "%s implicity filtered %d resources to %d by values %s",
+                "policy:%s action:%s implicitly filtered %d resources to %d by attr:%s",
+                self.manager.ctx.policy.name,
+                self.type,
                 rcount,
                 len(resources),
-                ", ".join(map(str, valid_enum))
+                attr_name,
             )
         return resources
 


### PR DESCRIPTION
- py3 client/cli compatibility for function upload
- py3 client/cli compatibility for function checksum delta
- gcp complete botocore dependency removal
- gcp method action, fix implicit filter logging
- gcp serverless add python-dateutil dependency

closes #2860 