### PR TITLE
azure - set account_id during init

### DIFF
--- a/tools/c7n_azure/c7n_azure/provider.py
+++ b/tools/c7n_azure/c7n_azure/provider.py
@@ -16,6 +16,7 @@ from functools import partial
 
 from c7n.provider import Provider, clouds
 from c7n.registry import PluginRegistry
+from c7n.utils import local_session
 from .session import Session
 
 
@@ -26,6 +27,8 @@ class Azure(Provider):
     resources = PluginRegistry('%s.resources' % resource_prefix)
 
     def initialize(self, options):
+        session = local_session(self.get_session_factory(options))
+        options['account_id'] = session.get_subscription_id()
         return options
 
     def initialize_policies(self, policy_collection, options):


### PR DESCRIPTION
#3044 

This has the effect of caching the session at init always.  I verified the session isn't instantiated "extra" times at all, and I verified that this does not run during a `custodian validate`

I was going to refactor session instead to do this without requesting a token at initialization, but I wasn't able to figure out how to do this and also support CLI auth as they bundle the token retrieval in with the current subscription information.  

In practice, this seems to work well anyway....