### PR TITLE
fix the issue of OnlyPorts not being recognized 

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -987,8 +987,8 @@ class SGPermission(Filter):
             perm_matches = {}
             for idx, f in enumerate(self.vfilters):
                 perm_matches[idx] = bool(f(perm))
-            perm_matches['ports'] = self.process_ports(perm)
-            perm_matches['cidrs'] = self.process_cidrs(perm)
+            perm_matches['ports'] = self.process_ports(perm) or False
+            perm_matches['cidrs'] = self.process_cidrs(perm) or False
             perm_matches['self-refs'] = self.process_self_reference(perm, sg_id)
             perm_match_values = list(filter(
                 lambda x: x is not None, perm_matches.values()))


### PR DESCRIPTION
Since match_op is a function that is expecting boolean values to filter out permissions that shouldn't be included as matches, 'None' doesn't qualify for this function's return values.