### PR TITLE
azure - block cassette recording during testing

### DIFF
--- a/tools/c7n_azure/tests/azure_common.py
+++ b/tools/c7n_azure/tests/azure_common.py
@@ -55,6 +55,11 @@ class AzureVCRBaseTest(VCRTestCase):
         myvcr = super(VCRTestCase, self)._get_vcr(**kwargs)
         myvcr.register_matcher('azurematcher', self.azure_matcher)
         myvcr.match_on = ['azurematcher']
+
+        # Block recording when using fake token (tox runs)
+        if os.environ.get(constants.ENV_ACCESS_TOKEN) == "fake_token":
+            myvcr.record_mode = 'none'
+
         return myvcr
 
     def azure_matcher(self, r1, r2):


### PR DESCRIPTION
This prevents live http requests during tests.  If a build was failing before this fix, it will keep failing after this fix - but at least you won't get files written to disk.

Also the error messages are a little better in the build logs - since they won't contain the error from the failed live request as well.