### PR TITLE
azure - add machine decryption key settings for Azure Functions

### DIFF
--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -125,7 +125,7 @@ class FunctionPackage(object):
 
         # linux
         platform = sys.platform
-        if platform == "linux" or platform == "linux2":
+        if platform == "linux" or platform == "linux2" or platform == "darwin":
             for so_file in os.listdir(site_pkg):
                 if fnmatch.fnmatch(so_file, '*ffi*.so*'):
                     self.pkg.add_file(os.path.join(site_pkg, so_file))
@@ -203,18 +203,22 @@ class FunctionPackage(object):
 
         return True
 
-    def publish(self, app_name):
+    def publish(self, app_name, pub_creds):
         self.close()
 
         # update perms of the package
         self._update_perms_package()
 
         s = local_session(Session)
-        zip_api_url = 'https://%s.scm.azurewebsites.net/api/zipdeploy?isAsync=true' % (app_name)
+        # zip_api_url = 'https://%s.scm.azurewebsites.net/api/zipdeploy?isAsync=true' % (app_name)
         headers = {
             'Content-type': 'application/zip',
-            'Authorization': 'Bearer %s' % (s.get_bearer_token())
+            # 'Authorization': 'Bearer %s' % (s.get_bearer_token())
         }
+
+        zip_api_url = "https://%s:%s@%s.scm.azurewebsites.net/api/zipdeploy?isAsync=true" % (
+            pub_creds.publishing_user_name, pub_creds.publishing_password, app_name)
+
 
         self.log.info("Publishing Function package from %s" % self.pkg.path)
 
@@ -227,7 +231,7 @@ class FunctionPackage(object):
 
         r.raise_for_status()
 
-        self.log.info("Function publish result: %s %s" % (r.status_code, r.text))
+        self.log.info("Function publish result: %s % s" % (r.status_code, r.text))
 
     def close(self):
         self.pkg.close()

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -125,7 +125,7 @@ class FunctionPackage(object):
 
         # linux
         platform = sys.platform
-        if platform == "linux" or platform == "linux2" or platform == "darwin":
+        if platform == "linux" or platform == "linux2":
             for so_file in os.listdir(site_pkg):
                 if fnmatch.fnmatch(so_file, '*ffi*.so*'):
                     self.pkg.add_file(os.path.join(site_pkg, so_file))
@@ -203,22 +203,18 @@ class FunctionPackage(object):
 
         return True
 
-    def publish(self, app_name, pub_creds):
+    def publish(self, app_name):
         self.close()
 
         # update perms of the package
         self._update_perms_package()
 
         s = local_session(Session)
-        # zip_api_url = 'https://%s.scm.azurewebsites.net/api/zipdeploy?isAsync=true' % (app_name)
+        zip_api_url = 'https://%s.scm.azurewebsites.net/api/zipdeploy?isAsync=true' % (app_name)
         headers = {
             'Content-type': 'application/zip',
-            # 'Authorization': 'Bearer %s' % (s.get_bearer_token())
+            'Authorization': 'Bearer %s' % (s.get_bearer_token())
         }
-
-        zip_api_url = "https://%s:%s@%s.scm.azurewebsites.net/api/zipdeploy?isAsync=true" % (
-            pub_creds.publishing_user_name, pub_creds.publishing_password, app_name)
-
 
         self.log.info("Publishing Function package from %s" % self.pkg.path)
 
@@ -231,7 +227,7 @@ class FunctionPackage(object):
 
         r.raise_for_status()
 
-        self.log.info("Function publish result: %s % s" % (r.status_code, r.text))
+        self.log.info("Function publish result: %s %s" % (r.status_code, r.text))
 
     def close(self):
         self.pkg.close()

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -42,7 +42,7 @@ class FunctionAppUtilities(object):
                                                       CONST_FUNCTIONS_EXT_VERSION))
         site_config.app_settings.append(NameValuePair('FUNCTIONS_WORKER_RUNTIME', 'python'))
         site_config.app_settings.append(
-            NameValuePair('MACHINEKEY_DecryptionKey', b16encode(os.urandom(64)).decode('utf-8')))
+            NameValuePair('MACHINEKEY_DecryptionKey', b16encode(os.urandom(32)).decode('utf-8')))
 
         #: :type: azure.mgmt.web.WebSiteManagementClient
         web_client = self.local_session.client('azure.mgmt.web.WebSiteManagementClient')

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -59,7 +59,8 @@ class FunctionAppUtilities(object):
                                                       CONST_FUNCTIONS_EXT_VERSION))
         site_config.app_settings.append(NameValuePair('FUNCTIONS_WORKER_RUNTIME', 'python'))
         site_config.app_settings.append(
-            NameValuePair('MACHINEKEY_DecryptionKey', FunctionAppUtilities.generate_machine_decryption_key()))
+            NameValuePair('MACHINEKEY_DecryptionKey',
+                          FunctionAppUtilities.generate_machine_decryption_key()))
 
         #: :type: azure.mgmt.web.WebSiteManagementClient
         web_client = self.local_session.client('azure.mgmt.web.WebSiteManagementClient')

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -30,6 +30,7 @@ class FunctionAppUtilities(object):
 
     @staticmethod
     def generate_machine_decryption_key():
