### PR TITLE
Fix policy name variable expansion (rename to policy_name)

### DIFF
--- a/c7n/output.py
+++ b/c7n/output.py
@@ -414,7 +414,7 @@ class DirectoryOutput(object):
         data = {
             'account_id': self.ctx.options.account_id,
             'region': self.ctx.options.region,
-            'policy': self.ctx.policy.name,
+            'policy_name': self.ctx.policy.name,
             'now': datetime.utcnow(),
             'uuid': str(uuid.uuid4())}
         return data

--- a/docs/source/azure/advanced/bloboutput.rst
+++ b/docs/source/azure/advanced/bloboutput.rst
@@ -20,7 +20,7 @@ This example is the same structure as the default one.
 
     .. code-block:: sh
 
-        custodian run -s azure://mystorage.blob.core.windows.net/logs/{policy}/{now:%Y/%m/%d/%H/} mypolicy.yml
+        custodian run -s azure://mystorage.blob.core.windows.net/logs/{policy_name}/{now:%Y/%m/%d/%H/} mypolicy.yml
 
 Use `{account_id}` for Subscription ID.
 

--- a/tools/c7n_azure/c7n_azure/output.py
+++ b/tools/c7n_azure/c7n_azure/output.py
@@ -39,7 +39,7 @@ class AzureStorageOutput(DirectoryOutput):
 
     """
 
-    DEFAULT_BLOB_FOLDER_PREFIX = '{policy}/{now:%Y/%m/%d/%H/}'
+    DEFAULT_BLOB_FOLDER_PREFIX = '{policy_name}/{now:%Y/%m/%d/%H/}'
 
     def __init__(self, ctx, config=None):
         self.ctx = ctx

--- a/tools/c7n_azure/tests/test_output.py
+++ b/tools/c7n_azure/tests/test_output.py
@@ -76,7 +76,7 @@ class OutputTest(BaseTest):
 
         AzureStorageOutput.get_output_vars = mock.Mock(
             return_value={
-                'policy': 'MyPolicy',
+                'policy_name': 'MyPolicy',
                 'now': date(2018, 10, 1)
             })
 

--- a/tools/c7n_azure/tests/test_output.py
+++ b/tools/c7n_azure/tests/test_output.py
@@ -95,7 +95,7 @@ class OutputTest(BaseTest):
                 'now': date(2018, 10, 1)
             })
 
-        output = self.get_azure_output('{policy}/{now:%Y}')
+        output = self.get_azure_output('{policy_name}/{now:%Y}')
         path = output.get_output_path(output.config['url'])
         self.assertEqual(path,
                          'azure://mystorage.blob.core.windows.net/logs/MyPolicy/2018')

--- a/tools/c7n_azure/tests/test_output.py
+++ b/tools/c7n_azure/tests/test_output.py
@@ -92,7 +92,7 @@ class OutputTest(BaseTest):
         AzureStorageOutput.get_output_vars = mock.Mock(
             return_value={
                 'account_id': 'MyAccountId',
-                'policy': 'MyPolicy',
+                'policy_name': 'MyPolicy',
                 'now': date(2018, 10, 1)
             })
 


### PR DESCRIPTION
`{policy}` is expanded both as the full Policy during policy load and as policy.name when parsing the blob output paths.

It was working fine if you only used {policy} in output paths in the command line, but if you include it in your execution options then really terrible things happen :) 

I think we just need to rename it to `{policy_name}`.  Should resolve the issue for all clouds.

Resolves #3091 