### PR TITLE
Fix onlyports cidr bug Issue# 2917

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -907,6 +907,8 @@ class SGPermission(Filter):
                     only_found = True
             if self.only_ports and not only_found:
                 found = found is None or found and True or False
+            if self.only_ports and only_found:
+                found = False
         return found
 
     def _process_cidr(self, cidr_key, cidr_type, range_type, perm):

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_1.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "dcd0fe69-e0c8-49f0-ab2a-fd77daf2197e", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:56 GMT", 
+                "content-length": "259", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_2.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_2.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "5f2a286f-c3c7-4d3a-b74e-f2c20fba6e3e", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:57 GMT", 
+                "content-length": "259", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_3.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_3.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "ee4c6085-dffa-4b3e-9b6c-28fb963bb374", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:57 GMT", 
+                "content-length": "259", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_4.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_4.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "8db4c4e5-10b6-4391-bf78-b27bb80676a6", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:57 GMT", 
+                "content-length": "259", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_5.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.AuthorizeSecurityGroupIngress_5.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "199462bc-57f6-48d1-9394-5b72df68856f", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:57 GMT", 
+                "content-length": "259", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.CreateSecurityGroup_1.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.CreateSecurityGroup_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "GroupId": "sg-02a60363e2b087ff8", 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "44615143-02cd-48e2-a47c-19cc85fedf72", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:56 GMT", 
+                "content-length": "283", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.CreateVpc_1.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.CreateVpc_1.json
@@ -1,0 +1,35 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "428285a4-5e17-4cca-adce-990bbde59710", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:56 GMT", 
+                "content-length": "883", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }, 
+        "Vpc": {
+            "VpcId": "vpc-007084954cd5c3c96", 
+            "InstanceTenancy": "default", 
+            "Tags": [], 
+            "CidrBlockAssociationSet": [
+                {
+                    "AssociationId": "vpc-cidr-assoc-04f26949fdecdc5b1", 
+                    "CidrBlock": "10.4.0.0/16", 
+                    "CidrBlockState": {
+                        "State": "associated"
+                    }
+                }
+            ], 
+            "Ipv6CidrBlockAssociationSet": [], 
+            "State": "pending", 
+            "DhcpOptionsId": "dopt-df6702bb", 
+            "CidrBlock": "10.4.0.0/16", 
+            "IsDefault": false
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DeleteSecurityGroup_1.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DeleteSecurityGroup_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "f47b5fad-9430-4aee-b63d-a13925f251a3", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:59 GMT", 
+                "content-length": "239", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DeleteVpc_1.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DeleteVpc_1.json
@@ -1,0 +1,17 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "64ab3dc4-d036-4baf-b89e-b29990591360", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "vary": "Accept-Encoding", 
+                "date": "Thu, 18 Oct 2018 11:59:59 GMT", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DescribeSecurityGroups_1.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DescribeSecurityGroups_1.json
@@ -1,0 +1,752 @@
+{
+    "status_code": 200, 
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/10/01 15:49:33", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-8", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0075c565291171ba8"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/25 14:51:32", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-7", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-018e9e60dfc0df90f"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "cloud-custodian test SG", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 80, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 80, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 8080, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 8080, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 0, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "10.2.0.0/16"
+                            }
+                        ], 
+                        "ToPort": 62000, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1234, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 4321, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 443, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 443, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "c7n-only-ports-and-cidr-test", 
+                "VpcId": "vpc-007084954cd5c3c96", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-02a60363e2b087ff8"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/24 15:20:43", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-4", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-033fce6be61e68f7c"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/24 15:10:07", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-1", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0437cca8648bcc4c1"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/24 17:35:51", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-6", 
+                "VpcId": "vpc-0d706a6a97fee8752", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0526564d2edfd2e93"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/10/01 16:13:39", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-12", 
+                "VpcId": "vpc-0156cdc91695ac9dd", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0711cf16fb39770b4"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/24 15:15:21", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-3", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-077d4541f4a7df7af"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/24 15:09:38", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-07c171b5b19979b2c"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/24 17:35:17", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-5", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-081d95b6a63fcedc3"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123456789012", 
+                                "GroupId": "sg-0828f69f583e2cd6b"
+                            }
+                        ], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-0d706a6a97fee8752", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0828f69f583e2cd6b"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123456789012", 
+                                "GroupId": "sg-0bd115efd42dd9782"
+                            }
+                        ], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-0156cdc91695ac9dd", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0bd115efd42dd9782"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123456789012", 
+                                "GroupId": "sg-0c459350495a9bdb5"
+                            }
+                        ], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-007084954cd5c3c96", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0c459350495a9bdb5"
+            }, 
+            {
+                "IpPermissionsEgress": [], 
+                "Description": "Testing c7n SG perms filter issue", 
+                "Tags": [
+                    {
+                        "Value": "jason.antman@coxautoinc.com", 
+                        "Key": "ownerEmail"
+                    }
+                ], 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 80, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 80, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 22, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 22, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 443, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 443, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "sg_jantmantest_1", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0d40e803b8b644e79"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/10/01 15:51:40", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-10", 
+                "VpcId": "vpc-0156cdc91695ac9dd", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0d7d0328e02aed3a3"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/10/01 15:50:11", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-9", 
+                "VpcId": "vpc-0d706a6a97fee8752", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0ed699502f9770695"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/10/01 16:06:44", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-11", 
+                "VpcId": "vpc-0156cdc91695ac9dd", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0fc432caea02aed11"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "Created from the RDS Management Console: 2018/09/24 15:11:58", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 1521, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "66.6.147.81/32"
+                            }
+                        ], 
+                        "ToPort": 1521, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "rds-launch-wizard-2", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-0fc89f11f492259c8"
+            }, 
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "default VPC security group", 
+                "IpPermissions": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [], 
+                        "UserIdGroupPairs": [
+                            {
+                                "UserId": "123456789012", 
+                                "GroupId": "sg-1952d160"
+                            }
+                        ], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "default", 
+                "VpcId": "vpc-6b7e9b0c", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-1952d160"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "d7bd0a19-8839-4ae3-b0f5-5351960e758b", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "vary": "Accept-Encoding", 
+                "date": "Thu, 18 Oct 2018 11:59:58 GMT", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DescribeSecurityGroups_2.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.DescribeSecurityGroups_2.json
@@ -1,0 +1,80 @@
+{
+    "status_code": 200, 
+    "data": {
+        "SecurityGroups": [
+            {
+                "IpPermissionsEgress": [
+                    {
+                        "IpProtocol": "-1", 
+                        "PrefixListIds": [], 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "Description": "cloud-custodian test SG", 
+                "IpPermissions": [
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 80, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 80, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 0, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "10.2.0.0/16"
+                            }
+                        ], 
+                        "ToPort": 62000, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }, 
+                    {
+                        "PrefixListIds": [], 
+                        "FromPort": 443, 
+                        "IpRanges": [
+                            {
+                                "CidrIp": "0.0.0.0/0"
+                            }
+                        ], 
+                        "ToPort": 443, 
+                        "IpProtocol": "tcp", 
+                        "UserIdGroupPairs": [], 
+                        "Ipv6Ranges": []
+                    }
+                ], 
+                "GroupName": "c7n-only-ports-and-cidr-test", 
+                "VpcId": "vpc-007084954cd5c3c96", 
+                "OwnerId": "123456789012", 
+                "GroupId": "sg-02a60363e2b087ff8"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "519b2842-0a87-4c39-a4a2-5733c526846e", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "vary": "Accept-Encoding", 
+                "date": "Thu, 18 Oct 2018 11:59:59 GMT", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.RevokeSecurityGroupIngress_1.json
+++ b/tests/data/placebo/test_only_ports_and_cidr_ingress/ec2.RevokeSecurityGroupIngress_1.json
@@ -1,0 +1,16 @@
+{
+    "status_code": 200, 
+    "data": {
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "3184e375-6fa3-43c3-8d69-aa1306fccb5e", 
+            "HTTPHeaders": {
+                "date": "Thu, 18 Oct 2018 11:59:58 GMT", 
+                "content-length": "253", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}


### PR DESCRIPTION
Fixes https://github.com/capitalone/cloud-custodian/issues/2917

This PR fixes the problem where remove-permissions action deletes valid SG rules. 
In the method in question (`process_ports`), the return value `found` defaults to None.  If `only_ports` is specified and `ports` is not, AND the permission we're checking matches a port in `only_ports`, (i.e. `only_found` becomes True)... the method ends up never setting `found` to False, it's left at the default value of None.

Detailed analysis: https://github.com/capitalone/cloud-custodian/issues/2917#issuecomment-430969369
