### PR TITLE
azure - fix azure output storage logging

### DIFF
--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -43,6 +43,8 @@ class AzureStorageOutput(DirectoryOutput):
     def __init__(self, ctx, config=None):
         super(AzureStorageOutput, self).__init__(ctx, config)
         self.log = logging.getLogger('custodian.output')
+
+        # date Year/Month/Day/Hour/Second
         self.date_path = datetime.datetime.now().strftime('%Y/%m/%d/%H/%M/%S')
         self.root_dir = tempfile.mkdtemp()
         self.blob_service, self.container, self.file_prefix = \

--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -44,7 +44,7 @@ class AzureStorageOutput(DirectoryOutput):
         super(AzureStorageOutput, self).__init__(ctx, config)
         self.log = logging.getLogger('custodian.output')
 
-        # date Year/Month/Day/Hour/Second
+        # folder structure Year/Month/Day/Hour/Second
         self.date_path = datetime.datetime.now().strftime('%Y/%m/%d/%H/%M/%S')
         self.root_dir = tempfile.mkdtemp()
         self.blob_service, self.container, self.file_prefix = \

--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -43,7 +43,7 @@ class AzureStorageOutput(DirectoryOutput):
     def __init__(self, ctx, config=None):
         super(AzureStorageOutput, self).__init__(ctx, config)
         self.log = logging.getLogger('custodian.output')
-        self.date_path = datetime.datetime.now().strftime('%Y/%m/%d/%H')
+        self.date_path = datetime.datetime.now().strftime('%Y/%m/%d/%H/%M/%S')
         self.root_dir = tempfile.mkdtemp()
         self.blob_service, self.container, self.file_prefix = \
             self.get_blob_client_wrapper(self.ctx.options.output_dir, ctx)

--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -46,13 +46,12 @@ class AzureStorageOutput(DirectoryOutput):
         self.date_path = datetime.datetime.now().strftime('%Y/%m/%d/%H')
         self.root_dir = tempfile.mkdtemp()
         self.blob_service, self.container, self.file_prefix = \
-            self.get_blob_client_wrapper(self.root_dir, ctx)
+            self.get_blob_client_wrapper(self.ctx.options.output_dir, ctx)
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
         if exc_type is not None:
             self.log.exception("Error while executing policy")
         self.log.debug("Uploading policy logs")
-        self.leave_log()
         self.compress()
         self.upload()
         shutil.rmtree(self.root_dir)


### PR DESCRIPTION
- Adding minutes and seconds support for storage logs
- fixed the directory being used for outputting to storage account