### PR TITLE
fix: Fixing the S3 bucket policy custodian applies

### DIFF
--- a/docs/source/usecases/s3denypublicobjectacls.rst
+++ b/docs/source/usecases/s3denypublicobjectacls.rst
@@ -11,10 +11,13 @@ Being that S3 object permissions can be hard to track and restrict due to the hu
 amount of S3 objects usually present in accounts, this policy allows you to prevent
 the issue from occuring in the first place and helps maintain tighter S3 security
 to avoid accidentally setting sensitive S3 objects to public.  Note the S3 bucket
-policy has a NotPrincipal statement of "AWS": "arn:aws:iam::858827067514:root"
-which is actually an account owned by AWS and used for it's Log Delivery Service.
-If the "arn:aws:iam::858827067514:root" statement is not there the Log Delivery
-service won't be able to write logs to your logging buckets!
+policy has a NotPrincipal statement with several "AWS": arns.  These arns are owned
+by AWS and they are used for the AWS logging services for Log Delivery Group, ELB Logs,
+and Redshift Logs.  The ELB and Redshift arns are region specific so depending on the
+regions you are utilizing you might need to add or remove addtional arns found here:
+Redshift Log Accounts: https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html
+ELB Log Accounts: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
+
 
 .. code-block:: yaml
 
@@ -34,7 +37,12 @@ service won't be able to write logs to your logging buckets!
                 Effect: "Deny"
                 Action: "s3:PutObjectAcl"
                 NotPrincipal:
-                   "AWS": "arn:aws:iam::858827067514:root"
+                  "AWS":
+                      - "arn:aws:iam::858827067514:root"
+                      - "arn:aws:iam::193672423079:user/logs"
+                      - "arn:aws:iam::210876761215:user/logs"
+                      - "arn:aws:iam::127311923021:root"
+                      - "arn:aws:iam::156460612806:root"
                 Resource:
                    - "arn:aws:s3:::{bucket_name}/*"
                    - "arn:aws:s3:::{bucket_name}"
@@ -69,7 +77,12 @@ service won't be able to write logs to your logging buckets!
                Effect: "Deny"
                Action: "s3:PutObjectAcl"
                NotPrincipal:
-                   "AWS": "arn:aws:iam::858827067514:root"
+                  "AWS":
+                      - "arn:aws:iam::858827067514:root"
+                      - "arn:aws:iam::193672423079:user/logs"
+                      - "arn:aws:iam::210876761215:user/logs"
+                      - "arn:aws:iam::127311923021:root"
+                      - "arn:aws:iam::156460612806:root"
                Resource:
                   - "arn:aws:s3:::{bucket_name}/*"
                   - "arn:aws:s3:::{bucket_name}"

--- a/docs/source/usecases/s3denypublicobjectacls.rst
+++ b/docs/source/usecases/s3denypublicobjectacls.rst
@@ -13,8 +13,9 @@ the issue from occuring in the first place and helps maintain tighter S3 securit
 to avoid accidentally setting sensitive S3 objects to public.  Note the S3 bucket
 policy has a NotPrincipal statement with several "AWS": arns.  These arns are owned
 by AWS and they are used for the AWS logging services for Log Delivery Group, ELB Logs,
-and Redshift Logs.  The ELB and Redshift arns are region specific so depending on the
-regions you are utilizing you might need to add or remove addtional arns found here:
+and Redshift Logs.  The ELB and Redshift arns are region specific
+(sample includesus-east-1 and eu-west-1) so depending on the regions you are utilizing
+you might need to add or remove addtional arns found here:
 Redshift Log Accounts: https://docs.aws.amazon.com/redshift/latest/mgmt/db-auditing.html
 ELB Log Accounts: https://docs.aws.amazon.com/elasticloadbalancing/latest/classic/enable-access-logs.html
 
