### PR TITLE
aws - sagemaker resources cleanup/refactor

### DIFF
--- a/c7n/resources/sagemaker.py
+++ b/c7n/resources/sagemaker.py
@@ -13,13 +13,10 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
-from botocore.exceptions import ClientError
-
 import six
 
 from c7n.actions import BaseAction
 from c7n.exceptions import PolicyValidationError
-from c7n.filters import FilterRegistry
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
 from c7n.utils import local_session, type_schema
@@ -42,8 +39,6 @@ class NotebookInstance(QueryResourceManager):
         dimension = None
         filter_name = None
 
-    filter_registry = FilterRegistry('sagemaker-notebook.filters')
-    filter_registry.register('marked-for-op', TagActionFilter)
     permissions = ('sagemaker:ListTags',)
 
     def augment(self, resources):
@@ -60,6 +55,9 @@ class NotebookInstance(QueryResourceManager):
         resources = super(NotebookInstance, self).augment(resources)
         with self.executor_factory(max_workers=1) as w:
             return list(filter(None, w.map(_augment, resources)))
+
+
+NotebookInstance.filter_registry.register('marked-for-op', TagActionFilter)
 
 
 @resources.register('sagemaker-job')
@@ -93,7 +91,7 @@ class SagemakerJob(QueryResourceManager):
             query = query or {}
             for k, v in q.items():
                 query[k] = v
-            return super(SagemakerJob, self).resources(query=query)
+        return super(SagemakerJob, self).resources(query=query)
 
     def augment(self, jobs):
         client = local_session(self.session_factory).client('sagemaker')
@@ -109,10 +107,10 @@ class SagemakerJob(QueryResourceManager):
             return list(filter(None, w.map(_augment, jobs)))
 
 
-JOB_FILTERS = ('StatusEquals', 'NameContains',)
-
-
 class QueryFilter(object):
+
+    JOB_FILTERS = ('StatusEquals', 'NameContains',)
+
     @classmethod
     def parse(cls, data):
         results = []
@@ -151,7 +149,7 @@ class QueryFilter(object):
         self.key = list(self.data.keys())[0]
         self.value = list(self.data.values())[0]
 
-        if self.key not in JOB_FILTERS and not self.key.startswith('tag:'):
+        if self.key not in self.JOB_FILTERS and not self.key.startswith('tag:'):
             raise PolicyValidationError(
                 "Training-Job Query Filter invalid filter name %s" % (
                     self.data))
@@ -185,8 +183,6 @@ class SagemakerEndpoint(QueryResourceManager):
         dimension = None
         filter_name = None
 
-    filter_registry = FilterRegistry('sagemaker-endpoint.filters')
-    filter_registry.register('marked-for-op', TagActionFilter)
     permissions = ('sagemaker:ListTags',)
 
     def augment(self, endpoints):
@@ -204,6 +200,9 @@ class SagemakerEndpoint(QueryResourceManager):
             return list(filter(None, w.map(_augment, endpoints)))
 
 
+SagemakerEndpoint.filter_registry.register('marked-for-op', TagActionFilter)
+
+
 @resources.register('sagemaker-endpoint-config')
 class SagemakerEndpointConfig(QueryResourceManager):
 
@@ -219,8 +218,6 @@ class SagemakerEndpointConfig(QueryResourceManager):
         dimension = None
         filter_name = None
 
-    filter_registry = FilterRegistry('sagemaker-endpoint-config.filters')
-    filter_registry.register('marked-for-op', TagActionFilter)
     permissions = ('sagemaker:ListTags',)
 
     def augment(self, endpoints):
@@ -237,6 +234,9 @@ class SagemakerEndpointConfig(QueryResourceManager):
             return list(filter(None, w.map(_augment, endpoints)))
 
 
+SagemakerEndpointConfig.filter_registry.register('marked-for-op', TagActionFilter)
+
+
 @resources.register('sagemaker-model')
 class Model(QueryResourceManager):
     class resource_type(object):
