### PR TITLE
aws - mu - restore assume role default in function provisioning

### DIFF
--- a/c7n/mu.py
+++ b/c7n/mu.py
@@ -418,6 +418,7 @@ class LambdaManager(object):
             # after configuration change?
 
             new_config = func.get_config()
+            new_config['Role'] = role
             new_tags = new_config.pop('Tags', {})
 
             config_changed = self.delta_function(old_config, new_config)
@@ -436,11 +437,11 @@ class LambdaManager(object):
             tags_to_add, tags_to_remove = self.diff_tags(old_tags, new_tags)
 
             if tags_to_add:
-                log.debug("Adding/updating tags: %s config" % func.name)
+                log.debug("Updating function tags: %s" % func.name)
                 self.client.tag_resource(
                     Resource=base_arn, Tags=tags_to_add)
             if tags_to_remove:
-                log.debug("Removing tags: %s config" % func.name)
+                log.debug("Removing function stale tags: %s" % func.name)
                 self.client.untag_resource(
                     Resource=base_arn, TagKeys=tags_to_remove)
 

--- a/tests/test_mu.py
+++ b/tests/test_mu.py
@@ -312,7 +312,7 @@ class PolicyLambdaProvision(BaseTest):
         lines = output.getvalue().strip().split("\n")
         self.assertTrue("Updating function custodian-s3-bucket-policy code" in lines)
         self.assertTrue(
-            "Updating function: custodian-s3-bucket-policy config MemorySize, Role" in lines)
+            "Updating function: custodian-s3-bucket-policy config MemorySize" in lines)
         self.assertEqual(result["FunctionName"], result2["FunctionName"])
         # drive by coverage
         functions = [


### PR DESCRIPTION
trunk only regression,  lambda policies with implicit roles from --assume cli params would trigger an exception on cli when being updated.

fixes #3006