+        # randomly generated decryption key for Functions key
         return str(hexlify(os.urandom(32)).decode()).upper()
 
     def deploy_webapp(self, app_name, group_name, service_plan, storage_account_name):

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -1,3 +1,5 @@
+from base64 import b16encode
+import os
 import logging
 
 from azure.mgmt.web.models import (Site, SiteConfig, NameValuePair)
@@ -38,6 +40,7 @@ class FunctionAppUtilities(object):
         site_config.app_settings.append(NameValuePair('FUNCTIONS_EXTENSION_VERSION',
                                                       CONST_FUNCTIONS_EXT_VERSION))
         site_config.app_settings.append(NameValuePair('FUNCTIONS_WORKER_RUNTIME', 'python'))
+        site_config.app_settings.append(NameValuePair('MACHINEKEY_DecryptionKey', b16encode(os.urandom(64)).decode('utf-8')))
 
         #: :type: azure.mgmt.web.WebSiteManagementClient
         web_client = self.local_session.client('azure.mgmt.web.WebSiteManagementClient')

--- a/tools/c7n_azure/c7n_azure/functionapp_utils.py
+++ b/tools/c7n_azure/c7n_azure/functionapp_utils.py
@@ -1,4 +1,5 @@
 from base64 import b16encode
+
 import os
 import logging
 
@@ -40,7 +41,8 @@ class FunctionAppUtilities(object):
         site_config.app_settings.append(NameValuePair('FUNCTIONS_EXTENSION_VERSION',
                                                       CONST_FUNCTIONS_EXT_VERSION))
         site_config.app_settings.append(NameValuePair('FUNCTIONS_WORKER_RUNTIME', 'python'))
-        site_config.app_settings.append(NameValuePair('MACHINEKEY_DecryptionKey', b16encode(os.urandom(64)).decode('utf-8')))
+        site_config.app_settings.append(
+            NameValuePair('MACHINEKEY_DecryptionKey', b16encode(os.urandom(64)).decode('utf-8')))
 
         #: :type: azure.mgmt.web.WebSiteManagementClient
         web_client = self.local_session.client('azure.mgmt.web.WebSiteManagementClient')
@@ -67,7 +69,7 @@ class FunctionAppUtilities(object):
 
         try:
             app_insights = insights_client.components.get(resource_group_name,
-                                                      application_insights_name)
+                                                          application_insights_name)
             return app_insights.instrumentation_key
 
         except Exception:

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -120,7 +120,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
         updated_parameters = {
             'dockerVersion': CONST_DOCKER_VERSION,
             'functionsExtVersion': CONST_FUNCTIONS_EXT_VERSION,
-            'machineDecryptionKey': b16encode(os.urandom(64)).decode('utf-8')
+            'machineDecryptionKey': b16encode(os.urandom(32)).decode('utf-8')
         }
 
         if 'mode' in data:

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -12,30 +12,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import os
-from binascii import hexlify
-
-import requests
-import logging
 import json
+import logging
 import time
 
-from c7n_azure.function_package import FunctionPackage
-from msrestazure.azure_exceptions import CloudError
-from c7n_azure.functionapp_utils import FunctionAppUtilities
-from c7n_azure.template_utils import TemplateUtilities
+import requests
+from azure.mgmt.eventgrid.models import (EventSubscription, EventSubscriptionFilter,
+                                         WebHookEventSubscriptionDestination)
 from c7n_azure.azure_events import AzureEvents
 from c7n_azure.constants import (CONST_DOCKER_VERSION, CONST_FUNCTIONS_EXT_VERSION,
                                  CONST_AZURE_EVENT_TRIGGER_MODE, CONST_AZURE_TIME_TRIGGER_MODE,
                                  CONST_AZURE_FUNCTION_KEY_URL)