@@ -251,8 +251,6 @@ class Model(QueryResourceManager):
         dimension = None
         filter_name = None
 
-    filter_registry = FilterRegistry('sagemaker-model.filters')
-    filter_registry.register('marked-for-op', TagActionFilter)
     permissions = ('sagemaker:ListTags',)
 
     def augment(self, resources):
@@ -266,6 +264,9 @@ class Model(QueryResourceManager):
 
         with self.executor_factory(max_workers=1) as w:
             return list(filter(None, w.map(_augment, resources)))
+
+
+Model.filter_registry.register('marked-for-op', TagActionFilter)
 
 
 class StateTransitionFilter(object):
@@ -283,7 +284,7 @@ class StateTransitionFilter(object):
         orig_length = len(instances)
         results = [i for i in instances
                    if i['NotebookInstanceStatus'] in states]
-        self.log.info("%s %d of %d notebook instances" % (
+        self.log.info("state filter %s %d of %d notebook instances" % (
             self.__class__.__name__, len(results), orig_length))
         return results
 
@@ -482,19 +483,19 @@ class StartNotebookInstance(BaseAction, StateTransitionFilter):
     permissions = ('sagemaker:StartNotebookInstance',)
     valid_origin_states = ('Stopped',)
 
-    def process_instance(self, resource):
-        client = local_session(
-            self.manager.session_factory).client('sagemaker')
-        client.start_notebook_instance(
-            NotebookInstanceName=resource['NotebookInstanceName'])
-
     def process(self, resources):
         resources = self.filter_instance_state(resources)
         if not len(resources):
             return
 
-        with self.executor_factory(max_workers=2) as w:
-                list(w.map(self.process_instance, resources))
+        client = local_session(self.manager.session_factory).client('sagemaker')
+
+        for n in resources:
+            try:
+                client.start_notebook_instance(
+                    NotebookInstanceName=n['NotebookInstanceName'])
+            except client.exceptions.ResourceNotFound:
+                pass
 
 
 @NotebookInstance.action_registry.register('stop')
@@ -517,19 +518,19 @@ class StopNotebookInstance(BaseAction, StateTransitionFilter):
     permissions = ('sagemaker:StopNotebookInstance',)
     valid_origin_states = ('InService',)
 
-    def process_instance(self, resource):
-        client = local_session(
-            self.manager.session_factory).client('sagemaker')
-        client.stop_notebook_instance(
-            NotebookInstanceName=resource['NotebookInstanceName'])
-
     def process(self, resources):
         resources = self.filter_instance_state(resources)
         if not len(resources):
             return
 
-        with self.executor_factory(max_workers=2) as w:
-                list(w.map(self.process_instance, resources))
+        client = local_session(self.manager.session_factory).client('sagemaker')
+
+        for n in resources:
+            try:
+                client.stop_notebook_instance(
+                    NotebookInstanceName=n['NotebookInstanceName'])
+            except client.exceptions.ResourceNotFound:
+                pass
 
 
 @NotebookInstance.action_registry.register('delete')
@@ -552,19 +553,19 @@ class DeleteNotebookInstance(BaseAction, StateTransitionFilter):
     permissions = ('sagemaker:DeleteNotebookInstance',)
     valid_origin_states = ('Stopped', 'Failed',)
 
-    def process_instance(self, resource):
-        client = local_session(
-            self.manager.session_factory).client('sagemaker')
-        client.delete_notebook_instance(
-            NotebookInstanceName=resource['NotebookInstanceName'])
-
     def process(self, resources):
         resources = self.filter_instance_state(resources)
         if not len(resources):
             return
 
-        with self.executor_factory(max_workers=2) as w:
-            list(w.map(self.process_instance, resources))
+        client = local_session(self.manager.session_factory).client('sagemaker')
+
+        for n in resources:
+            try:
+                client.delete_notebook_instance(
+                    NotebookInstanceName=n['NotebookInstanceName'])
+            except client.exceptions.ResourceNotFound:
+                pass
 
 
 @NotebookInstance.filter_registry.register('security-group')
@@ -598,18 +599,14 @@ class DeleteModel(BaseAction, StateTransitionFilter):
     schema = type_schema('delete')
     permissions = ('sagemaker:DeleteModel',)
 
-    def process_instance(self, resource):
-        client = local_session(
-            self.manager.session_factory).client('sagemaker')
-        client.delete_model(
-            ModelName=resource['ModelName'])
-
     def process(self, resources):
-        if not len(resources):
-            return
+        client = local_session(self.manager.session_factory).client('sagemaker')
 
-        with self.executor_factory(max_workers=2) as w:
-            list(w.map(self.process_instance, resources))
+        for m in resources:
+            try:
+                client.delete_model(ModelName=m['ModelName'])
+            except client.exceptions.ResourceNotFound:
+                pass
 
 
 @SagemakerJob.action_registry.register('stop')
@@ -631,23 +628,14 @@ class SagemakerJobStop(BaseAction):
     schema = type_schema('stop')
     permissions = ('sagemaker:StopTrainingJob',)
 
-    def process_job(self, job):
-        client = local_session(
-            self.manager.session_factory).client('sagemaker')
-        try:
-            client.stop_training_job(
-                TrainingJobName=job['TrainingJobName'])
-        except ClientError as e:
-            if e.response['Error']['Code'] == 'ResourceNotFound':
-                self.log.exception(
-                    "Exception stopping sagemaker job %s:\n %s" % (
-                        job['TrainingJobName'], e))
-            else:
-                raise
-
     def process(self, jobs):
-        with self.executor_factory(max_workers=2) as w:
-            list(w.map(self.process_job, jobs))
+        client = local_session(self.manager.session_factory).client('sagemaker')
+
+        for j in jobs:
+            try:
+                client.stop_training_job(TrainingJobName=j['TrainingJobName'])
+            except client.exceptions.ResourceNotFound:
+                pass
 
 
 @SagemakerEndpoint.action_registry.register('delete')
@@ -667,17 +655,17 @@ class SagemakerEndpointDelete(BaseAction):
               - type: delete
     """
     permissions = (
-        'sagemaker:DeleteEndpoint', 'sagemaker:DeleteEndpointConfig')
+        'sagemaker:DeleteEndpoint',
+        'sagemaker:DeleteEndpointConfig')
     schema = type_schema('delete')
 
-    def process_endpoint(self, endpoint):
-        client = local_session(
-            self.manager.session_factory).client('sagemaker')
-        client.delete_endpoint(EndpointName=endpoint['EndpointName'])
-
     def process(self, endpoints):
-        with self.executor_factory(max_workers=2) as w:
-            list(w.map(self.process_endpoint, endpoints))
+        client = local_session(self.manager.session_factory).client('sagemaker')
+        for e in endpoints:
+            try:
+                client.delete_endpoint(EndpointName=e['EndpointName'])
+            except client.exceptions.ResourceNotFound:
+                pass
 
 
 @SagemakerEndpointConfig.action_registry.register('delete')
@@ -699,12 +687,11 @@ class SagemakerEndpointConfigDelete(BaseAction):
     schema = type_schema('delete')
     permissions = ('sagemaker:DeleteEndpointConfig',)
 
-    def process_endpoint_config(self, endpoint):
-        client = local_session(
-            self.manager.session_factory).client('sagemaker')
-        client.delete_endpoint_config(
-            EndpointConfigName=endpoint['EndpointConfigName'])
-
     def process(self, endpoints):
-        with self.executor_factory(max_workers=2) as w:
-            list(w.map(self.process_endpoint_config, endpoints))
+        client = local_session(self.manager.session_factory).client('sagemaker')
+        for e in endpoints:
+            try:
+                client.delete_endpoint_config(
+                    EndpointConfigName=e['EndpointConfigName'])
+            except client.exceptions.ResourceNotFound:
+                pass


### PR DESCRIPTION

simplify and reduce bad patterns used for this resource type implementation.

- reduce concurrency
- add error handling around resource not found
- remove worker thread pool session creation