### PR TITLE
azure - add missing package dependencies

### DIFF
--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -152,7 +152,7 @@ class FunctionPackage(object):
 
         # add all loaded modules
         modules.discard('azure')
-        modules = modules.union({'c7n', 'c7n_azure', 'pkg_resources'})
+        modules = modules.union({'c7n', 'c7n_azure', 'pkg_resources', 'knack', 'argcomplete', 'applicationinsights'})
         if extra_modules:
             modules = modules.union(extra_modules)
 

--- a/tools/c7n_azure/c7n_azure/function_package.py
+++ b/tools/c7n_azure/c7n_azure/function_package.py
@@ -152,7 +152,8 @@ class FunctionPackage(object):
 
         # add all loaded modules
         modules.discard('azure')
-        modules = modules.union({'c7n', 'c7n_azure', 'pkg_resources', 'knack', 'argcomplete', 'applicationinsights'})
+        modules = modules.union({'c7n', 'c7n_azure', 'pkg_resources',
+                                 'knack', 'argcomplete', 'applicationinsights'})
         if extra_modules:
             modules = modules.union(extra_modules)
 


### PR DESCRIPTION
- These Azure package dependencies are missing `knack`, `argcomplete`, `applicationinsights`