### PR TITLE
fix: Correct example policy syntax from ge to le

### DIFF
--- a/docs/source/azure/policy/resources/loadbalancer.rst
+++ b/docs/source/azure/policy/resources/loadbalancer.rst
@@ -48,7 +48,7 @@ This policy will find all load balancers with 1000 or less transmitted packets o
         filters:
           - type: metric
             metric: PacketCount
-            op: ge
+            op: le
             aggregation: total
             threshold: 1000
             timeframe: 72


### PR DESCRIPTION
This policies filter seem to be off and needs to be looking at le rather than ge for inactive load balancers