### PR TITLE
azure - storage in functions fix

### DIFF
--- a/tools/c7n_azure/c7n_azure/actions.py
+++ b/tools/c7n_azure/c7n_azure/actions.py
@@ -364,18 +364,18 @@ class Notify(BaseNotify):
 
         for batch in utils.chunks(resources, self.batch_size):
             message['resources'] = batch
-            receipt = self.send_data_message(message)
+            receipt = self.send_data_message(message, session)
             self.log.info("sent message:%s policy:%s template:%s count:%s" % (
                 receipt, self.manager.data['name'],
                 self.data.get('template', 'default'), len(batch)))
 
-    def send_data_message(self, message):
+    def send_data_message(self, message, session):
         if self.data['transport']['type'] == 'asq':
             queue_uri = self.data['transport']['queue']
-            return self.send_to_azure_queue(queue_uri, message)
+            return self.send_to_azure_queue(queue_uri, message, session)
 
-    def send_to_azure_queue(self, queue_uri, message):
-        queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(queue_uri)
+    def send_to_azure_queue(self, queue_uri, message, session):
+        queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(queue_uri, session)
         return StorageUtilities.put_queue_message(queue_service, queue_name, self.pack(message)).id
 
 

--- a/tools/c7n_azure/c7n_azure/handler.py
+++ b/tools/c7n_azure/c7n_azure/handler.py
@@ -24,6 +24,8 @@ from c7n.config import Config
 from c7n.policy import PolicyCollection
 from c7n.resources import load_resources
 
+from c7n_azure.provider import Azure
+
 log = logging.getLogger('custodian.azure.functions')
 
 
@@ -50,6 +52,8 @@ def run(event, context):
     options = Config.empty(**options_overrides)
 
     load_resources()
+
+    options = Azure().initialize(options)
 
     policies = PolicyCollection.from_data(policy_config, options)
     if policies:

--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -24,6 +24,8 @@ import tempfile
 from c7n_azure.storage_utils import StorageUtilities
 from c7n.output import DirectoryOutput, blob_outputs
 
+from c7n.utils import local_session
+
 from azure.common import AzureHttpError
 
 
@@ -49,7 +51,7 @@ class AzureStorageOutput(DirectoryOutput):
         self.root_dir = tempfile.mkdtemp()
         self.output_dir = self.get_output_path(self.ctx.options.output_dir)
         self.blob_service, self.container, self.file_prefix = \
-            self.get_blob_client_wrapper(self.output_dir)
+            self.get_blob_client_wrapper(self.output_dir, ctx)
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):
         if exc_type is not None:
@@ -89,6 +91,7 @@ class AzureStorageOutput(DirectoryOutput):
         return "/".join([s.strip('/') for s in parts if s != ''])
 
     @staticmethod
-    def get_blob_client_wrapper(output_path):
+    def get_blob_client_wrapper(output_path, ctx):
         # provides easier test isolation
-        return StorageUtilities.get_blob_client_by_uri(output_path)
+        s = local_session(ctx.session_factory)
+        return StorageUtilities.get_blob_client_by_uri(output_path, s)

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -112,6 +112,12 @@ class Session(object):
         if self.credentials is None:
             self.log.error('Unable to locate credentials for Azure session.')
 
+    def get_session_for_resource(self, resource):
+        return Session(
+            subscription_id=self.subscription_id_override,
+            authorization_file=self.authorization_file,
+            resource=resource)
+
     def client(self, client):
         self._initialize_session()
         service_name, client_name = client.rsplit('.', 1)

--- a/tools/c7n_azure/c7n_azure/session.py
+++ b/tools/c7n_azure/c7n_azure/session.py
@@ -180,7 +180,8 @@ class Session(object):
             return (ServicePrincipalCredentials(
                 client_id=data['credentials']['client_id'],
                 secret=data['credentials']['secret'],
-                tenant=data['credentials']['tenant']
+                tenant=data['credentials']['tenant'],
+                resource=self.resource_namespace
             ), data['subscription'])
 
     def get_functions_auth_string(self):

--- a/tools/c7n_azure/tests/azure_common.py
+++ b/tools/c7n_azure/tests/azure_common.py
@@ -14,6 +14,7 @@
 import datetime
 import os
 import re
+import tempfile
 
 from c7n_azure import constants
 from c7n_azure.session import Session
@@ -96,6 +97,25 @@ class AzureVCRBaseTest(VCRTestCase):
 class BaseTest(TestUtils, AzureVCRBaseTest):
     """ Azure base testing class.
     """
+
+    @staticmethod
+    def get_auth_file_session(session=None, resource=None):
+        s = session or Session()
+
+        # Delete=false for windows compatibility
+        tf = tempfile.NamedTemporaryFile(delete=False)
+        tf.write(s.get_functions_auth_string())
+        tf.close()
+
+        file_session = Session(authorization_file=tf.name, resource=resource)
+
+        # Call something to init the session
+        file_session.get_subscription_id()
+
+        # Cleanup
+        os.remove(tf.name)
+
+        return file_session
 
     @staticmethod
     def setup_account():

