### PR TITLE
feat: Add aws:glue-dev-endpoint resource and delete action

### DIFF
--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -82,7 +82,6 @@ class DeleteConnection(BaseAction):
             list(w.map(self.delete_connection, resources))
 
 
-
 @resources.register('glue-dev-endpoint')
 class GlueDevEndpoint(QueryResourceManager):
 

--- a/c7n/resources/glue.py
+++ b/c7n/resources/glue.py
@@ -80,3 +80,51 @@ class DeleteConnection(BaseAction):
     def process(self, resources):
         with self.executor_factory(max_workers=2) as w:
             list(w.map(self.delete_connection, resources))
+
+
+
+@resources.register('glue-dev-endpoint')
+class GlueDevEndpoint(QueryResourceManager):
+
+    class resource_type(object):
+        service = 'glue'
+        enum_spec = ('get_dev_endpoints', 'DevEndpoints', None)
+        detail_spec = None
+        id = name = 'EndpointName'
+        date = 'CreatedTimestamp'
+        dimension = None
+        filter_name = None
+
+    permissions = ('glue:GetDevEndpoints',)
+
+
+@GlueDevEndpoint.action_registry.register('delete')
+class DeleteDevEndpoint(BaseAction):
+    """Delete a connection from the data catalog
+
+    :example:
+
+    .. code-block: yaml
+
+        policies:
+          - name: delete-public-dev-endpoints
+            resource: glue-dev-endpoint
+            filters:
+              - PublicAddress: present
+            actions:
+              - type: delete
+    """
+    schema = type_schema('delete')
+    permissions = ('glue:DeleteDevEndpoint',)
+
+    def delete_dev_endpoint(self, r):
+        client = local_session(self.manager.session_factory).client('glue')
+        try:
+            client.delete_dev_endpoint(EndpointName=r['EndpointName'])
+        except ClientError as e:
+            if e.response['Error']['Code'] != 'EntityNotFoundException':
+                raise
+
+    def process(self, resources):
+        with self.executor_factory(max_workers=2) as w:
+            list(w.map(self.delete_dev_endpoint, resources))

