### PR TITLE
tools/omnissm - retain ImageId in EC2 metadata doc

### DIFF
--- a/tools/omnissm/pkg/aws/ec2metadata/document.go
+++ b/tools/omnissm/pkg/aws/ec2metadata/document.go
@@ -33,6 +33,7 @@ type Document struct {
 	InstanceId       string `json:"instanceId"`
 	AccountId        string `json:"accountId"`
 	InstanceType     string `json:"instanceType"`
+	ImageId          string `json:"imageId"`
 }
 
 // Name returns the logical name for the instance described in the identity


### PR DESCRIPTION
Include `ImageId` in the data extracted from the EC2 identity document, for use by OmniSSM at the time of registration.