--- a/tools/c7n_azure/tests/azure_common.py
+++ b/tools/c7n_azure/tests/azure_common.py
@@ -99,25 +99,6 @@ class BaseTest(TestUtils, AzureVCRBaseTest):
     """
 
     @staticmethod
-    def get_auth_file_session(session=None, resource=None):
-        s = session or Session()
-
-        # Delete=false for windows compatibility
-        tf = tempfile.NamedTemporaryFile(delete=False)
-        tf.write(s.get_functions_auth_string())
-        tf.close()
-
-        file_session = Session(authorization_file=tf.name, resource=resource)
-
-        # Call something to init the session
-        file_session.get_subscription_id()
-
-        # Cleanup
-        os.remove(tf.name)
-
-        return file_session
-
-    @staticmethod
     def setup_account():
         # Find actual name of storage account provisioned in our test environment
         s = Session()

--- a/tools/c7n_azure/tests/azure_common.py
+++ b/tools/c7n_azure/tests/azure_common.py
@@ -14,7 +14,6 @@
 import datetime
 import os
 import re
-import tempfile
 
 from c7n_azure import constants
 from c7n_azure.session import Session

--- a/tools/c7n_azure/tests/cassettes/NotifyTest.test_notify_though_storage_queue.yaml
+++ b/tools/c7n_azure/tests/cassettes/NotifyTest.test_notify_though_storage_queue.yaml
@@ -5,11 +5,12 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python/2.7.15 (Windows-10-10.0.17134) msrest/0.6.1 msrest_azure/0.5.0
-          azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17134-SP0) msrest/0.6.1 msrest_azure/0.5.0
+          azure-mgmt-storage/2.0.0rc4 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01
   response:
     body:
       string: !!binary |
@@ -35,56 +36,54 @@ interactions:
         1lKA/V4KRV4hHBR7+/fXUxhXpNMkmvx5pCl27nOIcPDo/sPxp5/epyhhhwT8a2iKOCCC9LOlKfwO
         7z/Y2bm/S6oJ0JjTN2kK4ZPbawZtzx9HX2hBkP4L/HH0BZmmbnt8GmnOJOJBeZLumPX/OyJOXVxv
         Z837RSN4id5BMEeo6CDCD38k7reTUjjtnHncv/9of5dSEPt79+/tkZS+r7gPAiJIPyvi3unw4FPK
-        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rgGlZrWfb0zVJJo13
-        +V6agN+1r0739s/vf/rwU0JOhzX4/Y/0w+3Fev/N7qeP9vYf3b8/fnB/72DnPq1MEA6Qm28AEEH6
-        WdMPXoef3n+4c3/vtu5AnG9uryoG3udmUQAtCHYzAG4WBSDTetP7aBV5nUnMRPn/uC7hVaPt6Twr
-        lvfeS5EgeaGf7e4dPLi3v7v34IAQ0yENff0jNXJ76aco/t6jnfuPdvbHew/2dnb24R3coEZuD4gg
-        /aypEa/D3Yf3DvZvndWMss3ttUj8dW4Vfb8FuW58n1tF35c5veF1NIq8zeRlgvz/QoXIyvN7qRCr
-        bekHvqDwDV8Qajqo4QY/UiO3VyP7b3Z2Ht2jJYZ743uf7u+R00/S/3XUSBQQQfpZUyNeh3sPdvb3
-        kQ0BNJaITWpkgHFur0iGAHC7KIQWJLsFBG4XhSAzeyMANIu8z2Rmwvx/XJ2wI/Z1oxvz1l726cPp
-        zvQ+4aUjin31Iy3yPsJPicLdB492D8Y0ew8fPiSTTjhAor4BQATpZ1GL2A73Dh7uPdwl7wfQWBBu
-        pUUMy3wN/WFf5RbRd1uQaeO73CL6rszjhlfRIPImk5MJ8P9xbfG1nQ95RT/99GByQKtkCFB0SENf
-        /0hl3F7SeW2B8glkvu/d2394cECCRzhAiL4BQATpZ01leB3u7e/uHuzcNg0SZZvbq43469wq+n4L
-        ct34PreKvi9zesPraBR5m8nLBPn/uAr5RhwOkzAivHREsa9+pD1uLfT3dt7s3n+0t0PZyPHup8SH
-        B/dI6L+G9ogDIkg/W9rD75AyqAf3Hx7cUnv0WOb2mqP/KreIvtuCTBvf5RbRd2UeN7yKBpE3mZxM
-        gP+Pa4tF1tbFu7330hL6DmGh+LsPviGN8NHJyRv6bI++y7IMBCD8/v+vIB48uv+Q8ozjTx/cf3Cw
-        A6/gayqIPiCC9LOpIEyH9w/2dvYe7N5SQSjf3F4tmBf48+gbLUgSeYM/j74hM9V7AR9H2jOZeGBf
-        Q/C//0v+H3lf3ZTQNgAA
+        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rAM70bk/nWbG8915q
+        AAGHfra7d/Dg3v7u3oMDQkyHNPT1j1TD7SWaPO97j3buP9rZH+892NvZ2YdEfx3VEAVEkH7WVIPX
+        4e7Dewf7t85ERNnm9koi/jq3ir7fglw3vs+tou/LnN7wOhpF3mbyMkH+f6FCZLXovVTIdE2fkJZd
+        0g98QS4XviDUdFDDDX6kRm4v/ftvdnYe3aO0IK2vfrq/R4aapP82auRWgAjSz5oa8Trce7Czv48I
+        BtBYIjapkQHGub0iGQLA7aIQWtD+FhC4XRSCzOyNANAs8j6TmQnz/3F1Mi2r9Wzbjv7raZS97NOH
+        053pfcJLRxT76kda5H20CAX3uw8e7R6MafYePnxIJp1wgER9A4AI0s+iFrEd7h083Hu4S94PoLEg
+        3EqLGJb5GvrDvsotou+2INPGd7lF9F2Zxw2vokHkTSYnE+D/49riazsf8op++unB5IAy2whQdEhD
+        X/9IZdxe0jkfuPspzPe9e/sPDw5I8AgHCNE3AIgg/aypDK/Dvf3d3YOd22Yyo2xze7URf51bRd9v
+        Qa4b3+dW0fdlTm94HY0ibzN5mSD/H1ch34jDMd3bP7//6cNPCS8dUeyrH2mPWwv9vZ03u/cf7e08
+        2qMcwqfEhwe07kg4QJa+AUAE6WdLe/gd7tzfO7j/8OCW2qPHMrfXHP1XuUX03RZk2vgut4i+K/O4
+        4VU0iLzJ5GQC/H9cWyyyti7e7b2XltB3CAvF333wDWmEj05O3tBne/RdlmUgAOH3/38F8YDWGinP
+        OP70wf0HBzvwCr6mgugDIkg/mwrCdHj/YG9n78HuLRWE8s3t1YJ5gT+PvtGCJJE3+PPoGzJTvRfw
+        caQ9k4kH9jUE//u/5P8BFxl9i4QyAAA=
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['2067']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 31 Oct 2018 20:26:17 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [a5423d39-51fb-4ba1-9318-cd08187a86f4]
-      x-ms-original-request-ids: [bbccab3f-b4d9-4763-b1e7-a70935f98f3b, 59ce00ba-b5e9-4a6d-b61c-d307b7705fe5,
-        fb0071d1-394a-4947-aafe-5be146512aeb]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['1961']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 01 Nov 2018 15:59:15 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [9c7f3fc6-f1d3-4d4e-83b8-6ce1f098cdb9]
+      x-ms-original-request-ids: [4e182c33-ad76-4031-a14a-733b341f7636, 01842662-e6b6-4a78-8aba-50bb2fd2e0cc,
+        01123754-53f3-47c5-8403-e32a0037c4a9]
       x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [a5423d39-51fb-4ba1-9318-cd08187a86f4]
-      x-ms-routing-request-id: ['WESTUS2:20181031T202617Z:a5423d39-51fb-4ba1-9318-cd08187a86f4']
+      x-ms-request-id: [9c7f3fc6-f1d3-4d4e-83b8-6ce1f098cdb9]
+      x-ms-routing-request-id: ['WESTUS2:20181101T155916Z:9c7f3fc6-f1d3-4d4e-83b8-6ce1f098cdb9']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.15; Windows 10)]
-      x-ms-date: ['Wed, 31 Oct 2018 20:26:17 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:59:14 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testnotify
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      content-length: ['0']
-      date: ['Wed, 31 Oct 2018 20:26:20 GMT']
-      server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [a5517c14-7003-0127-5b57-71a474000000]
+      Content-Length: ['0']
+      Date: ['Thu, 01 Nov 2018 15:59:21 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [e8c062f8-4003-00a3-33fb-71b409000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
@@ -92,18 +91,18 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.15; Windows 10)]
-      x-ms-date: ['Wed, 31 Oct 2018 20:26:20 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:59:20 GMT']
       x-ms-version: ['2018-03-28']
     method: DELETE
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testnotify/messages
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      content-length: ['0']
-      date: ['Wed, 31 Oct 2018 20:26:20 GMT']
-      server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [a5517db0-7003-0127-2857-71a474000000]
+      Content-Length: ['0']
+      Date: ['Thu, 01 Nov 2018 15:59:22 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [e8c0679f-4003-00a3-47fb-71b409000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
@@ -113,11 +112,11 @@ interactions:
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
       Content-Type: [application/json; charset=utf-8]
-      User-Agent: [python/2.7.15 (Windows-10-10.0.17134) msrest/0.6.1 msrest_azure/0.5.0
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17134-SP0) msrest/0.6.1 msrest_azure/0.5.0
           azure-mgmt-keyvault/1.1.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?api-version=2015-11-01&$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/resources?$filter=resourceType%20eq%20%27Microsoft.KeyVault%2Fvaults%27&api-version=2015-11-01
   response:
     body:
       string: !!binary |
@@ -128,20 +127,20 @@ interactions:
         5u50aprvfjT6aJktCKGPwg/b6xU+HIRBTcpqmgFrakb4tPNpvmzrrFzjuza7aD569It/yS/5/i/5
         fwDnSjAt8wAAAA==
     headers:
-      cache-control: [no-cache]
-      content-encoding: [gzip]
-      content-length: ['295']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 31 Oct 2018 20:26:21 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      vary: [Accept-Encoding]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [eac299ea-d2a9-480d-a4d8-c27938aef2dc]
+      Cache-Control: [no-cache]
+      Content-Encoding: [gzip]
+      Content-Length: ['295']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 01 Nov 2018 15:59:23 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      Vary: [Accept-Encoding]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [7dd5b1ce-5896-428f-a6f4-ab517dc58814]
       x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [eac299ea-d2a9-480d-a4d8-c27938aef2dc]
-      x-ms-routing-request-id: ['WESTUS2:20181031T202621Z:eac299ea-d2a9-480d-a4d8-c27938aef2dc']
+      x-ms-request-id: [7dd5b1ce-5896-428f-a6f4-ab517dc58814]
+      x-ms-routing-request-id: ['WESTUS2:20181101T155923Z:7dd5b1ce-5896-428f-a6f4-ab517dc58814']
     status: {code: 200, message: OK}
 - request:
     body: null
@@ -149,90 +148,89 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python/2.7.15 (Windows-10-10.0.17134) msrest/0.6.1 msrest_azure/0.5.0
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17134-SP0) msrest/0.6.1 msrest_azure/0.5.0
           networkmanagementclient/2.2.1 Azure-SDK-For-Python]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Network/locations/eastus/operations/ea42f556-5106-4743-99b0-c129bfa71a47?api-version=2018-06-01
   response:
-    body: {string: !!python/unicode "{\r\n  \"error\": {\r\n    \"message\": \"Operation
-        273dd4dc-7c0b-4408-a9fa-fd0472050ac0 not found.\",\r\n    \"details\": []\r\n
-        \ }\r\n}"}
+    body: {string: "{\r\n  \"error\": {\r\n    \"message\": \"Operation 273dd4dc-7c0b-4408-a9fa-fd0472050ac0
+        not found.\",\r\n    \"details\": []\r\n  }\r\n}"}
     headers:
-      cache-control: [no-cache]
-      content-length: ['119']
-      content-type: [application/json; charset=utf-8]
-      date: ['Wed, 31 Oct 2018 20:26:26 GMT']
-      expires: ['-1']
-      pragma: [no-cache]
-      server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      strict-transport-security: [max-age=31536000; includeSubDomains]
-      x-content-type-options: [nosniff]
-      x-ms-correlation-request-id: [391d661f-91a0-438e-a82b-a71c4da1f570]
+      Cache-Control: [no-cache]
+      Content-Length: ['119']
+      Content-Type: [application/json; charset=utf-8]
+      Date: ['Thu, 01 Nov 2018 15:59:25 GMT']
+      Expires: ['-1']
+      Pragma: [no-cache]
+      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
+      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
+      X-Content-Type-Options: [nosniff]
+      x-ms-correlation-request-id: [2ceccb1a-f33e-4c3c-82c7-380c82bb05f6]
       x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [a684c696-c088-4d3b-a59c-4915ef7face5]
-      x-ms-routing-request-id: ['WESTUS2:20181031T202627Z:391d661f-91a0-438e-a82b-a71c4da1f570']
+      x-ms-request-id: [bbe0f5b0-d98d-46c7-915b-79a7e103891b]
+      x-ms-routing-request-id: ['WESTUS2:20181101T155925Z:2ceccb1a-f33e-4c3c-82c7-380c82bb05f6']
     status: {code: 404, message: Not Found}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.15; Windows 10)]
-      x-ms-date: ['Wed, 31 Oct 2018 20:26:21 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:59:22 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testnotify
   response:
-    body: {string: !!python/unicode ''}
+    body: {string: ''}
     headers:
-      content-length: ['0']
-      date: ['Wed, 31 Oct 2018 20:26:29 GMT']
-      server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [8ba0e0f1-8003-0079-2257-711122000000]
+      Content-Length: ['0']
+      Date: ['Thu, 01 Nov 2018 15:59:24 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [9ac40d41-5003-0052-55fb-71659a000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
-    body: !!python/unicode mock_body
+    body: mock_body
     headers:
       Connection: [keep-alive]
-      Content-Length: ['619']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.15; Windows 10)]
-      x-ms-date: ['Wed, 31 Oct 2018 20:26:30 GMT']
+      Content-Length: ['631']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:59:24 GMT']
       x-ms-version: ['2018-03-28']
     method: POST
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testnotify/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>b42e6de5-4777-47f5-8f08-865742f7314c</MessageId><InsertionTime>Wed,
-        31 Oct 2018 20:26:30 GMT</InsertionTime><ExpirationTime>Wed, 07 Nov 2018 20:26:30
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAiH0UAlhx1AE=</PopReceipt><TimeNextVisible>Wed,
-        31 Oct 2018 20:26:30 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>666e2573-ba27-4750-9a97-7c5fe1997089</MessageId><InsertionTime>Thu,
+        01 Nov 2018 15:59:25 GMT</InsertionTime><ExpirationTime>Thu, 08 Nov 2018 15:59:25
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAA8tjr3Ptx1AE=</PopReceipt><TimeNextVisible>Thu,
+        01 Nov 2018 15:59:25 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
     headers:
-      content-type: [application/xml]
-      date: ['Wed, 31 Oct 2018 20:26:29 GMT']
-      server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [8ba0e864-8003-0079-0258-711122000000]
+      Content-Type: [application/xml]
+      Date: ['Thu, 01 Nov 2018 15:59:24 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [9ac40f0e-5003-0052-7afb-71659a000000]
       x-ms-version: ['2018-03-28']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.15; Windows 10)]
-      x-ms-date: ['Wed, 31 Oct 2018 20:26:30 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:59:24 GMT']
       x-ms-version: ['2018-03-28']
     method: GET
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testnotify/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>b42e6de5-4777-47f5-8f08-865742f7314c</MessageId><InsertionTime>Wed,
-        31 Oct 2018 20:26:30 GMT</InsertionTime><ExpirationTime>Wed, 07 Nov 2018 20:26:30
-        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAsukIFFhx1AE=</PopReceipt><TimeNextVisible>Wed,
-        31 Oct 2018 20:27:00 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>eJzlUz1v2zAQ3fUrDM6R2NhJbWfqliHo2iUIjAt5ktnQPJo8OlCM/PdKpG1YQ4B27kTg+D7uHo/HSoBSlByLh5kAWK/Wy7vX+l7Pob7T61UNyxXUi9W8XSxv7/W3JYqb2YWzMfqfaAE7Qy5TrD0JcakcK8E0nM+VSBHDD007MK5RtBPVy4hk3HkLjCNbYwvJclbwwVAw3G+2CBrDeD3PF9z7DHbEpu1LKYCLngIXw33ClCFbZh8fpFSKI1OADvvv8NbvPXSaF9Rk4NBLwObdOE3vsXHIkjHytfrJEOJeVJ9jJabX36hytCPWuG5W8LPT3AXmyRrVl54CRkpBFaGPNDi+YX+4TOtgh2e5umjVLYV6AiriMaf5v+ZavRQoHjDvtkvWlhUs+V7SOSeq1DnD2+IK3Yg5fl6zHgMlf7bdTEK3pOC0y2IA81YNxgFsipMhfhoVKFLLzRP2v0a2zBoFVf6THOaLKhifn1H+zfeSkw6jnPQnfaCDGR4xyi/t5fX8Jb4/KLJRfw==</MessageText></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>666e2573-ba27-4750-9a97-7c5fe1997089</MessageId><InsertionTime>Thu,
+        01 Nov 2018 15:59:25 GMT</InsertionTime><ExpirationTime>Thu, 08 Nov 2018 15:59:25
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAh+Hg7vtx1AE=</PopReceipt><TimeNextVisible>Thu,
+        01 Nov 2018 15:59:55 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>eJzlU7Fu2zAQ3fUVBudKauyktjN161B07VIExoU8yWxoHk0eHahG/r0kFbpugALtXGjSvXfv7p2ezo3AE1oW9wsbjXnXCJCSouWdVqkmALab7fr2sb1TS2hv1XbTwnoD7WqzHFbrmzv1fo3iV9e/tHgcNdnSYUwuODJaTqlwboSFA2aIMXBrifUwtQP59gmnE0TDs0Cg6GXhwY/osbtGQXKSDwn81iRBnlwhzlqZwHhwBrhUFQ61z3lNXvO02yMo9Bld5nqIj99Rcl1K23Exay3mSUWSyjgRA/qPig6gbSfpIJqHDHqwwZHn2WFdCMIxtx4jxvK+Z3bhvu+l5MDkYcTpAzxNRwej4hV1hZhUk91nbRU9h84i93mnV2/NS3oempfLEX4f+J9c4CoglxDMme6TkSC9diUg/d/kta9SnzxFF8qsXU1b7zyddLpU6L9o6SnQwN1nnL4WsFBCMlPpN9lszfebcj3JH3UyyZCE188q0la8l+kH9mBiQRnG7Pd8fYCydf1ul73FHJOff7NOXw==</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
-      cache-control: [no-cache]
-      content-type: [application/xml]
-      date: ['Wed, 31 Oct 2018 20:26:30 GMT']
-      server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [a55184b9-7003-0127-5d58-71a474000000]
+      Cache-Control: [no-cache]
+      Content-Type: [application/xml]
+      Date: ['Thu, 01 Nov 2018 15:59:25 GMT']
+      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [e8c069cd-4003-00a3-21fb-71b409000000]
       x-ms-version: ['2018-03-28']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_create_queue_from_storage_account.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_create_queue_from_storage_account.yaml
@@ -5,8 +5,8 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python/3.6.7 (Linux-4.4.0-17134-Microsoft-x86_64-with-debian-buster-sid)
-          msrest/0.6.1 msrest_azure/0.5.0 azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
+      User-Agent: [python/2.7.15 (Windows-10-10.0.17134) msrest/0.6.1 msrest_azure/0.5.0
+          azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
     uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
@@ -31,59 +31,57 @@ interactions:
         rj/N3l7/olV2MWvvVYSaDmq4wY+UC/EWft5OJ8AVePhm9/4j/G9/fI/k88GncEfeV7kMAiJIPyvK
         pdvh7v2DBw8+vaVyGeCf2yuXIQDcLgqhBcluAYHbRSHIzN4IAM0i7zOZmTD/P1Iul4v30iv79xe/
         aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv8jrUJMhZ+3UwYw/A/f7O09uvfw0c7e+OGDg539Tx+QMnhf
-        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aBTq
-        4hpaJVut3kureO9lBzvnhJGOpf/F19MjPjl/vqgQmPf9Nzv3H+3tP9rbHe89uH+P5o4k/31VyCAg
-        gvSzokI6He5+uvfwwQPqENBYBDapkA7L3F53dF/k76NvtiDRhjf5++ibMoODL+LryHtMRh64pyZ8
-        liYIP380xMH04S5hpGPpf/EjDfH+gv3po/t7408PDu7vfEqmmnCA1HwDgAjSz7KG4A7vP3i4u3+f
-        vBpAYxG4pYYAy3wtDcEv8vfRN1uQaMOb/H30TZnBwRfxdeQ9JiMP/P/zGmKWtZSkfy/lIK8QDoq9
-        /fvrqYIrordkpH++KALy2Xfuc5rx4NH9h+NPP71PmcYdkt/3VQSDgAjSz4oi6HR4/8HOzv3d2yoC
-        4ZPby7+254+jL7QgSP8F/jj6gkxTtz0+jTRnEvGgPCF3zPr/HRGnLq63s+b9Mpp4id5BQphQ0UGE
-        H/5I3G8npbCevHq5f//R/i4tY+zv3b9H/jXhAFn4EEAKiCD9rIh7B/ODT2nddZ9ypIDGXL9J3D1m
-        ub3M+y/xd9G3WtB44C3+LvqWzFr0JXwVeYfJxgP9/7gKmJbVerY9XZNk0niX76UJ+F376nRv//z+
-        pw8/JeR0WIPf/0g/3F4/7L/Z/RTx9/374wf39w527u+TWH8d/RAFRJB+1vSD1+Gn9x/u3N+7rTsQ
-        55vbq4qB97lZFEALgt0MgJtFAci03vQ+WkVeZxIzUf4/rkveFnVRbi8Iubx+P0ViSEU/8AX5XviC
-        UNNBDTf4kSp5Hw2ws/PoHq0x3hvf+3R/jyw2aYCvp0oigAjSz6IqsR3uPdjZ30coA2gsERtVSZxx
-        3kOXDADgdlEILUh2CwjcLgpBZvZGAGgWeZ/JzIT5/7g6YS36dV0T89Ze9unD6c70PuGlI4p99SMt
-        8j7CT1H+7oNHuwdjmr2HDx9+SsL/9bRIBBBB+lnUIrbDvYOHew93KUICNBaEW2kRwzJfQ3/YV7lF
-        9N0WZNr4LreIvivzuOFVNIi8yeRkAvx/XFt8bedDXtFPPz2YHNAy+QEhpkMa+vpHKuP2ks6JQQoG
-        yHzfu7f/8IAXLb+OyogCIkg/ayrD63Bvf3f3YOe2MUyUbW6vNuKvc6vo+y3IdeP73Cr6vszpDa+j
-        UeRtJi8T5P/jKmSRtXXxbu89tQe/Q1go/u6DH2mI9xHsvR1aQHy092B8b3//3sMHJGeEA+TlGwBE
-        kH4WNYTtcI8WW+/v3DY0UUZ5H50gL/Dn0TdakCTyBn8efUNmqvcCPo60ZzLxwL6GpH//l/w/3Pvw
-        spQ2AAA=
+        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aJRZ
+        1lKA/V4KRV4hHBR7+/fXUxhXpNMkmvx5pCl27nOIcPDo/sPxp5/epyhhhwT8a2iKOCCC9LOlKfwO
+        7z/Y2bm/S6oJ0JjTN2kK4ZPbawZtzx9HX2hBkP4L/HH0BZmmbnt8GmnOJOJBeZLumPX/OyJOXVxv
+        Z837RSN4id5BMEeo6CDCD38k7reTUjjtnHncv/9of5dSEPt79+/tkZS+r7gPAiJIPyvi3unw4FPK
+        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rAM70bk/nWbG8915q
+        AAGHfra7d/Dg3v7u3oMDQkyHNPT1j1TD7SWaPO97j3buP9rZH+892NvZ2YdEfx3VEAVEkH7WVIPX
+        4e7Dewf7t85ERNnm9koi/jq3ir7fglw3vs+tou/LnN7wOhpF3mbyMkH+f6FCZLXovVTIdE2fkJZd
+        0g98QS4XviDUdFDDDX6kRm4v/ftvdnYe3aO0IK2vfrq/R4aapP82auRWgAjSz5oa8Trce7Czv48I
+        BtBYIjapkQHGub0iGQLA7aIQWtD+FhC4XRSCzOyNANAs8j6TmQnz/3F1Mi2r9Wzbjv7raZS97NOH
+        053pfcJLRxT76kda5H20CAX3uw8e7R6MafYePnxIJp1wgER9A4AI0s+iFrEd7h083Hu4S94PoLEg
+        3EqLGJb5GvrDvsotou+2INPGd7lF9F2Zxw2vokHkTSYnE+D/49riazsf8op++unB5IAy2whQdEhD
+        X/9IZdxe0jkfuPspzPe9e/sPDw5I8AgHCNE3AIgg/aypDK/Dvf3d3YOd22Yyo2xze7URf51bRd9v
+        Qa4b3+dW0fdlTm94HY0ibzN5mSD/H1ch34jDMd3bP7//6cNPCS8dUeyrH2mPWwv9vZ03u/cf7e08
+        2qMcwqfEhwe07kg4QJa+AUAE6WdLe/gd7tzfO7j/8OCW2qPHMrfXHP1XuUX03RZk2vgut4i+K/O4
+        4VU0iLzJ5GQC/H9cWyyyti7e7b2XltB3CAvF333wDWmEj05O3tBne/RdlmUgAOH3/38F8YDWGinP
+        OP70wf0HBzvwCr6mgugDIkg/mwrCdHj/YG9n78HuLRWE8s3t1YJ5gT+PvtGCJJE3+PPoGzJTvRfw
+        caQ9k4kH9jUE//u/5P8BFxl9i4QyAAA=
     headers:
-      Cache-Control: [no-cache]
-      Content-Encoding: [gzip]
-      Content-Length: ['2057']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 29 Oct 2018 15:54:36 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      Vary: [Accept-Encoding]
-      X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [df3383fa-a1b3-44c2-8c22-d5ff20bc0f80]
-      x-ms-original-request-ids: [fee1b036-9f32-442e-9611-cac356acea53, 2e09525a-9c1d-44f9-8473-9389dc7ef02b,
-        610bf409-6f9c-48d6-af45-392c2d95e588, 7496d3ba-da8b-4b61-bb43-850c8e739941]
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['1961']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 01 Nov 2018 15:54:04 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [fba6bd54-46fe-4119-88a0-24ddc2df03dc]
+      x-ms-original-request-ids: [22c0ca10-e402-4bc3-93a2-82fb3e9404e0, 2b3610c2-6f0e-496f-87e1-6341f265134b,
+        ff88bc96-b72d-4f2c-8735-1ae93229ef37]
       x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [df3383fa-a1b3-44c2-8c22-d5ff20bc0f80]
-      x-ms-routing-request-id: ['WESTUS2:20181029T155436Z:df3383fa-a1b3-44c2-8c22-d5ff20bc0f80']
+      x-ms-request-id: [fba6bd54-46fe-4119-88a0-24ddc2df03dc]
+      x-ms-routing-request-id: ['WESTUS2:20181101T155405Z:fba6bd54-46fe-4119-88a0-24ddc2df03dc']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:54:36 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.15; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:55:34 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testqueuecc
   response:
-    body: {string: ''}
+    body: {string: !!python/unicode ''}
     headers:
-      Date: ['Mon, 29 Oct 2018 15:54:43 GMT']
-      Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [39dab7d9-c003-00df-0e9f-6f293c000000]
+      date: ['Thu, 01 Nov 2018 15:55:46 GMT']
+      server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [1fd51571-d003-00a6-12fb-714076000000]
       x-ms-version: ['2018-03-28']
     status: {code: 201, message: Created}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_cycle_queue_message_by_uri.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_cycle_queue_message_by_uri.yaml
@@ -5,11 +5,12 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python/3.6.7 (Linux-4.4.0-17134-Microsoft-x86_64-with-debian-buster-sid)
-          msrest/0.6.1 msrest_azure/0.5.0 azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17134-SP0) msrest/0.6.1 msrest_azure/0.5.0
+          azure-mgmt-storage/2.0.0rc4 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01
   response:
     body:
       string: !!binary |
@@ -31,50 +32,50 @@ interactions:
         rj/N3l7/olV2MWvvVYSaDmq4wY+UC/EWft5OJ8AVePhm9/4j/G9/fI/k88GncEfeV7kMAiJIPyvK
         pdvh7v2DBw8+vaVyGeCf2yuXIQDcLgqhBcluAYHbRSHIzN4IAM0i7zOZmTD/P1Iul4v30iv79xe/
         aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv8jrUJMhZ+3UwYw/A/f7O09uvfw0c7e+OGDg539Tx+QMnhf
-        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aBTq
-        4hpaJVut3kureO9lBzvnhJGOpf/F19MjPjl/vqgQmPf9Nzv3H+3tP9rbHe89uH+P5o4k/31VyCAg
-        gvSzokI6He5+uvfwwQPqENBYBDapkA7L3F53dF/k76NvtiDRhjf5++ibMoODL+LryHtMRh64pyZ8
-        liYIP380xMH04S5hpGPpf/EjDfH+gv3po/t7408PDu7vfEqmmnCA1HwDgAjSz7KG4A7vP3i4u3+f
-        vBpAYxG4pYYAy3wtDcEv8vfRN1uQaMOb/H30TZnBwRfxdeQ9JiMP/P/zGmKWtZSkfy/lIK8QDoq9
-        /fvrqYIrordkpH++KALy2Xfuc5rx4NH9h+NPP71PmcYdkt/3VQSDgAjSz4oi6HR4/8HOzv3d2yoC
-        4ZPby7+254+jL7QgSP8F/jj6gkxTtz0+jTRnEvGgPCF3zPr/HRGnLq63s+b9Mpp4id5BQphQ0UGE
-        H/5I3G8npbCevHq5f//R/i4tY+zv3b9H/jXhAFn4EEAKiCD9rIh7B/ODT2nddZ9ypIDGXL9J3D1m
-        ub3M+y/xd9G3WtB44C3+LvqWzFr0JXwVeYfJxgP9/7gKmJbVerY9XZNk0niX76UJ+F376nRv//z+
-        pw8/JeR0WIPf/0g/3F4/7L/Z/RTx9/374wf39w527u+TWH8d/RAFRJB+1vSD1+Gn9x/u3N+7rTsQ
-        55vbq4qB97lZFEALgt0MgJtFAci03vQ+WkVeZxIzUf4/rkveFnVRbi8Iubx+P0ViSEU/8AX5XviC
-        UNNBDTf4kSp5Hw2ws/PoHq0x3hvf+3R/jyw2aYCvp0oigAjSz6IqsR3uPdjZ30coA2gsERtVSZxx
-        3kOXDADgdlEILUh2CwjcLgpBZvZGAGgWeZ/JzIT5/7g6YS36dV0T89Ze9unD6c70PuGlI4p99SMt
-        8j7CT1H+7oNHuwdjmr2HDx9+SsL/9bRIBBBB+lnUIrbDvYOHew93KUICNBaEW2kRwzJfQ3/YV7lF
-        9N0WZNr4LreIvivzuOFVNIi8yeRkAvx/XFt8bedDXtFPPz2YHNAy+QEhpkMa+vpHKuP2ks6JQQoG
-        yHzfu7f/8IAXLb+OyogCIkg/ayrD63Bvf3f3YOe2MUyUbW6vNuKvc6vo+y3IdeP73Cr6vszpDa+j
-        UeRtJi8T5P/jKmSRtXXxbu89tQe/Q1go/u6DH2mI9xHsvR1aQHy092B8b3//3sMHJGeEA+TlGwBE
-        kH4WNYTtcI8WW+/v3DY0UUZ5H50gL/Dn0TdakCTyBn8efUNmqvcCPo60ZzLxwL6GpH//l/w/3Pvw
-        spQ2AAA=
+        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aJRZ
+        1lKA/V4KRV4hHBR7+/fXUxhXpNMkmvx5pCl27nOIcPDo/sPxp5/epyhhhwT8a2iKOCCC9LOlKfwO
+        7z/Y2bm/S6oJ0JjTN2kK4ZPbawZtzx9HX2hBkP4L/HH0BZmmbnt8GmnOJOJBeZLumPX/OyJOXVxv
+        Z837RSN4id5BMEeo6CDCD38k7reTUjjtnHncv/9of5dSEPt79+/tkZS+r7gPAiJIPyvi3unw4FPK
+        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rgGlZrWfb0zVJJo13
+        +V6agN+1r0739s/vf/rwU0JOhzX4/Y/0w+3Fev/N7qeP9vYf3b8/fnB/72DnPq1MEA6Qm28AEEH6
+        WdMPXoef3n+4c3/vtu5AnG9uryoG3udmUQAtCHYzAG4WBSDTetP7aBV5nUnMRPn/uC7hVaPt6Twr
+        lvfeS5EgeaGf7e4dPLi3v7v34IAQ0yENff0jNXJ76aco/t6jnfuPdvbHew/2dnb24R3coEZuD4gg
+        /aypEa/D3Yf3DvZvndWMss3ttUj8dW4Vfb8FuW58n1tF35c5veF1NIq8zeRlgvz/QoXIyvN7qRCr
+        bekHvqDwDV8Qajqo4QY/UiO3VyP7b3Z2Ht2jJYZ743uf7u+R00/S/3XUSBQQQfpZUyNeh3sPdvb3
+        kQ0BNJaITWpkgHFur0iGAHC7KIQWJLsFBG4XhSAzeyMANIu8z2Rmwvx/XJ2wI/Z1oxvz1l726cPp
+        zvQ+4aUjin31Iy3yPsJPicLdB492D8Y0ew8fPiSTTjhAor4BQATpZ1GL2A73Dh7uPdwl7wfQWBBu
+        pUUMy3wN/WFf5RbRd1uQaeO73CL6rszjhlfRIPImk5MJ8P9xbfG1nQ95RT/99GByQKtkCFB0SENf
+        /0hl3F7SeW2B8glkvu/d2394cECCRzhAiL4BQATpZ01leB3u7e/uHuzcNg0SZZvbq43469wq+n4L
+        ct34PreKvi9zesPraBR5m8nLBPn/uAr5RhwOkzAivHREsa9+pD1uLfT3dt7s3n+0t0PZyPHup8SH
+        B/dI6L+G9ogDIkg/W9rD75AyqAf3Hx7cUnv0WOb2mqP/KreIvtuCTBvf5RbRd2UeN7yKBpE3mZxM
+        gP+Pa4tF1tbFu7330hL6DmGh+LsPviGN8NHJyRv6bI++y7IMBCD8/v+vIB48uv+Q8ozjTx/cf3Cw
+        A6/gayqIPiCC9LOpIEyH9w/2dvYe7N5SQSjf3F4tmBf48+gbLUgSeYM/j74hM9V7AR9H2jOZeGBf
+        Q/C//0v+H3lf3ZTQNgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2057']
+      Content-Length: ['2067']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 29 Oct 2018 15:48:44 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:16 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [924486f5-e27f-4eec-b6ca-3e3332bea86b]
-      x-ms-original-request-ids: [af5855db-ecf5-442d-9916-b9880d4fd667, f75fd516-1831-4d2c-b4f9-591ab4fd77a0,
-        347e7834-a564-4e64-b6d8-6e5f059cc907, fd6606a6-c227-4fe5-ae77-9a2a78225a19]
-      x-ms-ratelimit-remaining-subscription-reads: ['11998']
-      x-ms-request-id: [924486f5-e27f-4eec-b6ca-3e3332bea86b]
-      x-ms-routing-request-id: ['WESTUS2:20181029T154845Z:924486f5-e27f-4eec-b6ca-3e3332bea86b']
+      x-ms-correlation-request-id: [9873925e-2644-461b-a646-79852b615127]
+      x-ms-original-request-ids: [14b50f76-7943-4122-90e3-fa87a0ca9f47, 5f9a43bd-74fe-4cc3-96c9-42bad90a1db2,
+        cbd4efed-b9ed-4b82-acd1-63f61668a0bf]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [9873925e-2644-461b-a646-79852b615127]
+      x-ms-routing-request-id: ['WESTUS2:20181101T151316Z:9873925e-2644-461b-a646-79852b615127']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:48:45 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:15 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage
@@ -82,9 +83,9 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Mon, 29 Oct 2018 15:48:57 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:18 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [4b242b31-b003-001c-549e-6fa07f000000]
+      x-ms-request-id: [20342b2f-e003-00c3-36f5-71f12b000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
@@ -92,44 +93,44 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['106']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:48:57 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:17 GMT']
       x-ms-version: ['2018-03-28']
     method: POST
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>5ba40d56-4e8a-4b25-ab71-7c6565ca7fb9</MessageId><InsertionTime>Mon,\
-        \ 29 Oct 2018 15:48:58 GMT</InsertionTime><ExpirationTime>Mon, 05 Nov 2018\
-        \ 15:48:58 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAVtaV555v1AE=</PopReceipt><TimeNextVisible>Mon,\
-        \ 29 Oct 2018 15:48:58 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>1eb37c29-c428-483b-9a78-a525c552ec0b</MessageId><InsertionTime>Thu,
+        01 Nov 2018 15:13:19 GMT</InsertionTime><ExpirationTime>Thu, 08 Nov 2018 15:13:19
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAXgkCbPVx1AE=</PopReceipt><TimeNextVisible>Thu,
+        01 Nov 2018 15:13:19 GMT</TimeNextVisible></QueueMessage></QueueMessagesList>"}
     headers:
       Content-Type: [application/xml]
-      Date: ['Mon, 29 Oct 2018 15:48:57 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:18 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [4b2439cc-b003-001c-409e-6fa07f000000]
+      x-ms-request-id: [20342cba-e003-00c3-12f5-71f12b000000]
       x-ms-version: ['2018-03-28']
     status: {code: 201, message: Created}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:48:57 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:17 GMT']
       x-ms-version: ['2018-03-28']
     method: GET
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>5ba40d56-4e8a-4b25-ab71-7c6565ca7fb9</MessageId><InsertionTime>Mon,\
-        \ 29 Oct 2018 15:48:58 GMT</InsertionTime><ExpirationTime>Mon, 05 Nov 2018\
-        \ 15:48:58 GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAARbGD+Z5v1AE=</PopReceipt><TimeNextVisible>Mon,\
-        \ 29 Oct 2018 15:49:28 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>hello\
-        \ queue</MessageText></QueueMessage></QueueMessagesList>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList><QueueMessage><MessageId>1eb37c29-c428-483b-9a78-a525c552ec0b</MessageId><InsertionTime>Thu,
+        01 Nov 2018 15:13:19 GMT</InsertionTime><ExpirationTime>Thu, 08 Nov 2018 15:13:19
+        GMT</ExpirationTime><PopReceipt>AgAAAAMAAAAAAAAAzKfwffVx1AE=</PopReceipt><TimeNextVisible>Thu,
+        01 Nov 2018 15:13:49 GMT</TimeNextVisible><DequeueCount>1</DequeueCount><MessageText>hello
+        queue</MessageText></QueueMessage></QueueMessagesList>"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Mon, 29 Oct 2018 15:48:57 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:19 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [4b2439d8-b003-001c-499e-6fa07f000000]
+      x-ms-request-id: [20342cd4-e003-00c3-28f5-71f12b000000]
       x-ms-version: ['2018-03-28']
     status: {code: 200, message: OK}
 - request:
@@ -137,38 +138,38 @@ interactions:
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:48:57 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:17 GMT']
       x-ms-version: ['2018-03-28']
     method: DELETE
-    uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages/5ba40d56-4e8a-4b25-ab71-7c6565ca7fb9?popreceipt=AgAAAAMAAAAAAAAARbGD%2BZ5v1AE%3D
+    uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages/1eb37c29-c428-483b-9a78-a525c552ec0b?popreceipt=AgAAAAMAAAAAAAAAzKfwffVx1AE%3D
   response:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Mon, 29 Oct 2018 15:48:58 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:19 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [4b2439e9-b003-001c-589e-6fa07f000000]
+      x-ms-request-id: [20342cea-e003-00c3-3af5-71f12b000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:48:57 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:17 GMT']
       x-ms-version: ['2018-03-28']
     method: GET
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcyclemessage/messages
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList\
-        \ />"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><QueueMessagesList
+        />"}
     headers:
       Cache-Control: [no-cache]
       Content-Type: [application/xml]
-      Date: ['Mon, 29 Oct 2018 15:48:58 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:19 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [4b2439ef-b003-001c-5d9e-6fa07f000000]
+      x-ms-request-id: [20342cfc-e003-00c3-4bf5-71f12b000000]
       x-ms-version: ['2018-03-28']
     status: {code: 200, message: OK}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri.yaml
@@ -5,11 +5,12 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python/3.6.7 (Linux-4.4.0-17134-Microsoft-x86_64-with-debian-buster-sid)
-          msrest/0.6.1 msrest_azure/0.5.0 azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17134-SP0) msrest/0.6.1 msrest_azure/0.5.0
+          azure-mgmt-storage/2.0.0rc4 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01
   response:
     body:
       string: !!binary |
@@ -31,50 +32,50 @@ interactions:
         rj/N3l7/olV2MWvvVYSaDmq4wY+UC/EWft5OJ8AVePhm9/4j/G9/fI/k88GncEfeV7kMAiJIPyvK
         pdvh7v2DBw8+vaVyGeCf2yuXIQDcLgqhBcluAYHbRSHIzN4IAM0i7zOZmTD/P1Iul4v30iv79xe/
         aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv8jrUJMhZ+3UwYw/A/f7O09uvfw0c7e+OGDg539Tx+QMnhf
-        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aBTq
-        4hpaJVut3kureO9lBzvnhJGOpf/F19MjPjl/vqgQmPf9Nzv3H+3tP9rbHe89uH+P5o4k/31VyCAg
-        gvSzokI6He5+uvfwwQPqENBYBDapkA7L3F53dF/k76NvtiDRhjf5++ibMoODL+LryHtMRh64pyZ8
-        liYIP380xMH04S5hpGPpf/EjDfH+gv3po/t7408PDu7vfEqmmnCA1HwDgAjSz7KG4A7vP3i4u3+f
-        vBpAYxG4pYYAy3wtDcEv8vfRN1uQaMOb/H30TZnBwRfxdeQ9JiMP/P/zGmKWtZSkfy/lIK8QDoq9
-        /fvrqYIrordkpH++KALy2Xfuc5rx4NH9h+NPP71PmcYdkt/3VQSDgAjSz4oi6HR4/8HOzv3d2yoC
-        4ZPby7+254+jL7QgSP8F/jj6gkxTtz0+jTRnEvGgPCF3zPr/HRGnLq63s+b9Mpp4id5BQphQ0UGE
-        H/5I3G8npbCevHq5f//R/i4tY+zv3b9H/jXhAFn4EEAKiCD9rIh7B/ODT2nddZ9ypIDGXL9J3D1m
-        ub3M+y/xd9G3WtB44C3+LvqWzFr0JXwVeYfJxgP9/7gKmJbVerY9XZNk0niX76UJ+F376nRv//z+
-        pw8/JeR0WIPf/0g/3F4/7L/Z/RTx9/374wf39w527u+TWH8d/RAFRJB+1vSD1+Gn9x/u3N+7rTsQ
-        55vbq4qB97lZFEALgt0MgJtFAci03vQ+WkVeZxIzUf4/rkveFnVRbi8Iubx+P0ViSEU/8AX5XviC
-        UNNBDTf4kSp5Hw2ws/PoHq0x3hvf+3R/jyw2aYCvp0oigAjSz6IqsR3uPdjZ30coA2gsERtVSZxx
-        3kOXDADgdlEILUh2CwjcLgpBZvZGAGgWeZ/JzIT5/7g6YS36dV0T89Ze9unD6c70PuGlI4p99SMt
-        8j7CT1H+7oNHuwdjmr2HDx9+SsL/9bRIBBBB+lnUIrbDvYOHew93KUICNBaEW2kRwzJfQ3/YV7lF
-        9N0WZNr4LreIvivzuOFVNIi8yeRkAvx/XFt8bedDXtFPPz2YHNAy+QEhpkMa+vpHKuP2ks6JQQoG
-        yHzfu7f/8IAXLb+OyogCIkg/ayrD63Bvf3f3YOe2MUyUbW6vNuKvc6vo+y3IdeP73Cr6vszpDa+j
-        UeRtJi8T5P/jKmSRtXXxbu89tQe/Q1go/u6DH2mI9xHsvR1aQHy092B8b3//3sMHJGeEA+TlGwBE
-        kH4WNYTtcI8WW+/v3DY0UUZ5H50gL/Dn0TdakCTyBn8efUNmqvcCPo60ZzLxwL6GpH//l/w/3Pvw
-        spQ2AAA=
+        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aJRZ
+        1lKA/V4KRV4hHBR7+/fXUxhXpNMkmvx5pCl27nOIcPDo/sPxp5/epyhhhwT8a2iKOCCC9LOlKfwO
+        7z/Y2bm/S6oJ0JjTN2kK4ZPbawZtzx9HX2hBkP4L/HH0BZmmbnt8GmnOJOJBeZLumPX/OyJOXVxv
+        Z837RSN4id5BMEeo6CDCD38k7reTUjjtnHncv/9of5dSEPt79+/tkZS+r7gPAiJIPyvi3unw4FPK
+        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rgGlZrWfb0zVJJo13
+        +V6agN+1r0739s/vf/rwU0JOhzX4/Y/0w+3Fev/N7qeP9vYf3b8/fnB/72DnPq1MEA6Qm28AEEH6
+        WdMPXoef3n+4c3/vtu5AnG9uryoG3udmUQAtCHYzAG4WBSDTetP7aBV5nUnMRPn/uC7hVaPt6Twr
+        lvfeS5EgeaGf7e4dPLi3v7v34IAQ0yENff0jNXJ76aco/t6jnfuPdvbHew/2dnb24R3coEZuD4gg
+        /aypEa/D3Yf3DvZvndWMss3ttUj8dW4Vfb8FuW58n1tF35c5veF1NIq8zeRlgvz/QoXIyvN7qRCr
+        bekHvqDwDV8Qajqo4QY/UiO3VyP7b3Z2Ht2jJYZ743uf7u+R00/S/3XUSBQQQfpZUyNeh3sPdvb3
+        kQ0BNJaITWpkgHFur0iGAHC7KIQWJLsFBG4XhSAzeyMANIu8z2Rmwvx/XJ2wI/Z1oxvz1l726cPp
+        zvQ+4aUjin31Iy3yPsJPicLdB492D8Y0ew8fPiSTTjhAor4BQATpZ1GL2A73Dh7uPdwl7wfQWBBu
+        pUUMy3wN/WFf5RbRd1uQaeO73CL6rszjhlfRIPImk5MJ8P9xbfG1nQ95RT/99GByQKtkCFB0SENf
+        /0hl3F7SeW2B8glkvu/d2394cECCRzhAiL4BQATpZ01leB3u7e/uHuzcNg0SZZvbq43469wq+n4L
+        ct34PreKvi9zesPraBR5m8nLBPn/uAr5RhwOkzAivHREsa9+pD1uLfT3dt7s3n+0t0PZyPHup8SH
+        B/dI6L+G9ogDIkg/W9rD75AyqAf3Hx7cUnv0WOb2mqP/KreIvtuCTBvf5RbRd2UeN7yKBpE3mZxM
+        gP+Pa4tF1tbFu7330hL6DmGh+LsPviGN8NHJyRv6bI++y7IMBCD8/v+vIB48uv+Q8ozjTx/cf3Cw
+        A6/gayqIPiCC9LOpIEyH9w/2dvYe7N5SQSjf3F4tmBf48+gbLUgSeYM/j74hM9V7AR9H2jOZeGBf
+        Q/C//0v+H3lf3ZTQNgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2057']
+      Content-Length: ['2067']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 29 Oct 2018 15:48:59 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:20 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [ec458e44-9bfb-4d14-bfcf-adff13063814]
-      x-ms-original-request-ids: [bef10038-230f-455f-9778-a189bd5adc86, c8f0c099-7dd5-47a5-8239-55ac60c55b0e,
-        80b89791-34f2-45de-b3f0-afb6d7d11702, d8b1b2ac-6c08-454e-8b62-c4693e08e644]
+      x-ms-correlation-request-id: [46115a97-db90-42c6-a031-5ec7757dc3de]
+      x-ms-original-request-ids: [03b8fc7c-5b7d-461e-a2ee-67ae61ec7e0a, ea88e743-9f17-4414-9150-b0856b7925f0,
+        25ee38d8-d2cb-460c-8ba9-786c7ce0b499]
       x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [ec458e44-9bfb-4d14-bfcf-adff13063814]
-      x-ms-routing-request-id: ['WESTUS2:20181029T154859Z:ec458e44-9bfb-4d14-bfcf-adff13063814']
+      x-ms-request-id: [46115a97-db90-42c6-a031-5ec7757dc3de]
+      x-ms-routing-request-id: ['WESTUS2:20181101T151320Z:46115a97-db90-42c6-a031-5ec7757dc3de']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:48:59 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:19 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc
@@ -82,9 +83,9 @@ interactions:
     body: {string: ''}
     headers:
       Content-Length: ['0']
-      Date: ['Mon, 29 Oct 2018 15:49:01 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:26 GMT']
       Server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
-      x-ms-request-id: [89a9a348-c003-0117-6d9e-6ffe5e000000]
+      x-ms-request-id: [75e6fe72-b003-00b6-50f5-717690000000]
       x-ms-version: ['2018-03-28']
     status: {code: 204, message: No Content}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri_auth_file.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_queue_client_by_uri_auth_file.yaml
@@ -1,0 +1,88 @@
+interactions:
+- request:
+    body: null
+    headers:
+      Accept: [application/json]
+      Accept-Encoding: ['gzip, deflate']
+      Connection: [keep-alive]
+      User-Agent: [python/2.7.15 (Windows-10-10.0.17134) msrest/0.6.1 msrest_azure/0.5.0
+          azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
+      accept-language: [en-US]
+    method: GET
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+  response:
+    body:
+      string: !!binary |
+        H4sIAAAAAAAEAO29B2AcSZYlJi9tynt/SvVK1+B0oQiAYBMk2JBAEOzBiM3mkuwdaUcjKasqgcpl
+        VmVdZhZAzO2dvPfee++999577733ujudTif33/8/XGZkAWz2zkrayZ4hgKrIHz9+fB8/In7xR5dZ
+        uc4/evS9X/xR83b90aNf/NEyW9DfH71us+Usq2e///NXrz8afdQWee19+tEvGX30tljO+KOqzi7y
+        n9yjVgU+uNusJ820LlZtUS2bu1n28ODhg/3J9v3ZXra9P3t4sJ09OMi27x3snd97sHt/tvMgv1vn
+        TbWup/nndbVeNXffFnVRbi+yoszru6u6uixmed3c/aKY1lVTnbdj7fRuIz+Pp9NqvWz1RXmP0NGh
+        hB+21yt8eCMsalpW0wyDoOZ51rTrBmNss4uG6EQEIMRWeU2Uwd8fLfP2qqrfHk9L/nNyvcoa+u2j
+        4x+s6/x1Xl8WU2o4+uiyqNt1Vr6Q5q/WJX366HvfJ+KtvD9m+Xm2LtvjqfZ/XJbVFajerFerqm6b
+        b7ftqnlTZ+fnxfTLZXn90aO2Xuejj/LltL5m0gOLxvRLv58TAfAzX2aTMqeZkhdKGtmpfPSmYHrt
+        7ewebO/ubO/tvdk9eHRv99HuvfG9ew8PHuzc/ymgMCmryTcAiCC9za9f87xT496EoKtsSsg3b4T5
+        vl21RD+i+mXR0PiK5QWxY4t3X6+pXT4jXEYfTeucJ20DDnv7n+7u7e3/FLVe1cUiq69Pl7NVVWDW
+        aVxXOQ3vozkI/Oiuz1LjH+ztjOnb8bSq8/EV8X911Yxp4u8SJKFK9DV8FX3nF61zCF/0Jf4u+lYL
+        Gg+8xd9F35Lpj76EryLvEP2VPM9jgtAQ8dfNl+cvpQ19l10SPCCAySXm+yCFQm2+KXXS5k37+8+K
+        7GJZNW0x3W7ytiXuad5Ltbj36/XV9YP989m9+hflGaGpAxxu8PVUDg2hnU/zZVtn5Rrf/b9W85xn
+        ZUMK4JtSPTsPt3cP3uw+fHT/waN7D8YP9+/v3dvdJY1hhOyDARGkG1UP0fi99Uynw4N79x88OLg3
+        pGdkMB8ZiRzgn9trjyEA3C4KoQXJbgGB20UhyMzeCADNIu8zmZkwnobp8f3/xxSNCvV7KZfptNWP
+        rj/N3l7/olV2MWvvVYSaDmq4wY+UC/EWft5OJ8AVePhm9/4j/G9/fI/k88GncEfeV7kMAiJIPyvK
+        pdvh7v2DBw8+vaVyGeCf2yuXIQDcLgqhBcluAYHbRSHIzN4IAM0i7zOZmTD/P1Iul4v30iv79xe/
+        aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv8jrUJMhZ+3UwYw/A/f7O09uvfw0c7e+OGDg539Tx+QMnhf
+        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aJRZ
+        1lKA/V4KRV4hHBR7+/fXUxhXpNMkmvx5pCl27nOIcPDo/sPxp5/epyhhhwT8a2iKOCCC9LOlKfwO
+        7z/Y2bm/S6oJ0JjTN2kK4ZPbawZtzx9HX2hBkP4L/HH0BZmmbnt8GmnOJOJBeZLumPX/OyJOXVxv
+        Z837RSN4id5BMEeo6CDCD38k7reTUjjtnHncv/9of5dSEPt79+/tkZS+r7gPAiJIPyvi3unw4FPK
+        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rAM70bk/nWbG8915q
+        AAGHfra7d/Dg3v7u3oMDQkyHNPT1j1TD7SWaPO97j3buP9rZH+892NvZ2YdEfx3VEAVEkH7WVIPX
+        4e7Dewf7t85ERNnm9koi/jq3ir7fglw3vs+tou/LnN7wOhpF3mbyMkH+f6FCZLXovVTIdE2fkJZd
+        0g98QS4XviDUdFDDDX6kRm4v/ftvdnYe3aO0IK2vfrq/R4aapP82auRWgAjSz5oa8Trce7Czv48I
+        BtBYIjapkQHGub0iGQLA7aIQWtD+FhC4XRSCzOyNANAs8j6TmQnz/3F1Mi2r9Wzbjv7raZS97NOH
+        053pfcJLRxT76kda5H20CAX3uw8e7R6MafYePnxIJp1wgER9A4AI0s+iFrEd7h083Hu4S94PoLEg
+        3EqLGJb5GvrDvsotou+2INPGd7lF9F2Zxw2vokHkTSYnE+D/49riazsf8op++unB5IAy2whQdEhD
+        X/9IZdxe0jkfuPspzPe9e/sPDw5I8AgHCNE3AIgg/aypDK/Dvf3d3YOd22Yyo2xze7URf51bRd9v
+        Qa4b3+dW0fdlTm94HY0ibzN5mSD/H1ch34jDMd3bP7//6cNPCS8dUeyrH2mPWwv9vZ03u/cf7e08
+        2qMcwqfEhwe07kg4QJa+AUAE6WdLe/gd7tzfO7j/8OCW2qPHMrfXHP1XuUX03RZk2vgut4i+K/O4
+        4VU0iLzJ5GQC/H9cWyyyti7e7b2XltB3CAvF333wDWmEj05O3tBne/RdlmUgAOH3/38F8YDWGinP
+        OP70wf0HBzvwCr6mgugDIkg/mwrCdHj/YG9n78HuLRWE8s3t1YJ5gT+PvtGCJJE3+PPoGzJTvRfw
+        caQ9k4kH9jUE//u/5P8BFxl9i4QyAAA=
+    headers:
+      cache-control: [no-cache]
+      content-encoding: [gzip]
+      content-length: ['1961']
+      content-type: [application/json; charset=utf-8]
+      date: ['Thu, 01 Nov 2018 17:17:41 GMT']
+      expires: ['-1']
+      pragma: [no-cache]
+      strict-transport-security: [max-age=31536000; includeSubDomains]
+      vary: [Accept-Encoding]
+      x-content-type-options: [nosniff]
+      x-ms-correlation-request-id: [1907d276-b459-4d4c-a72a-99e16ef70c57]
+      x-ms-original-request-ids: [20bb6f19-24bc-4924-b363-4cf3e6965975, ee188121-e38d-4a7f-8cbe-2f010b29b8a2,
+        9f5166e3-eefd-4e80-ba92-a187d1156c4b]
+      x-ms-ratelimit-remaining-subscription-reads: ['11999']
+      x-ms-request-id: [1907d276-b459-4d4c-a72a-99e16ef70c57]
+      x-ms-routing-request-id: ['WESTUS2:20181101T171741Z:1907d276-b459-4d4c-a72a-99e16ef70c57']
+    status: {code: 200, message: OK}
+- request:
+    body: null
+    headers:
+      Connection: [keep-alive]
+      Content-Length: ['0']
+      User-Agent: [Azure-Storage/1.3.0-1.3.0 (Python CPython 2.7.15; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 17:17:40 GMT']
+      x-ms-version: ['2018-03-28']
+    method: PUT
+    uri: https://cctstoragey6akyqpagdt3o.queue.core.windows.net/testcc
+  response:
+    body: {string: !!python/unicode ''}
+    headers:
+      content-length: ['0']
+      date: ['Thu, 01 Nov 2018 17:17:48 GMT']
+      server: [Windows-Azure-Queue/1.0 Microsoft-HTTPAPI/2.0]
+      x-ms-request-id: [9df62e26-8003-001f-3006-72a378000000]
+      x-ms-version: ['2018-03-28']
+    status: {code: 204, message: No Content}
+version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_storage_client_by_uri.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_storage_client_by_uri.yaml
@@ -5,11 +5,12 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python/3.6.7 (Linux-4.4.0-17134-Microsoft-x86_64-with-debian-buster-sid)
-          msrest/0.6.1 msrest_azure/0.5.0 azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17134-SP0) msrest/0.6.1 msrest_azure/0.5.0
+          azure-mgmt-storage/2.0.0rc4 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01
   response:
     body:
       string: !!binary |
@@ -31,92 +32,63 @@ interactions:
         rj/N3l7/olV2MWvvVYSaDmq4wY+UC/EWft5OJ8AVePhm9/4j/G9/fI/k88GncEfeV7kMAiJIPyvK
         pdvh7v2DBw8+vaVyGeCf2yuXIQDcLgqhBcluAYHbRSHIzN4IAM0i7zOZmTD/P1Iul4v30iv79xe/
         aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv8jrUJMhZ+3UwYw/A/f7O09uvfw0c7e+OGDg539Tx+QMnhf
-        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aBTq
-        4hpaJVut3kureO9lBzvnhJGOpf/F19MjPjl/vqgQmPf9Nzv3H+3tP9rbHe89uH+P5o4k/31VyCAg
-        gvSzokI6He5+uvfwwQPqENBYBDapkA7L3F53dF/k76NvtiDRhjf5++ibMoODL+LryHtMRh64pyZ8
-        liYIP380xMH04S5hpGPpf/EjDfH+gv3po/t7408PDu7vfEqmmnCA1HwDgAjSz7KG4A7vP3i4u3+f
-        vBpAYxG4pYYAy3wtDcEv8vfRN1uQaMOb/H30TZnBwRfxdeQ9JiMP/P/zGmKWtZSkfy/lIK8QDoq9
-        /fvrqYIrordkpH++KALy2Xfuc5rx4NH9h+NPP71PmcYdkt/3VQSDgAjSz4oi6HR4/8HOzv3d2yoC
-        4ZPby7+254+jL7QgSP8F/jj6gkxTtz0+jTRnEvGgPCF3zPr/HRGnLq63s+b9Mpp4id5BQphQ0UGE
-        H/5I3G8npbCevHq5f//R/i4tY+zv3b9H/jXhAFn4EEAKiCD9rIh7B/ODT2nddZ9ypIDGXL9J3D1m
-        ub3M+y/xd9G3WtB44C3+LvqWzFr0JXwVeYfJxgP9/7gKmJbVerY9XZNk0niX76UJ+F376nRv//z+
-        pw8/JeR0WIPf/0g/3F4/7L/Z/RTx9/374wf39w527u+TWH8d/RAFRJB+1vSD1+Gn9x/u3N+7rTsQ
-        55vbq4qB97lZFEALgt0MgJtFAci03vQ+WkVeZxIzUf4/rkveFnVRbi8Iubx+P0ViSEU/8AX5XviC
-        UNNBDTf4kSp5Hw2ws/PoHq0x3hvf+3R/jyw2aYCvp0oigAjSz6IqsR3uPdjZ30coA2gsERtVSZxx
-        3kOXDADgdlEILUh2CwjcLgpBZvZGAGgWeZ/JzIT5/7g6YS36dV0T89Ze9unD6c70PuGlI4p99SMt
-        8j7CT1H+7oNHuwdjmr2HDx9+SsL/9bRIBBBB+lnUIrbDvYOHew93KUICNBaEW2kRwzJfQ3/YV7lF
-        9N0WZNr4LreIvivzuOFVNIi8yeRkAvx/XFt8bedDXtFPPz2YHNAy+QEhpkMa+vpHKuP2ks6JQQoG
-        yHzfu7f/8IAXLb+OyogCIkg/ayrD63Bvf3f3YOe2MUyUbW6vNuKvc6vo+y3IdeP73Cr6vszpDa+j
-        UeRtJi8T5P/jKmSRtXXxbu89tQe/Q1go/u6DH2mI9xHsvR1aQHy092B8b3//3sMHJGeEA+TlGwBE
-        kH4WNYTtcI8WW+/v3DY0UUZ5H50gL/Dn0TdakCTyBn8efUNmqvcCPo60ZzLxwL6GpH//l/w/3Pvw
-        spQ2AAA=
+        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aJRZ
+        1lKA/V4KRV4hHBR7+/fXUxhXpNMkmvx5pCl27nOIcPDo/sPxp5/epyhhhwT8a2iKOCCC9LOlKfwO
+        7z/Y2bm/S6oJ0JjTN2kK4ZPbawZtzx9HX2hBkP4L/HH0BZmmbnt8GmnOJOJBeZLumPX/OyJOXVxv
+        Z837RSN4id5BMEeo6CDCD38k7reTUjjtnHncv/9of5dSEPt79+/tkZS+r7gPAiJIPyvi3unw4FPK
+        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rgGlZrWfb0zVJJo13
+        +V6agN+1r0739s/vf/rwU0JOhzX4/Y/0w+3Fev/N7qeP9vYf3b8/fnB/72DnPq1MEA6Qm28AEEH6
+        WdMPXoef3n+4c3/vtu5AnG9uryoG3udmUQAtCHYzAG4WBSDTetP7aBV5nUnMRPn/uC7hVaPt6Twr
+        lvfeS5EgeaGf7e4dPLi3v7v34IAQ0yENff0jNXJ76aco/t6jnfuPdvbHew/2dnb24R3coEZuD4gg
+        /aypEa/D3Yf3DvZvndWMss3ttUj8dW4Vfb8FuW58n1tF35c5veF1NIq8zeRlgvz/QoXIyvN7qRCr
+        bekHvqDwDV8Qajqo4QY/UiO3VyP7b3Z2Ht2jJYZ743uf7u+R00/S/3XUSBQQQfpZUyNeh3sPdvb3
+        kQ0BNJaITWpkgHFur0iGAHC7KIQWJLsFBG4XhSAzeyMANIu8z2Rmwvx/XJ2wI/Z1oxvz1l726cPp
+        zvQ+4aUjin31Iy3yPsJPicLdB492D8Y0ew8fPiSTTjhAor4BQATpZ1GL2A73Dh7uPdwl7wfQWBBu
+        pUUMy3wN/WFf5RbRd1uQaeO73CL6rszjhlfRIPImk5MJ8P9xbfG1nQ95RT/99GByQKtkCFB0SENf
+        /0hl3F7SeW2B8glkvu/d2394cECCRzhAiL4BQATpZ01leB3u7e/uHuzcNg0SZZvbq43469wq+n4L
+        ct34PreKvi9zesPraBR5m8nLBPn/uAr5RhwOkzAivHREsa9+pD1uLfT3dt7s3n+0t0PZyPHup8SH
+        B/dI6L+G9ogDIkg/W9rD75AyqAf3Hx7cUnv0WOb2mqP/KreIvtuCTBvf5RbRd2UeN7yKBpE3mZxM
+        gP+Pa4tF1tbFu7330hL6DmGh+LsPviGN8NHJyRv6bI++y7IMBCD8/v+vIB48uv+Q8ozjTx/cf3Cw
+        A6/gayqIPiCC9LOpIEyH9w/2dvYe7N5SQSjf3F4tmBf48+gbLUgSeYM/j74hM9V7AR9H2jOZeGBf
+        Q/C//0v+H3lf3ZTQNgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2057']
+      Content-Length: ['2067']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 29 Oct 2018 15:59:16 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:27 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [df50f8e4-1ae7-400b-b8b5-642860ed44ca]
-      x-ms-original-request-ids: [d333e23c-911f-4995-9049-007915d2f549, 4f5e6ff8-eeda-47ea-a5a3-8584c61c2cc1,
-        4713bb67-f572-4cfa-ada3-15f813045ead, ed88e8a2-90d6-4109-8540-4253b136308b]
+      x-ms-correlation-request-id: [3a851f8e-4486-42c0-906e-23cd40a87ea6]
+      x-ms-original-request-ids: [39377458-5bc8-45af-9289-84275f818eba, eaf1ed77-56ff-47df-8367-af6218e14122,
+        06733280-fec1-4e85-b491-d7fbcc88b8b8]
       x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [df50f8e4-1ae7-400b-b8b5-642860ed44ca]
-      x-ms-routing-request-id: ['WESTUS2:20181029T155916Z:df50f8e4-1ae7-400b-b8b5-642860ed44ca']
+      x-ms-request-id: [3a851f8e-4486-42c0-906e-23cd40a87ea6]
+      x-ms-routing-request-id: ['WESTUS2:20181101T151328Z:3a851f8e-4486-42c0-906e-23cd40a87ea6']
     status: {code: 200, message: OK}
-- request:
-    body: null
-    headers:
-      Accept: [application/json]
-      Accept-Encoding: ['gzip, deflate']
-      Connection: [keep-alive]
-      User-Agent: [python/3.6.7 (Linux-4.4.0-17134-Microsoft-x86_64-with-debian-buster-sid)
-          msrest/0.6.1 msrest_azure/0.5.0 networkmanagementclient/2.2.1 Azure-SDK-For-Python]
-    method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Network/locations/eastus/operations/ea42f556-5106-4743-99b0-c129bfa71a47?api-version=2018-06-01
-  response:
-    body: {string: "{\r\n  \"error\": {\r\n    \"message\": \"Operation 273dd4dc-7c0b-4408-a9fa-fd0472050ac0\
-        \ not found.\",\r\n    \"details\": []\r\n  }\r\n}"}
-    headers:
-      Cache-Control: [no-cache]
-      Content-Length: ['119']
-      Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 29 Oct 2018 15:59:19 GMT']
-      Expires: ['-1']
-      Pragma: [no-cache]
-      Server: [Microsoft-HTTPAPI/2.0, Microsoft-HTTPAPI/2.0]
-      Strict-Transport-Security: [max-age=31536000; includeSubDomains]
-      X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [7a3f0d9f-7778-41a8-a676-14d874c374c3]
-      x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [9c4882fa-e349-44cd-8737-92ba753136a1]
-      x-ms-routing-request-id: ['WESTUS2:20181029T155919Z:7a3f0d9f-7778-41a8-a676-14d874c374c3']
-    status: {code: 404, message: Not Found}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.1 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:59:16 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.1 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:26 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.blob.core.windows.net/testcontainer?restype=container
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The\
-        \ specified container already exists.\nRequestId:7b8224a4-701e-0067-7ea0-6fcbcf000000\n\
-        Time:2018-10-29T15:59:21.6034095Z</Message></Error>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:f21357ad-a01e-002a-0ef5-710d2d000000\nTime:2018-11-01T15:13:33.6450228Z</Message></Error>"}
     headers:
       Content-Length: ['230']
       Content-Type: [application/xml]
-      Date: ['Mon, 29 Oct 2018 15:59:21 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:32 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-error-code: [ContainerAlreadyExists]
-      x-ms-request-id: [7b8224a4-701e-0067-7ea0-6fcbcf000000]
+      x-ms-request-id: [f21357ad-a01e-002a-0ef5-710d2d000000]
       x-ms-version: ['2018-03-28']
     status: {code: 409, message: The specified container already exists.}
 version: 1

--- a/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_storage_client_by_uri_extra_directories.yaml
+++ b/tools/c7n_azure/tests/cassettes/StorageUtilsTest.test_get_storage_client_by_uri_extra_directories.yaml
@@ -5,11 +5,12 @@ interactions:
       Accept: [application/json]
       Accept-Encoding: ['gzip, deflate']
       Connection: [keep-alive]
-      User-Agent: [python/3.6.7 (Linux-4.4.0-17134-Microsoft-x86_64-with-debian-buster-sid)
-          msrest/0.6.1 msrest_azure/0.5.0 azure-mgmt-storage/3.0.0 Azure-SDK-For-Python]
+      Content-Type: [application/json; charset=utf-8]
+      User-Agent: [python/3.7.0 (Windows-10-10.0.17134-SP0) msrest/0.6.1 msrest_azure/0.5.0
+          azure-mgmt-storage/2.0.0rc4 Azure-SDK-For-Python]
       accept-language: [en-US]
     method: GET
-    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-07-01
+    uri: https://management.azure.com/subscriptions/ea42f556-5106-4743-99b0-c129bfa71a47/providers/Microsoft.Storage/storageAccounts?api-version=2018-02-01
   response:
     body:
       string: !!binary |
@@ -31,64 +32,63 @@ interactions:
         rj/N3l7/olV2MWvvVYSaDmq4wY+UC/EWft5OJ8AVePhm9/4j/G9/fI/k88GncEfeV7kMAiJIPyvK
         pdvh7v2DBw8+vaVyGeCf2yuXIQDcLgqhBcluAYHbRSHIzN4IAM0i7zOZmTD/P1Iul4v30iv79xe/
         aHqRPVi9ba6KJiuL5frd5YKQ0uEMfv8jrUJMhZ+3UwYw/A/f7O09uvfw0c7e+OGDg539Tx+QMnhf
-        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aBTq
-        4hpaJVut3kureO9lBzvnhJGOpf/F19MjPjl/vqgQmPf9Nzv3H+3tP9rbHe89uH+P5o4k/31VyCAg
-        gvSzokI6He5+uvfwwQPqENBYBDapkA7L3F53dF/k76NvtiDRhjf5++ibMoODL+LryHtMRh64pyZ8
-        liYIP380xMH04S5hpGPpf/EjDfH+gv3po/t7408PDu7vfEqmmnCA1HwDgAjSz7KG4A7vP3i4u3+f
-        vBpAYxG4pYYAy3wtDcEv8vfRN1uQaMOb/H30TZnBwRfxdeQ9JiMP/P/zGmKWtZSkfy/lIK8QDoq9
-        /fvrqYIrordkpH++KALy2Xfuc5rx4NH9h+NPP71PmcYdkt/3VQSDgAjSz4oi6HR4/8HOzv3d2yoC
-        4ZPby7+254+jL7QgSP8F/jj6gkxTtz0+jTRnEvGgPCF3zPr/HRGnLq63s+b9Mpp4id5BQphQ0UGE
-        H/5I3G8npbCevHq5f//R/i4tY+zv3b9H/jXhAFn4EEAKiCD9rIh7B/ODT2nddZ9ypIDGXL9J3D1m
-        ub3M+y/xd9G3WtB44C3+LvqWzFr0JXwVeYfJxgP9/7gKmJbVerY9XZNk0niX76UJ+F376nRv//z+
-        pw8/JeR0WIPf/0g/3F4/7L/Z/RTx9/374wf39w527u+TWH8d/RAFRJB+1vSD1+Gn9x/u3N+7rTsQ
-        55vbq4qB97lZFEALgt0MgJtFAci03vQ+WkVeZxIzUf4/rkveFnVRbi8Iubx+P0ViSEU/8AX5XviC
-        UNNBDTf4kSp5Hw2ws/PoHq0x3hvf+3R/jyw2aYCvp0oigAjSz6IqsR3uPdjZ30coA2gsERtVSZxx
-        3kOXDADgdlEILUh2CwjcLgpBZvZGAGgWeZ/JzIT5/7g6YS36dV0T89Ze9unD6c70PuGlI4p99SMt
-        8j7CT1H+7oNHuwdjmr2HDx9+SsL/9bRIBBBB+lnUIrbDvYOHew93KUICNBaEW2kRwzJfQ3/YV7lF
-        9N0WZNr4LreIvivzuOFVNIi8yeRkAvx/XFt8bedDXtFPPz2YHNAy+QEhpkMa+vpHKuP2ks6JQQoG
-        yHzfu7f/8IAXLb+OyogCIkg/ayrD63Bvf3f3YOe2MUyUbW6vNuKvc6vo+y3IdeP73Cr6vszpDa+j
-        UeRtJi8T5P/jKmSRtXXxbu89tQe/Q1go/u6DH2mI9xHsvR1aQHy092B8b3//3sMHJGeEA+TlGwBE
-        kH4WNYTtcI8WW+/v3DY0UUZ5H50gL/Dn0TdakCTyBn8efUNmqvcCPo60ZzLxwL6GpH//l/w/3Pvw
-        spQ2AAA=
+        rTIIiCD9rGiVTocP9vf39vZu67LE2ef2SmXgfW4WBdCCYDcD4GZRADKtN72PVpHXmcRMlP9/aJRZ
+        1lKA/V4KRV4hHBR7+/fXUxhXpNMkmvx5pCl27nOIcPDo/sPxp5/epyhhhwT8a2iKOCCC9LOlKfwO
+        7z/Y2bm/S6oJ0JjTN2kK4ZPbawZtzx9HX2hBkP4L/HH0BZmmbnt8GmnOJOJBeZLumPX/OyJOXVxv
+        Z837RSN4id5BMEeo6CDCD38k7reTUjjtnHncv/9of5dSEPt79+/tkZS+r7gPAiJIPyvi3unw4FPK
+        me5TfANozPWbxN1jltvLvP8Sfxd9qwVpBt7i76JvyaxFX8JXkXeYbDzQ/4+rgGlZrWfb0zVJJo13
+        +V6agN+1r0739s/vf/rwU0JOhzX4/Y/0w+3Fev/N7qeP9vYf3b8/fnB/72DnPq1MEA6Qm28AEEH6
+        WdMPXoef3n+4c3/vtu5AnG9uryoG3udmUQAtCHYzAG4WBSDTetP7aBV5nUnMRPn/uC7hVaPt6Twr
+        lvfeS5EgeaGf7e4dPLi3v7v34IAQ0yENff0jNXJ76aco/t6jnfuPdvbHew/2dnb24R3coEZuD4gg
+        /aypEa/D3Yf3DvZvndWMss3ttUj8dW4Vfb8FuW58n1tF35c5veF1NIq8zeRlgvz/QoXIyvN7qRCr
+        bekHvqDwDV8Qajqo4QY/UiO3VyP7b3Z2Ht2jJYZ743uf7u+R00/S/3XUSBQQQfpZUyNeh3sPdvb3
+        kQ0BNJaITWpkgHFur0iGAHC7KIQWJLsFBG4XhSAzeyMANIu8z2Rmwvx/XJ2wI/Z1oxvz1l726cPp
+        zvQ+4aUjin31Iy3yPsJPicLdB492D8Y0ew8fPiSTTjhAor4BQATpZ1GL2A73Dh7uPdwl7wfQWBBu
+        pUUMy3wN/WFf5RbRd1uQaeO73CL6rszjhlfRIPImk5MJ8P9xbfG1nQ95RT/99GByQKtkCFB0SENf
+        /0hl3F7SeW2B8glkvu/d2394cECCRzhAiL4BQATpZ01leB3u7e/uHuzcNg0SZZvbq43469wq+n4L
+        ct34PreKvi9zesPraBR5m8nLBPn/uAr5RhwOkzAivHREsa9+pD1uLfT3dt7s3n+0t0PZyPHup8SH
+        B/dI6L+G9ogDIkg/W9rD75AyqAf3Hx7cUnv0WOb2mqP/KreIvtuCTBvf5RbRd2UeN7yKBpE3mZxM
+        gP+Pa4tF1tbFu7330hL6DmGh+LsPviGN8NHJyRv6bI++y7IMBCD8/v+vIB48uv+Q8ozjTx/cf3Cw
+        A6/gayqIPiCC9LOpIEyH9w/2dvYe7N5SQSjf3F4tmBf48+gbLUgSeYM/j74hM9V7AR9H2jOZeGBf
+        Q/C//0v+H3lf3ZTQNgAA
     headers:
       Cache-Control: [no-cache]
       Content-Encoding: [gzip]
-      Content-Length: ['2057']
+      Content-Length: ['2067']
       Content-Type: [application/json; charset=utf-8]
-      Date: ['Mon, 29 Oct 2018 15:59:21 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:33 GMT']
       Expires: ['-1']
       Pragma: [no-cache]
       Strict-Transport-Security: [max-age=31536000; includeSubDomains]
       Vary: [Accept-Encoding]
       X-Content-Type-Options: [nosniff]
-      x-ms-correlation-request-id: [d9ddbd3e-28ee-444a-9b04-8762fb6ae80b]
-      x-ms-original-request-ids: [26d9fcec-9b97-4860-93c2-ca4e2b148bad, b1924a1b-1d6e-47b7-abe3-ce8abb2f5c90,
-        e46d7978-b20d-4249-9537-3294203d09fe, 3a804ab2-a59b-413d-831d-361436c1a05a]
+      x-ms-correlation-request-id: [0085d17b-3bb7-4a84-8dcd-dd212353f58c]
+      x-ms-original-request-ids: [86437dc3-8419-4f46-9a6c-091ca6d46a65, 3abb425e-24ad-4659-994b-71359f2aa24d,
+        fc743472-083b-4444-bd03-02cf445a781c]
       x-ms-ratelimit-remaining-subscription-reads: ['11999']
-      x-ms-request-id: [d9ddbd3e-28ee-444a-9b04-8762fb6ae80b]
-      x-ms-routing-request-id: ['WESTUS2:20181029T155922Z:d9ddbd3e-28ee-444a-9b04-8762fb6ae80b']
+      x-ms-request-id: [0085d17b-3bb7-4a84-8dcd-dd212353f58c]
+      x-ms-routing-request-id: ['WESTUS2:20181101T151334Z:0085d17b-3bb7-4a84-8dcd-dd212353f58c']
     status: {code: 200, message: OK}
 - request:
     body: null
     headers:
       Connection: [keep-alive]
       Content-Length: ['0']
-      User-Agent: [Azure-Storage/1.3.0-1.3.1 (Python CPython 3.6.7; Linux 4.4.0-17134-Microsoft)]
-      x-ms-date: ['Mon, 29 Oct 2018 15:59:22 GMT']
+      User-Agent: [Azure-Storage/1.3.0-1.3.1 (Python CPython 3.7.0; Windows 10)]
+      x-ms-date: ['Thu, 01 Nov 2018 15:13:33 GMT']
       x-ms-version: ['2018-03-28']
     method: PUT
     uri: https://cctstoragey6akyqpagdt3o.blob.core.windows.net/testcontainer?restype=container
   response:
-    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The\
-        \ specified container already exists.\nRequestId:b8102b50-f01e-0039-0da0-6f38cc000000\n\
-        Time:2018-10-29T15:59:23.3861578Z</Message></Error>"}
+    body: {string: "\uFEFF<?xml version=\"1.0\" encoding=\"utf-8\"?><Error><Code>ContainerAlreadyExists</Code><Message>The
+        specified container already exists.\nRequestId:0b38499f-c01e-011c-4ef5-71e62a000000\nTime:2018-11-01T15:13:39.7000280Z</Message></Error>"}
     headers:
       Content-Length: ['230']
       Content-Type: [application/xml]
-      Date: ['Mon, 29 Oct 2018 15:59:22 GMT']
+      Date: ['Thu, 01 Nov 2018 15:13:39 GMT']
       Server: [Windows-Azure-Blob/1.0 Microsoft-HTTPAPI/2.0]
       x-ms-error-code: [ContainerAlreadyExists]
-      x-ms-request-id: [b8102b50-f01e-0039-0da0-6f38cc000000]
+      x-ms-request-id: [0b38499f-c01e-011c-4ef5-71e62a000000]
       x-ms-version: ['2018-03-28']
     status: {code: 409, message: The specified container already exists.}
 version: 1

--- a/tools/c7n_azure/tests/test_azure_events.py
+++ b/tools/c7n_azure/tests/test_azure_events.py
@@ -13,15 +13,17 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from azure.mgmt.eventgrid.models import StorageQueueEventSubscriptionDestination
 from azure_common import BaseTest, arm_template
 from c7n_azure.azure_events import AzureEvents, AzureEventSubscription
-from azure.mgmt.eventgrid.models import StorageQueueEventSubscriptionDestination
+from c7n_azure.session import Session
 from c7n_azure.storage_utils import StorageUtilities
 
 
 class AzureEventsTest(BaseTest):
     def setUp(self):
         super(AzureEventsTest, self).setUp()
+        self.session = Session()
 
     def test_get_returns_event_dict(self):
         event_dic = AzureEvents.get('VmWrite')
@@ -58,7 +60,7 @@ class AzureEventsTest(BaseTest):
     def test_create_azure_event_subscription(self):
         account = self.setup_account()
         queue_name = 'cctestevensub'
-        StorageUtilities.create_queue_from_storage_account(account, queue_name)
+        StorageUtilities.create_queue_from_storage_account(account, queue_name, self.session)
         sub_destination = StorageQueueEventSubscriptionDestination(resource_id=account.id,
                                                                    queue_name=queue_name)
         sub_name = 'custodiantestsubscription'

--- a/tools/c7n_azure/tests/test_event_subscriptions.py
+++ b/tools/c7n_azure/tests/test_event_subscriptions.py
@@ -13,9 +13,10 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from azure.mgmt.eventgrid.models import StorageQueueEventSubscriptionDestination
 from azure_common import BaseTest, arm_template
 from c7n_azure.azure_events import AzureEventSubscription
-from azure.mgmt.eventgrid.models import StorageQueueEventSubscriptionDestination
+from c7n_azure.session import Session
 from c7n_azure.storage_utils import StorageUtilities
 
 
@@ -24,9 +25,10 @@ class AzureEventSubscriptionsTest(BaseTest):
 
     def setUp(self):
         super(AzureEventSubscriptionsTest, self).setUp()
+        self.session = Session()
         account = self.setup_account()
         queue_name = 'cctesteventsub'
-        StorageUtilities.create_queue_from_storage_account(account, queue_name)
+        StorageUtilities.create_queue_from_storage_account(account, queue_name, self.session)
         event_sub_destination = StorageQueueEventSubscriptionDestination(
             resource_id=account.id, queue_name=queue_name)
         AzureEventSubscription.create(event_sub_destination, self.event_sub_name)

--- a/tools/c7n_azure/tests/test_notify.py
+++ b/tools/c7n_azure/tests/test_notify.py
@@ -15,11 +15,13 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 
 from azure_common import BaseTest, arm_template
 from c7n_azure.storage_utils import StorageUtilities
+from c7n_azure.session import Session
 
 
 class NotifyTest(BaseTest):
     def setUp(self):
         super(NotifyTest, self).setUp()
+        self.session = Session()
 
     def test_notify_schema_validate(self):
         with self.sign_out_patch():
@@ -45,7 +47,7 @@ class NotifyTest(BaseTest):
 
         # Create queue, make sure it is empty
         queue_url = "https://" + account.name + ".queue.core.windows.net/testnotify"
-        queue, name = StorageUtilities.get_queue_client_by_uri(queue_url)
+        queue, name = StorageUtilities.get_queue_client_by_uri(queue_url, self.session)
         queue.clear_messages(name)
 
         p = self.load_policy({

--- a/tools/c7n_azure/tests/test_output.py
+++ b/tools/c7n_azure/tests/test_output.py
@@ -91,7 +91,7 @@ class OutputTest(BaseTest):
 
         AzureStorageOutput.get_output_vars = mock.Mock(
             return_value={
-                'account_id': 'account',
+                'account_id': 'MyAccountId',
                 'policy': 'MyPolicy',
                 'now': date(2018, 10, 1)
             })
@@ -99,4 +99,4 @@ class OutputTest(BaseTest):
         output = self.get_azure_output('{account_id}/{policy}/{now:%Y}')
         path = output.get_output_path(output.config['url'])
         self.assertEqual(path,
-                         'azure://mystorage.blob.core.windows.net/logs/account/MyPolicy/2018')
+                         'azure://mystorage.blob.core.windows.net/logs/MyAccountId/MyPolicy/2018')

--- a/tools/c7n_azure/tests/test_output.py
+++ b/tools/c7n_azure/tests/test_output.py
@@ -91,11 +91,12 @@ class OutputTest(BaseTest):
 
         AzureStorageOutput.get_output_vars = mock.Mock(
             return_value={
+                'account_id': 'account',
                 'policy': 'MyPolicy',
                 'now': date(2018, 10, 1)
             })
 
-        output = self.get_azure_output('{policy}/{now:%Y}')
+        output = self.get_azure_output('{account_id}/{policy}/{now:%Y}')
         path = output.get_output_path(output.config['url'])
         self.assertEqual(path,
-                         'azure://mystorage.blob.core.windows.net/logs/MyPolicy/2018')
+                         'azure://mystorage.blob.core.windows.net/logs/account/MyPolicy/2018')

--- a/tools/c7n_azure/tests/test_session.py
+++ b/tools/c7n_azure/tests/test_session.py
@@ -122,3 +122,8 @@ class SessionTest(BaseTest):
         resource = next(client.resources.list())
         self.assertTrue(re.match('\\d{4}-\\d{2}-\\d{2}',
                                  s.resource_api_version(resource.id)) is not None)
+
+    def test_get_session_for_resource(self):
+        s = Session()
+        resource_session = s.get_session_for_resource(constants.RESOURCE_STORAGE)
+        self.assertEqual(resource_session.resource_namespace, constants.RESOURCE_STORAGE)

--- a/tools/c7n_azure/tests/test_storageutils.py
+++ b/tools/c7n_azure/tests/test_storageutils.py
@@ -16,6 +16,7 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from azure_common import BaseTest, arm_template
 from c7n_azure.storage_utils import StorageUtilities
 from c7n_azure.session import Session
+from c7n_azure.constants import RESOURCE_STORAGE
 
 
 class StorageUtilsTest(BaseTest):
@@ -52,6 +53,17 @@ class StorageUtilsTest(BaseTest):
         queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(url, self.session)
         self.assertIsNotNone(queue_service)
         self.assertEqual(queue_name, "testcc")
+
+    @arm_template('storage.json')
+    def test_get_queue_client_by_uri_auth_file(self):
+        file_session = self.get_auth_file_session(self.session, RESOURCE_STORAGE)
+        account = self.setup_account()
+        url = "https://" + account.name + ".queue.core.windows.net/testcc"
+        queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(url, file_session)
+        self.assertIsNotNone(queue_service)
+        self.assertEqual(queue_name, "testcc")
+
+
 
     @arm_template('storage.json')
     def test_create_queue_from_storage_account(self):

--- a/tools/c7n_azure/tests/test_storageutils.py
+++ b/tools/c7n_azure/tests/test_storageutils.py
@@ -16,7 +16,6 @@ from __future__ import absolute_import, division, print_function, unicode_litera
 from azure_common import BaseTest, arm_template
 from c7n_azure.storage_utils import StorageUtilities
 from c7n_azure.session import Session
-from c7n_azure.constants import RESOURCE_STORAGE
 
 
 class StorageUtilsTest(BaseTest):
@@ -53,17 +52,6 @@ class StorageUtilsTest(BaseTest):
         queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(url, self.session)
         self.assertIsNotNone(queue_service)
         self.assertEqual(queue_name, "testcc")
-
-    @arm_template('storage.json')
-    def test_get_queue_client_by_uri_auth_file(self):
-        file_session = self.get_auth_file_session(self.session, RESOURCE_STORAGE)
-        account = self.setup_account()
-        url = "https://" + account.name + ".queue.core.windows.net/testcc"
-        queue_service, queue_name = StorageUtilities.get_queue_client_by_uri(url, file_session)
-        self.assertIsNotNone(queue_service)
-        self.assertEqual(queue_name, "testcc")
-
-
 
     @arm_template('storage.json')
     def test_create_queue_from_storage_account(self):

--- a/tools/c7n_mailer/c7n_mailer/azure/azure_queue_processor.py
+++ b/tools/c7n_mailer/c7n_mailer/azure/azure_queue_processor.py
@@ -25,8 +25,10 @@ from c7n_mailer.azure.sendgrid_delivery import SendGridDelivery
 
 try:
     from c7n_azure.storage_utils import StorageUtilities
+    from c7n_azure.session import Session
 except ImportError:
     StorageUtilities = None
+    Session = None
     pass
 
 
@@ -42,7 +44,7 @@ class MailerAzureQueueProcessor(object):
         self.receive_queue = self.config['queue_url']
         self.batch_size = 16
         self.max_message_retry = 3
-        self.session = session
+        self.session = session or Session()
 
     def run(self, parallel=False):
         if parallel:


### PR DESCRIPTION
Getting rid of this stuff where we take a session optionally, too much room for mistakes.  We always take one, and if it doesn't fit our audience we deal with that automatically.

Sessions now know how to mutate themselves to new audiences so we do that automatically in storage_utils.

Also fixing handler to properly initialize the Azure provider.