--- a/tests/data/placebo/test_glue_dev_endpoint_delete/glue.DeleteDevEndpoint_1.json
+++ b/tests/data/placebo/test_glue_dev_endpoint_delete/glue.DeleteDevEndpoint_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d6b3a326-c8db-11e8-934b-0d1a57ba5a33", 
+            "HTTPHeaders": {
+                "date": "Fri, 05 Oct 2018 20:18:36 GMT", 
+                "x-amzn-requestid": "d6b3a326-c8db-11e8-934b-0d1a57ba5a33", 
+                "content-length": "2", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_glue_dev_endpoint_delete/glue.GetDevEndpoints_1.json
+++ b/tests/data/placebo/test_glue_dev_endpoint_delete/glue.GetDevEndpoints_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NextToken": "", 
+        "DevEndpoints": [
+            {
+                "Status": "READY", 
+                "AvailabilityZone": "us-east-1b", 
+                "PublicAddress": "ec2-35-171-203-92.compute-1.amazonaws.com", 
+                "RoleArn": "arn:aws:iam::12345678910:role/Glue-Service-Role", 
+                "ZeppelinRemoteSparkInterpreterPort": 9007, 
+                "CreatedTimestamp": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 2, 
+                    "microsecond": 779000, 
+                    "year": 2018, 
+                    "day": 5, 
+                    "minute": 9
+                }, 
+                "EndpointName": "public-test-bad-end", 
+                "SecurityGroupIds": [], 
+                "LastModifiedTimestamp": {
+                    "hour": 20, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 48, 
+                    "microsecond": 920000, 
+                    "year": 2018, 
+                    "day": 5, 
+                    "minute": 16
+                }, 
+                "NumberOfNodes": 5
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d6a3c4b6-c8db-11e8-82d7-81fe315e3e71", 
+            "HTTPHeaders": {
+                "date": "Fri, 05 Oct 2018 20:18:35 GMT", 
+                "x-amzn-requestid": "d6a3c4b6-c8db-11e8-82d7-81fe315e3e71", 
+                "content-length": "404", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_glue_dev_endpoint_delete/glue.GetDevEndpoints_2.json
+++ b/tests/data/placebo/test_glue_dev_endpoint_delete/glue.GetDevEndpoints_2.json
@@ -1,0 +1,19 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NextToken": "", 
+        "DevEndpoints": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d6d5aa30-c8db-11e8-b29f-8f943bd9b259", 
+            "HTTPHeaders": {
+                "date": "Fri, 05 Oct 2018 20:18:36 GMT", 
+                "x-amzn-requestid": "d6d5aa30-c8db-11e8-b29f-8f943bd9b259", 
+                "content-length": "34", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_glue_query_resources/glue.GetDevEndpoints_1.json
+++ b/tests/data/placebo/test_glue_query_resources/glue.GetDevEndpoints_1.json
@@ -1,0 +1,50 @@
+{
+    "status_code": 200, 
+    "data": {
+        "NextToken": "", 
+        "DevEndpoints": [
+            {
+                "Status": "READY", 
+                "AvailabilityZone": "us-east-1c", 
+                "PublicAddress": "ec2-54-196-134-254.compute-1.amazonaws.com", 
+                "RoleArn": "arn:aws:iam::12345678910:role/Glue-Service-Role", 
+                "ZeppelinRemoteSparkInterpreterPort": 9007, 
+                "CreatedTimestamp": {
+                    "hour": 15, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 36, 
+                    "microsecond": 632000, 
+                    "year": 2018, 
+                    "day": 5, 
+                    "minute": 51
+                }, 
+                "EndpointName": "public-test-bad-end2", 
+                "SecurityGroupIds": [], 
+                "LastModifiedTimestamp": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 10, 
+                    "second": 46, 
+                    "microsecond": 580000, 
+                    "year": 2018, 
+                    "day": 5, 
+                    "minute": 30
+                }, 
+                "NumberOfNodes": 5
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "73e213cf-c8d7-11e8-af80-17647f59ab9f", 
+            "HTTPHeaders": {
+                "date": "Fri, 05 Oct 2018 19:47:12 GMT", 
+                "x-amzn-requestid": "73e213cf-c8d7-11e8-af80-17647f59ab9f", 
+                "content-length": "406", 
+                "content-type": "application/x-amz-json-1.1", 
+                "connection": "keep-alive"
+            }
+        }
+    }
+}

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -79,3 +79,31 @@ class TestGlueConnections(BaseTest):
         client = session_factory().client("glue")
         connections = client.get_connections()["ConnectionList"]
         self.assertFalse(connections)
+
+class TestGlueDevEndpoints(BaseTest):
+
+    def test_dev_endpoints_query(self):
+        session_factory = self.replay_flight_data("test_glue_query_resources")
+        p = self.load_policy(
+            {"name": "list-glue-dev-endpoints", "resource": "glue-dev-endpoint"},
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+
+    def test_dev_endpoints_delete(self):
+        session_factory = self.replay_flight_data("test_glue_dev_endpoint_delete")
+        p = self.load_policy(
+            {
+                "name": "glue-dev-endpoint-delete",
+                "resource": "glue-dev-endpoint",
+                "filters": [{"PublicAddress": "present"}],
+                "actions": [{"type": "delete"}],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        client = session_factory().client("glue")
+        dev_endpoints = client.get_dev_endpoints()["DevEndpoints"]
+        self.assertFalse(dev_endpoints)

--- a/tests/test_glue.py
+++ b/tests/test_glue.py
@@ -80,6 +80,7 @@ class TestGlueConnections(BaseTest):
         connections = client.get_connections()["ConnectionList"]
         self.assertFalse(connections)
 
+
 class TestGlueDevEndpoints(BaseTest):
 
     def test_dev_endpoints_query(self):


### PR DESCRIPTION
Added the Dev Endpoints resource to glue.py and the delete action for
Dev Endpoints so custodian admins can deploy policies to find and delete
public dev endpoints in glue.