### PR TITLE
always perform non schema validation for filters/actions doing lazy init

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -123,9 +123,10 @@ def policy_command(f):
                     log.error("duplicate policy name '{}'".format(policy))
                     sys.exit(1)
 
-        # Variable expansion
+        # Variable expansion and non schema validation (not optional)
         for p in policies:
             p.expand_variables(p.get_variables())
+            p.validate()
 
         return f(options, list(policies))
 


### PR DESCRIPTION

Several filters and actions do lazy initialization in validate method, we should always perform non schema validation. Additionally non schema validation was taking place pre policy expansion by the provider which meant the new policy set returned by the provider was not having validation performed on it.