@@ -27,9 +28,9 @@ ELB Log Accounts: https://docs.aws.amazon.com/elasticloadbalancing/latest/classi
        resource: s3
        description: |
          Appends a bucket policy statement to all existing s3 buckets to
-         deny anyone except for the AWS Log Delivery Service (arn:aws:iam::858827067514:root)
-         from setting s3 objects in the bucket to public-read,
-         public-read-write, or any authenticated AWS user.
+         deny anyone except for the AWS Logging Services from setting s3
+         objects in the bucket to public-read, public-read-write, or any
+         authenticated AWS user.
        actions:
          - type: set-statements
            statements:
@@ -68,8 +69,9 @@ ELB Log Accounts: https://docs.aws.amazon.com/elasticloadbalancing/latest/classi
        description: |
          Appends a bucket policy statement to an s3 bucket when it detects
          a policy change to the bucket or a new bucket is created which
-         will deny anyone from setting s3 objects in the bucket to public-read,
-         public-read-write, or any authenticated AWS user.
+         will deny anyone except some AWS logging services from setting
+         s3 objects in the bucket to public-read, public-read-write, or
+         any authenticated AWS user.
        actions:
          - type: set-statements
            statements:

--- a/docs/source/usecases/s3denypublicobjectacls.rst
+++ b/docs/source/usecases/s3denypublicobjectacls.rst
@@ -10,7 +10,11 @@ in these buckets from being set to public-read, public-read-write
 Being that S3 object permissions can be hard to track and restrict due to the huge
 amount of S3 objects usually present in accounts, this policy allows you to prevent
 the issue from occuring in the first place and helps maintain tighter S3 security
-to avoid accidentally setting sensitive S3 objects to public.
+to avoid accidentally setting sensitive S3 objects to public.  Note the S3 bucket
+policy has a NotPrincipal statement of "AWS": "arn:aws:iam::858827067514:root"
+which is actually an account owned by AWS and used for it's Log Delivery Service.
+If the "arn:aws:iam::858827067514:root" statement is not there the Log Delivery
+service won't be able to write logs to your logging buckets!
 
 .. code-block:: yaml
 
@@ -20,7 +24,8 @@ to avoid accidentally setting sensitive S3 objects to public.
        resource: s3
        description: |
          Appends a bucket policy statement to all existing s3 buckets to
-         deny anyone from setting s3 objects in the bucket to public-read,
+         deny anyone except for the AWS Log Delivery Service (arn:aws:iam::858827067514:root)
+         from setting s3 objects in the bucket to public-read,
          public-read-write, or any authenticated AWS user.
        actions:
          - type: set-statements
@@ -28,7 +33,8 @@ to avoid accidentally setting sensitive S3 objects to public.
               - Sid: "DenyS3PublicObjectACL"
                 Effect: "Deny"
                 Action: "s3:PutObjectAcl"
-                Principal: "*"
+                NotPrincipal:
+                   "AWS": "arn:aws:iam::858827067514:root"
                 Resource:
                    - "arn:aws:s3:::{bucket_name}/*"
                    - "arn:aws:s3:::{bucket_name}"
@@ -62,7 +68,8 @@ to avoid accidentally setting sensitive S3 objects to public.
              - Sid: "DenyS3PublicObjectACL"
                Effect: "Deny"
                Action: "s3:PutObjectAcl"
-               Principal: "*"
+               NotPrincipal:
+                   "AWS": "arn:aws:iam::858827067514:root"
                Resource:
                   - "arn:aws:s3:::{bucket_name}/*"
                   - "arn:aws:s3:::{bucket_name}"


### PR DESCRIPTION
The S3 policy as it was would block the AWS Log Delivery service from writing logs to any buckets the policy was applied to.  By changing the Principle: * to a NotPrinciple: AWS: "arn:aws:iam::858827067514:root" that fixes this issue as that is the arn of AWS's Log Delivery Service account.  I have tested and verified this is working and allows logs to be written and blocks both console and sdk public object attempts