### PR TITLE
c7norg - fix iterator of account_region_pcounts

### DIFF
--- a/tools/c7n_org/c7n_org/cli.py
+++ b/tools/c7n_org/c7n_org/cli.py
@@ -558,8 +558,8 @@ def run(config, use, output_dir, accounts, tags,
                     a['name'], r, f.exception())
 
             account_region_pcounts, account_region_success = f.result()
-            for p, count in account_region_pcounts:
-                policy_counts[p] += count
+            for p in account_region_pcounts:
+                policy_counts[p] += account_region_pcounts[p]
 
             if not account_region_success:
                 success = False


### PR DESCRIPTION
- fix #3048, seemed to be an issue with the recent changes from #2659
- account_region_pcounts appears to be a dictionary and it was throwing an error when iterating over the keys and attempting to pull out the tuple of (key, value)
- I could have also done the following if preferred, but in py27 it I believe `items()` is fully materialized and not an iterator.
`
for p, count in account_region_pcounts.items():
`