### PR TITLE
json schema on a diet

### DIFF
--- a/c7n/filters/config.py
+++ b/c7n/filters/config.py
@@ -62,7 +62,7 @@ class ConfigCompliance(Filter):
             'COMPLIANT', 'NON_COMPLIANT',
             'NOT_APPLICABLE', 'INSUFFICIENT_DATA']}},
         rules={'type': 'array', 'items': {'type': 'string'}})
-
+    schema_alias = True
     annotation_key = 'c7n:config-compliance'
 
     def get_resource_map(self, filters, resource_model, resources):

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -161,6 +161,7 @@ class Filter(object):
     metrics = ()
     permissions = ()
     schema = {'type': 'object'}
+    schema_alias = None
 
     def __init__(self, data, manager=None):
         self.data = data

--- a/c7n/filters/health.py
+++ b/c7n/filters/health.py
@@ -26,7 +26,6 @@ class HealthEventFilter(Filter):
 
     Health events are stored as annotation on a resource.
     """
-
     schema = type_schema(
         'health-event',
         types={'type': 'array', 'items': {'type': 'string'}},
@@ -34,7 +33,6 @@ class HealthEventFilter(Filter):
             'type': 'string',
             'enum': ['open', 'upcoming', 'closed']
         }})
-
     permissions = ('health:DescribeEvents', 'health:DescribeAffectedEntities',
                    'health:DescribeEventDetails')
 

--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -68,7 +68,7 @@ class MetricsFilter(Filter):
            'attr-multiplier': {'type': 'number'},
            'percent-attr': {'type': 'string'},
            'required': ('value', 'name')})
-
+    schema_alias = True
     permissions = ("cloudwatch:GetMetricStatistics",)
 
     MAX_QUERY_POINTS = 50850

--- a/c7n/filters/vpc.py
+++ b/c7n/filters/vpc.py
@@ -26,6 +26,7 @@ class SecurityGroupFilter(RelatedResourceFilter):
         'security-group', rinherit=ValueFilter.schema,
         **{'match-resource': {'type': 'boolean'},
            'operator': {'enum': ['and', 'or']}})
+    schema_alias = True
 
     RelatedResource = "c7n.resources.vpc.SecurityGroup"
     AnnotationKey = "matched-security-groups"
@@ -37,6 +38,7 @@ class SubnetFilter(RelatedResourceFilter):
         'subnet', rinherit=ValueFilter.schema,
         **{'match-resource': {'type': 'boolean'},
            'operator': {'enum': ['and', 'or']}})
+    schema_alias = True
 
     RelatedResource = "c7n.resources.vpc.Subnet"
     AnnotationKey = "matched-subnets"

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -313,7 +313,9 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None, d
             if filter_name in definitions['filters']:
                 assert definitions['filters'][filter_name] == f.schema, "Schema mismatch on filter w/ schema alias"
             definitions['filters'][filter_name] = f.schema
-            r['filters']['$ref'] = '#/definitions/filters/%s' % filter_name
+            filter_refs.append({
+                '$ref': '#/definitions/filters/%s' % filter_name})
+            continue
         elif filter_name == 'value':
             r['filters'][filter_name] = {
                 '$ref': '#/definitions/filters/value'}

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -165,6 +165,7 @@ def generate(resource_types=()):
                 {'required': ['NotPrincipal', 'NotAction', 'NotResource']}
             ]
         },
+        'actions': {},
         'filters': {
             'value': ValueFilter.schema,
             'event': EventFilter.schema,
@@ -232,7 +233,13 @@ def generate(resource_types=()):
             if cloud_name == 'aws':
                 alias_name = type_name
             resource_refs.append(
-                process_resource(r_type_name, resource_type, resource_defs, alias_name))
+                process_resource(
+                    r_type_name,
+                    resource_type,
+                    resource_defs,
+                    alias_name,
+                    definitions
+                ))
 
     schema = {
         '$schema': 'http://json-schema.org/schema#',
@@ -254,7 +261,7 @@ def generate(resource_types=()):
     return schema
 
 
-def process_resource(type_name, resource_type, resource_defs, alias_name=None):
+def process_resource(type_name, resource_type, resource_defs, alias_name=None, definitions=None):
     r = resource_defs.setdefault(type_name, {'actions': {}, 'filters': {}})
 
     seen_actions = set()  # Aliases get processed once
@@ -264,10 +271,16 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None):
             continue
         else:
             seen_actions.add(a)
-        r['actions'][action_name] = a.schema
-        action_refs.append(
-            {'$ref': '#/definitions/resources/%s/actions/%s' % (
-                type_name, action_name)})
+        if a.schema_alias:
+            if action_name in definitions['actions']:
+                assert definitions['actions'][action_name] == a.schema, "Schema mismatch on action w/ schema alias"
+            definitions['actions'][action_name] = a.schema
+            action_refs.append({'$ref': '#/definitions/actions/%s' % action_name})
+        else:
+            r['actions'][action_name] = a.schema
+            action_refs.append(
+                {'$ref': '#/definitions/resources/%s/actions/%s' % (
+                    type_name, action_name)})
 
     # one word action shortcuts
     action_refs.append(
@@ -296,6 +309,11 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None):
 
         if filter_name in ('or', 'and', 'not'):
             continue
+        if f.schema_alias:
+            if filter_name in definitions['filters']:
+                assert definitions['filters'][filter_name] == f.schema, "Schema mismatch on filter w/ schema alias"
+            definitions['filters'][filter_name] = f.schema
+            r['filters']['$ref'] = '#/definitions/filters/%s' % filter_name
         elif filter_name == 'value':
             r['filters'][filter_name] = {
                 '$ref': '#/definitions/filters/value'}

--- a/c7n/schema.py
+++ b/c7n/schema.py
@@ -273,7 +273,7 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None, d
             seen_actions.add(a)
         if a.schema_alias:
             if action_name in definitions['actions']:
-                assert definitions['actions'][action_name] == a.schema, "Schema mismatch on action w/ schema alias"
+                assert definitions['actions'][action_name] == a.schema, "Schema mismatch on action w/ schema alias"  # NOQA
             definitions['actions'][action_name] = a.schema
             action_refs.append({'$ref': '#/definitions/actions/%s' % action_name})
         else:
@@ -311,7 +311,7 @@ def process_resource(type_name, resource_type, resource_defs, alias_name=None, d
             continue
         if f.schema_alias:
             if filter_name in definitions['filters']:
-                assert definitions['filters'][filter_name] == f.schema, "Schema mismatch on filter w/ schema alias"
+                assert definitions['filters'][filter_name] == f.schema, "Schema mismatch on filter w/ schema alias" # NOQA
             definitions['filters'][filter_name] = f.schema
             filter_refs.append({
                 '$ref': '#/definitions/filters/%s' % filter_name})

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -167,6 +167,7 @@ class TagTrim(Action):
         'tag-trim',
         space={'type': 'integer'},
         preserve={'type': 'array', 'items': {'type': 'string'}})
+    schema_alias = True
 
     permissions = ('ec2:DeleteTags',)
 
@@ -263,6 +264,7 @@ class TagActionFilter(Filter):
         skew={'type': 'number', 'minimum': 0},
         skew_hours={'type': 'number', 'minimum': 0},
         op={'type': 'string'})
+    schema_alias = True
 
     current_date = None
 
@@ -342,6 +344,7 @@ class TagCountFilter(Filter):
         'tag-count',
         count={'type': 'integer', 'minimum': 0},
         op={'enum': list(OPERATORS.keys())})
+    schema_alias = 'tag_count'
 
     def __call__(self, i):
         count = self.data.get('count', 10)
@@ -367,7 +370,7 @@ class Tag(Action):
         value={'type': 'string'},
         tag={'type': 'string'},
     )
-
+    schema_alias = 'tag'
     permissions = ('ec2:CreateTags',)
 
     def validate(self):
@@ -469,6 +472,7 @@ class RenameTag(Action):
         'rename-tag',
         old_key={'type': 'string'},
         new_key={'type': 'string'})
+    schema_alias = True
 
     permissions = ('ec2:CreateTags', 'ec2:DeleteTags')
 
@@ -584,6 +588,7 @@ class TagDelayedAction(Action):
         hours={'type': 'integer', 'minimum': 0, 'exclusiveMinimum': False},
         tz={'type': 'string'},
         op={'type': 'string'})
+    schema_alias = True
 
     permissions = ('ec2:CreateTags',)
 
@@ -698,6 +703,7 @@ class NormalizeTag(Action):
 
     """
 
+    schema_alias = True
     schema = utils.type_schema(
         'normalize-tag',
         key={'type': 'string'},

--- a/c7n/tags.py
+++ b/c7n/tags.py
@@ -344,7 +344,7 @@ class TagCountFilter(Filter):
         'tag-count',
         count={'type': 'integer', 'minimum': 0},
         op={'enum': list(OPERATORS.keys())})
-    schema_alias = 'tag_count'
+    schema_alias = True
 
     def __call__(self, i):
         count = self.data.get('count', 10)
@@ -370,7 +370,7 @@ class Tag(Action):
         value={'type': 'string'},
         tag={'type': 'string'},
     )
-    schema_alias = 'tag'
+    schema_alias = True
     permissions = ('ec2:CreateTags',)
 
     def validate(self):


### PR DESCRIPTION
generated schema goes from 2.8mb to 1.2mb via better use of 'refs', still preserves `custodian schema` usage on individual filter/actions.

this also removes default registration for actions that don't make sense for other providers ('invoke-lambda', etc).