### PR TITLE
azure- Add support for pyformat to Azure Blob Output

### DIFF
--- a/docs/source/azure/advanced/bloboutput.rst
+++ b/docs/source/azure/advanced/bloboutput.rst
@@ -9,9 +9,18 @@ Writing Custodian Output to Azure Blob Storage
 You may pass the URL to a blob storage container as the output path to Custodian.
 You must change the URL prefix from https to azure.
 
+By default, Custodian will add the policy name and date as the prefix to the blob.
+
     .. code-block:: sh
 
         custodian run -s azure://mystorage.blob.core.windows.net/logs mypolicy.yml
+
+In addition, you can use `pyformat` syntax to format the output prefix.
+This is example is the as same structure as the default one.
+
+    .. code-block:: sh
+
+        custodian run -s azure://mystorage.blob.core.windows.net/logs/{policy}/{now:%Y/%m/%d/%H/} mypolicy.yml
 
 Custodian will use your current credentials to discover the storage account and
 load the storage account keys.  The account must be in your current subscription.

--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -16,7 +16,6 @@ Provides output support for Azure Blob Storage using
 the 'azure://' prefix
 
 """
-import datetime
 import logging
 import os
 import shutil
@@ -40,15 +39,15 @@ class AzureStorageOutput(DirectoryOutput):
 
     """
 
+    DEFAULT_BLOB_FOLDER_PREFIX = '{policy}/{now:%Y/%m/%d/%H/}'
+
     def __init__(self, ctx, config=None):
         super(AzureStorageOutput, self).__init__(ctx, config)
         self.log = logging.getLogger('custodian.output')
-
-        # folder structure Year/Month/Day/Hour/Second
-        self.date_path = datetime.datetime.now().strftime('%Y/%m/%d/%H/%M/%S')
         self.root_dir = tempfile.mkdtemp()
+        self.output_dir = self.get_output_path(self.ctx.options.output_dir)
         self.blob_service, self.container, self.file_prefix = \
-            self.get_blob_client_wrapper(self.ctx.options.output_dir, ctx)
+            self.get_blob_client_wrapper(self.output_dir, ctx)
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
         if exc_type is not None:
@@ -59,14 +58,19 @@ class AzureStorageOutput(DirectoryOutput):
         shutil.rmtree(self.root_dir)
         self.log.debug("Policy Logs uploaded")
 
+    def get_output_path(self, output_url):
+
+        # if pyformat is not specified, then use the policy name and a formatted date structure
+        if '{' not in output_url:
+            output_url = os.path.join(output_url, self.DEFAULT_BLOB_FOLDER_PREFIX)
+
+        return output_url.format(**self.get_output_vars())
+
     def upload(self):
         for root, dirs, files in os.walk(self.root_dir):
             for f in files:
-                blob_name = "%s/%s%s" % (
-                    self.file_prefix,
-                    self.date_path,
-                    "%s/%s" % (
-                        root[len(self.root_dir):], f))
+                file = '{folder}/{file_name}'.format(folder=root[len(self.root_dir):], file_name=f)
+                blob_name = "{file_prefix}{file}".format(file_prefix=self.file_prefix, file=file)
                 blob_name = blob_name.strip('/')
                 self.blob_service.create_blob_from_path(
                     self.container,

--- a/tools/c7n_azure/tests/test_output.py
+++ b/tools/c7n_azure/tests/test_output.py
@@ -15,6 +15,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 import os
 import shutil
+from datetime import date
 
 import mock
 from azure_common import BaseTest
@@ -28,8 +29,11 @@ class OutputTest(BaseTest):
     def setUp(self):
         super(OutputTest, self).setUp()
 
-    def get_azure_output(self):
+    def get_azure_output(self, custom_pyformat=None):
         output_dir = "azure://mystorage.blob.core.windows.net/logs"
+        if custom_pyformat:
+            output_dir = os.path.join(output_dir, custom_pyformat)
+
         output = AzureStorageOutput(
             ExecutionContext(
                 None,
@@ -44,9 +48,8 @@ class OutputTest(BaseTest):
 
     def test_azure_output_upload(self):
         # Mock storage utilities to avoid calling azure to get a real client.
-
         AzureStorageOutput.get_blob_client_wrapper = gm = mock.MagicMock()
-        gm.return_value = None, "logs", "xyz"
+        gm.return_value = None, "logs", 'xyz'
 
         output = self.get_azure_output()
         self.assertEqual(output.file_prefix, "xyz")
@@ -63,6 +66,36 @@ class OutputTest(BaseTest):
 
         m.assert_called_with(
             "logs",
-            "xyz/%s/foo.txt" % output.date_path,
+            "xyz/foo.txt",
             fh.name
         )
+
+    def test_azure_output_get_default_output_dir(self):
+        AzureStorageOutput.get_blob_client_wrapper = gm = mock.MagicMock()
+        gm.return_value = None, "logs", 'xyz'
+
+        AzureStorageOutput.get_output_vars = mock.Mock(
+            return_value={
+                'policy': 'MyPolicy',
+                'now': date(2018, 10, 1)
+            })
+
+        output = self.get_azure_output()
+        path = output.get_output_path(output.config['url'])
+        self.assertEqual(path,
+                         'azure://mystorage.blob.core.windows.net/logs/MyPolicy/2018/10/01/00/')
+
+    def test_azure_output_get_custom_output_dir(self):
+        AzureStorageOutput.get_blob_client_wrapper = gm = mock.MagicMock()
+        gm.return_value = None, "logs", 'xyz'
+
+        AzureStorageOutput.get_output_vars = mock.Mock(
+            return_value={
+                'policy': 'MyPolicy',
+                'now': date(2018, 10, 1)
+            })
+
+        output = self.get_azure_output('{policy}/{now:%Y}')
+        path = output.get_output_path(output.config['url'])
+        self.assertEqual(path,
+                         'azure://mystorage.blob.core.windows.net/logs/MyPolicy/2018')


### PR DESCRIPTION
- the output path for the Azure outputter can use pyformat syntax
- added documentation with an example