### PR TITLE
Resolve email delivery based off tags

### DIFF
--- a/tools/c7n_mailer/c7n_mailer/utils_email.py
+++ b/tools/c7n_mailer/c7n_mailer/utils_email.py
@@ -5,9 +5,9 @@ logger = logging.getLogger('c7n_mailer.utils.email')
 
 
 def is_email(target):
-    if target.startswith('slack://'):
-        logger.debug("Slack payload, not an email.")
-        return False
+  #  if target.startswith('slack://'):
+  #      logger.debug("Slack payload, not an email.")
+  #      return False
     if parseaddr(target)[1] and '@' in target and '.' in target:
         return True
     else:


### PR DESCRIPTION
Commenting out slack check in is_email function which resolved email delivery based off of tags.

policy that works with this commented out: 

```
  policies:
  - name: azure-notify
    resource: azure.resourcegroup
    description: example policy
    actions:
      - type: notify
        template: default
        priority_header: '2'
        subject: hello from the mailer
        to:
          - tag:OwnerContact
        transport:
          type: asq
          queue: https://myblob.queue.core.windows.net/taskqueue
```