+from c7n_azure.function_package import FunctionPackage
+from c7n_azure.functionapp_utils import FunctionAppUtilities
+from c7n_azure.template_utils import TemplateUtilities
+from msrestazure.azure_exceptions import CloudError
 
 from c7n import utils
 from c7n.actions import EventAction
 from c7n.policy import ServerlessExecutionMode, PullMode, execution
 from c7n.utils import local_session
-
-from azure.mgmt.eventgrid.models import (EventSubscription, EventSubscriptionFilter,
-                                         WebHookEventSubscriptionDestination)
 
 
 class AzureFunctionMode(ServerlessExecutionMode):
@@ -105,7 +101,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
         archive.build(self.policy.data)
         archive.close()
 
-        self.log.info("Function package built: %dMB" % (archive.pkg.size / (1024 * 1024)))
+        self.log.info("Function package built, size is %dMB" % (archive.pkg.size / (1024 * 1024)))
 
         if archive.wait_for_status(self.webapp_name):
             archive.publish(self.webapp_name)
@@ -212,8 +208,8 @@ class AzureEventGridMode(AzureFunctionMode):
                 status_success = True
             except CloudError as e:
                 self.log.info(e)
-                self.log.info('Retrying in 15 seconds')
-                time.sleep(15)
+                self.log.info('Retrying in 30 seconds')
+                time.sleep(30)
 
     def _get_webhook_key(self):
         self.log.info("Fetching Function's API keys")

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -12,8 +12,8 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from base64 import b16encode
-import os
 
+import os
 import requests
 import logging
 import json
@@ -104,7 +104,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
         archive.build(self.policy.data)
         archive.close()
 
-        self.log.info("Function package built: %dMB" % (archive.pkg.size / (1024*1024)))
+        self.log.info("Function package built: %dMB" % (archive.pkg.size / (1024 * 1024)))
 
         if archive.wait_for_status(self.webapp_name):
             archive.publish(self.webapp_name)
@@ -120,7 +120,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
         updated_parameters = {
             'dockerVersion': CONST_DOCKER_VERSION,
             'functionsExtVersion': CONST_FUNCTIONS_EXT_VERSION,
-            'machineDecryptionKey' : b16encode(os.urandom(64)).decode('utf-8')
+            'machineDecryptionKey': b16encode(os.urandom(64)).decode('utf-8')
         }
 
         if 'mode' in data:
@@ -224,10 +224,10 @@ class AzureEventGridMode(AzureFunctionMode):
             'https://management.azure.com'
             '/subscriptions/{0}/resourceGroups/{1}/'
             'providers/Microsoft.Web/sites/{2}/{3}').format(
-                self.session.subscription_id,
-                self.group_name,
-                self.webapp_name,
-                CONST_AZURE_FUNCTION_KEY_URL)
+            self.session.subscription_id,
+            self.group_name,
+            self.webapp_name,
+            CONST_AZURE_FUNCTION_KEY_URL)
 
         retrieved_key = False
 

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -11,9 +11,10 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
-from base64 import b16encode
 
 import os
+from binascii import hexlify
+
 import requests
 import logging
 import json
@@ -120,7 +121,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
         updated_parameters = {
             'dockerVersion': CONST_DOCKER_VERSION,
             'functionsExtVersion': CONST_FUNCTIONS_EXT_VERSION,
-            'machineDecryptionKey': b16encode(os.urandom(32)).decode('utf-8')
+            'machineDecryptionKey': FunctionAppUtilities.generate_machine_decryption_key()
         }
 
         if 'mode' in data:

--- a/tools/c7n_azure/c7n_azure/policy.py
+++ b/tools/c7n_azure/c7n_azure/policy.py
@@ -107,9 +107,7 @@ class AzureFunctionMode(ServerlessExecutionMode):
         self.log.info("Function package built: %dMB" % (archive.pkg.size / (1024*1024)))
 
         if archive.wait_for_status(self.webapp_name):
-            web_client = self.session.client('azure.mgmt.web.WebSiteManagementClient')
-            pub_creds = web_client.web_apps.list_publishing_credentials(self.group_name, self.webapp_name).result(30)
-            archive.publish(self.webapp_name, pub_creds)
+            archive.publish(self.webapp_name)
         else:
             self.log.error("Aborted deployment, ensure Application Service is healthy.")
 

