### PR TITLE
aws shield - retry revisit, to include protection pagination

### DIFF
--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -19,7 +19,7 @@ from botocore.paginate import Paginator
 from c7n.actions import BaseAction
 from c7n.filters import Filter
 from c7n.manager import resources
-from c7n.query import QueryResourceManager
+from c7n.query import QueryResourceManager, pager
 from c7n.utils import local_session, type_schema, get_retry
 
 
@@ -58,12 +58,14 @@ def get_protections_paginator(client):
 
 def get_type_protections(client, model):
     try:
-        protections = get_protections_paginator(
-            client).paginate().build_full_result().get('Protections')
+        protections = pager(get_protections_paginator(client), ShieldRetry).get('Protections')
     except client.exceptions.ResourceNotFoundException:
         # shield is not enabled in the account, so all resources are not protected
         return []
     return [p for p in protections if model.type in p['ResourceArn']]
+
+
+ShieldRetry = get_retry(('ThrottlingException',))
 
 
 class IsShieldProtected(Filter):
@@ -103,8 +105,6 @@ class SetShieldProtection(BaseAction):
         'set-shield',
         state={'type': 'boolean'}, sync={'type': 'boolean'})
 
-    retry = staticmethod(get_retry(('ThrottlingException',)))
-
     def process(self, resources):
         client = local_session(self.manager.session_factory).client(
             'shield', region_name='us-east-1')
@@ -121,12 +121,12 @@ class SetShieldProtection(BaseAction):
             if state and arn in protected_resources:
                 continue
             if state is False and arn in protected_resources:
-                self.retry(
+                ShieldRetry(
                     client.delete_protection,
                     ProtectionId=protected_resources[arn]['Id'])
                 continue
             try:
-                self.retry(
+                ShieldRetry(
                     client.create_protection,
                     Name=r[model.name], ResourceArn=arn)
             except ClientError as e:
@@ -152,4 +152,4 @@ class SetShieldProtection(BaseAction):
         stale = set(pmap).difference(resource_arns)
         self.log.info("clearing %d stale protections", len(stale))
         for s in stale:
-            self.retry(client.delete_protection, ProtectionId=pmap[s]['Id'])
+            ShieldRetry(client.delete_protection, ProtectionId=pmap[s]['Id'])

--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -58,7 +58,9 @@ def get_protections_paginator(client):
 
 def get_type_protections(client, model):
     try:
-        protections = pager(get_protections_paginator(client).paginate(), ShieldRetry).get('Protections')
+        protections = pager(
+            get_protections_paginator(client).paginate(),
+            ShieldRetry).get('Protections')
     except client.exceptions.ResourceNotFoundException:
         # shield is not enabled in the account, so all resources are not protected
         return []

--- a/c7n/resources/shield.py
+++ b/c7n/resources/shield.py
@@ -58,7 +58,7 @@ def get_protections_paginator(client):
 
 def get_type_protections(client, model):
     try:
-        protections = pager(get_protections_paginator(client), ShieldRetry).get('Protections')
+        protections = pager(get_protections_paginator(client).paginate(), ShieldRetry).get('Protections')
     except client.exceptions.ResourceNotFoundException:
         # shield is not enabled in the account, so all resources are not protected
         return []


### PR DESCRIPTION
previously retry was only on mutation api calls, we now also do retry on per pagination of protections for a given resource type.