### PR TITLE
azure- add try/catch while executing policies in func handler

### DIFF
--- a/tools/c7n_azure/c7n_azure/handler.py
+++ b/tools/c7n_azure/c7n_azure/handler.py
@@ -57,7 +57,7 @@ def run(event, context):
             try:
                 p.push(event, context)
             except (CloudError, AzureHttpError) as error:
-                log.warning("Unable to process policy: %s :: %s" % (p.name, error))
+                log.error("Unable to process policy: %s :: %s" % (p.name, error))
     return True
 
 
@@ -67,5 +67,5 @@ def get_tmp_output_dir():
         try:
             os.mkdir(output_dir)
         except OSError as error:
-            log.warning("Unable to make output directory: {}".format(error))
+            log.error("Unable to make output directory: {}".format(error))
     return output_dir

--- a/tools/c7n_azure/c7n_azure/handler.py
+++ b/tools/c7n_azure/c7n_azure/handler.py
@@ -17,6 +17,7 @@ import logging
 import os
 import uuid
 
+from azure.common import AzureHttpError
 from msrestazure.azure_exceptions import CloudError
 
 from c7n.config import Config
@@ -55,8 +56,8 @@ def run(event, context):
         for p in policies:
             try:
                 p.push(event, context)
-            except CloudError as error:
-                log.warning("Failed to process policy: %s :: %s" % (p.name, error))
+            except (CloudError, AzureHttpError) as error:
+                log.warning("Unable to process policy: %s :: %s" % (p.name, error))
     return True
 
 


### PR DESCRIPTION
- #3063 It is possible that when we are processing delayed or older events, the resources cannot be manipulated or have been deleted. 
- In conjunction with #3061, we will eventually not processed these events any further