--- a/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.json
+++ b/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.json
@@ -29,6 +29,9 @@
         },
         "functionsExtVersion" : {
             "type": "string"
+        },
+        "machineDecryptionKey" : {
+            "type": "securestring"
         }
     },
     "resources": [
@@ -103,6 +106,10 @@
                         {
                             "name": "APPINSIGHTS_INSTRUMENTATIONKEY",
                             "value": "[reference(resourceId('microsoft.insights/components/', parameters('servicePlanName')), '2015-05-01').InstrumentationKey]"
+                        },
+                        {
+                            "name": "MACHINEKEY_DecryptionKey",
+                            "value": "[parameters('machineDecryptionKey')]"
                         }
                     ],
                     "alwaysOn": true,

--- a/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.parameters.json
+++ b/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.parameters.json
@@ -31,6 +31,9 @@
         },
         "functionsExtVersion": {
             "value": "beta"
+        },
+        "machineDecryptionKey": {
+            "value": "DefaultKey"
         }
     }
 }

--- a/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.test.parameters.json
+++ b/tools/c7n_azure/c7n_azure/templates/dedicated_functionapp.test.parameters.json
@@ -31,6 +31,9 @@
         },
         "functionsExtVersion": {
             "value": "beta"
+        },
+        "machineDecryptionKey": {
+            "value": "DefaultKey"
         }
     }
 }

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -12,14 +12,15 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
-from base64 import b16encode
 
 import json
-import os
 import logging
+import os
+from binascii import hexlify
 
 try:
     from c7n_azure.function_package import FunctionPackage
+    from c7n_azure.functionapp_utils import FunctionAppUtilities
     from c7n_azure.template_utils import TemplateUtilities
     from c7n_azure.constants import CONST_DOCKER_VERSION, CONST_FUNCTIONS_EXT_VERSION
 except ImportError:
@@ -108,7 +109,7 @@ def _get_parameters(template_util, func_config):
     func_config['storageName'] = (func_config['servicePlanName']).replace('-', '')
     func_config['dockerVersion'] = CONST_DOCKER_VERSION
     func_config['functionsExtVersion'] = CONST_FUNCTIONS_EXT_VERSION
-    func_config['machineDecryptionKey'] = b16encode(os.urandom(32)).decode('utf-8')
+    func_config['machineDecryptionKey'] = FunctionAppUtilities.generate_machine_decryption_key()
 
     parameters = template_util.update_parameters(parameters, func_config)
 

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -13,6 +13,8 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from base64 import b16encode
+
 import json
 import os
 import logging
@@ -107,6 +109,7 @@ def _get_parameters(template_util, func_config):
     func_config['storageName'] = (func_config['servicePlanName']).replace('-', '')
     func_config['dockerVersion'] = CONST_DOCKER_VERSION
     func_config['functionsExtVersion'] = CONST_FUNCTIONS_EXT_VERSION
+    func_config['machineDecryptionKey'] = b16encode(os.urandom(64)).decode('utf-8')
 
     parameters = template_util.update_parameters(parameters, func_config)
 

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -14,9 +14,8 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 import json
-import logging
 import os
-from binascii import hexlify
+import logging
 
 try:
     from c7n_azure.function_package import FunctionPackage

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -12,7 +12,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
-
 from base64 import b16encode
 
 import json

--- a/tools/c7n_mailer/c7n_mailer/azure/deploy.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/deploy.py
@@ -108,7 +108,7 @@ def _get_parameters(template_util, func_config):
     func_config['storageName'] = (func_config['servicePlanName']).replace('-', '')
     func_config['dockerVersion'] = CONST_DOCKER_VERSION
     func_config['functionsExtVersion'] = CONST_FUNCTIONS_EXT_VERSION
-    func_config['machineDecryptionKey'] = b16encode(os.urandom(64)).decode('utf-8')
+    func_config['machineDecryptionKey'] = b16encode(os.urandom(32)).decode('utf-8')
 
     parameters = template_util.update_parameters(parameters, func_config)
 


### PR DESCRIPTION
- This setting is needed for the Linux dedicated machines in order for the system keys to be encrypted. Without the setting, we will not be able to fetch the keys needed for completing the Event Grid subscription
- We have opened an issue with the Function Host to fix this run-time requirement [here](https://github.com/Azure/azure-functions-host/issues/3518)
- Fix #2934 