### PR TITLE
aws set-flow-logs support s3 destinations

### DIFF
--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1750,11 +1750,6 @@ class CreateFlowLogs(BaseAction):
     schema = {
         'type': 'object',
         'additionalProperties': False,
-        'required': ['DeliverLogsPermissionArn'],
-        'oneOf': [
-            {'required': ['LogGroupName']},
-            {'required': ['LogDestination']}
-        ],
         'properties': {
             'type': {'enum': ['set-flow-log']},
             'state': {'type': 'boolean'},
@@ -1778,10 +1773,17 @@ class CreateFlowLogs(BaseAction):
     def validate(self):
         self.state = self.data.get('state', True)
         if self.state:
+            if not self.data.get('DeliverLogsPermissionArn'):
+                raise PolicyValidationError(
+                    'DeliverLogsPermissionArn required when '
+                    'creating flow-logs on %s' % (self.manager.data,))
+            if (not self.data.get('LogGroupName') and not self.data.get('LogDestination')):
+                raise PolicyValidationError(
+                    'LoggroupName or LogDestination required')
             if (self.data.get('LogDestinationType') == 's3' and
                not self.data.get('LogDestination')):
                 raise PolicyValidationError(
-                        'LogDestination required when LogDestinationType is s3')
+                    'LogDestination required when LogDestinationType is s3')
         return self
 
     def delete_flow_logs(self, client, rids):

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -1779,7 +1779,7 @@ class CreateFlowLogs(BaseAction):
                     'creating flow-logs on %s' % (self.manager.data,))
             if (not self.data.get('LogGroupName') and not self.data.get('LogDestination')):
                 raise PolicyValidationError(
-                    'LoggroupName or LogDestination required')
+                    'Either LogGroupName or LogDestination required')
             if (self.data.get('LogDestinationType') == 's3' and
                not self.data.get('LogDestination')):
                 raise PolicyValidationError(

--- a/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DeleteFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DeleteFlowLogs_1.json
@@ -4,13 +4,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "47fb1ff8-4465-41b5-b4b7-692ae78fa909", 
+            "RequestId": "02421146-64c6-4fe9-84c2-df5466098dde", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
-                "vary": "Accept-Encoding", 
-                "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Mon, 16 Apr 2018 14:37:27 GMT"
+                "vary": "Accept-Encoding", 
+                "date": "Fri, 02 Nov 2018 21:48:53 GMT", 
+                "server": "AmazonEC2"
             }
         }, 
         "Unsuccessful": []

--- a/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeFlowLogs_1.json
@@ -3,34 +3,36 @@
     "data": {
         "FlowLogs": [
             {
-                "ResourceId": "vpc-7af45101", 
+                "LogDestinationType": "s3", 
+                "ResourceId": "vpc-d2d616b5", 
                 "CreationTime": {
-                    "hour": 16, 
+                    "hour": 21, 
                     "__class__": "datetime", 
-                    "month": 4, 
-                    "second": 46, 
-                    "microsecond": 20000, 
+                    "month": 11, 
+                    "second": 21, 
+                    "microsecond": 961000, 
                     "year": 2018, 
-                    "day": 6, 
-                    "minute": 51
+                    "day": 2, 
+                    "minute": 48
                 }, 
-                "LogGroupName": "/custodian/vpc_logs/", 
                 "TrafficType": "ALL", 
                 "FlowLogStatus": "ACTIVE", 
-                "FlowLogId": "fl-f076b299", 
-                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+                "FlowLogId": "fl-061d3f3b816da485e", 
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role", 
+                "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs/test.log.gz", 
+                "DeliverLogsStatus": "SUCCESS"
             }
         ], 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "e9849fcc-0a7d-48ab-a585-04ce816ad2c9", 
+            "RequestId": "02a8d9a9-edf5-4cf6-9788-17cf853078f5", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
-                "vary": "Accept-Encoding", 
-                "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Mon, 16 Apr 2018 14:37:27 GMT"
+                "vary": "Accept-Encoding", 
+                "date": "Fri, 02 Nov 2018 21:48:53 GMT", 
+                "server": "AmazonEC2"
             }
         }
     }

--- a/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeFlowLogs_2.json
+++ b/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeFlowLogs_2.json
@@ -3,34 +3,36 @@
     "data": {
         "FlowLogs": [
             {
-                "ResourceId": "vpc-7af45101", 
+                "LogDestinationType": "s3", 
+                "ResourceId": "vpc-d2d616b5", 
                 "CreationTime": {
-                    "hour": 16, 
+                    "hour": 21, 
                     "__class__": "datetime", 
-                    "month": 4, 
-                    "second": 46, 
-                    "microsecond": 20000, 
+                    "month": 11, 
+                    "second": 21, 
+                    "microsecond": 961000, 
                     "year": 2018, 
-                    "day": 6, 
-                    "minute": 51
+                    "day": 2, 
+                    "minute": 48
                 }, 
-                "LogGroupName": "/custodian/vpc_logs/", 
                 "TrafficType": "ALL", 
                 "FlowLogStatus": "ACTIVE", 
-                "FlowLogId": "fl-f076b299", 
-                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/flowlogsRole"
+                "FlowLogId": "fl-061d3f3b816da485e", 
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role", 
+                "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs/test.log.gz", 
+                "DeliverLogsStatus": "SUCCESS"
             }
         ], 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "ff2f3bb7-24cc-4ad5-89fd-d85929576017", 
+            "RequestId": "698a589a-d3c0-4b56-b5d4-16825eb1b962", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
-                "vary": "Accept-Encoding", 
-                "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Mon, 16 Apr 2018 14:37:27 GMT"
+                "vary": "Accept-Encoding", 
+                "date": "Fri, 02 Nov 2018 21:48:53 GMT", 
+                "server": "AmazonEC2"
             }
         }
     }

--- a/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeFlowLogs_3.json
+++ b/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeFlowLogs_3.json
@@ -5,13 +5,13 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "87d06b12-1bec-47d0-bd50-596f42eeaf54", 
+            "RequestId": "230dcccf-86a9-4459-afc2-f455a09d2c9a", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
-                "vary": "Accept-Encoding", 
-                "server": "AmazonEC2", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Mon, 16 Apr 2018 14:37:27 GMT"
+                "vary": "Accept-Encoding", 
+                "date": "Fri, 02 Nov 2018 21:48:53 GMT", 
+                "server": "AmazonEC2"
             }
         }
     }

--- a/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_delete_flow_logs/ec2.DescribeVpcs_1.json
@@ -30,26 +30,58 @@
                 "IsDefault": false
             }, 
             {
-                "VpcId": "vpc-7af45101", 
+                "VpcId": "vpc-f8c6d983", 
                 "InstanceTenancy": "default", 
                 "Tags": [
                     {
-                        "Value": "FlowLogTest", 
+                        "Value": "IpV6", 
                         "Key": "Name"
                     }
                 ], 
                 "CidrBlockAssociationSet": [
                     {
-                        "AssociationId": "vpc-cidr-assoc-7c1eb811", 
-                        "CidrBlock": "10.0.16.0/24", 
+                        "AssociationId": "vpc-cidr-assoc-c9ff12a5", 
+                        "CidrBlock": "10.0.0.0/16", 
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ], 
+                "Ipv6CidrBlockAssociationSet": [
+                    {
+                        "Ipv6CidrBlock": "2600:1f18:2466:4b00::/56", 
+                        "AssociationId": "vpc-cidr-assoc-caff12a6", 
+                        "Ipv6CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ], 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-24ff1940", 
+                "CidrBlock": "10.0.0.0/16", 
+                "IsDefault": false
+            }, 
+            {
+                "VpcId": "vpc-03005fb9b8740263d", 
+                "InstanceTenancy": "default", 
+                "Tags": [
+                    {
+                        "Value": "testing-vpc", 
+                        "Key": "Name"
+                    }
+                ], 
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0f6765530d80dc044", 
+                        "CidrBlock": "10.205.0.0/18", 
                         "CidrBlockState": {
                             "State": "associated"
                         }
                     }
                 ], 
                 "State": "available", 
-                "DhcpOptionsId": "dopt-4d4c3035", 
-                "CidrBlock": "10.0.16.0/24", 
+                "DhcpOptionsId": "dopt-24ff1940", 
+                "CidrBlock": "10.205.0.0/18", 
                 "IsDefault": false
             }, 
             {
@@ -57,7 +89,7 @@
                 "InstanceTenancy": "default", 
                 "Tags": [
                     {
-                        "Value": "Default", 
+                        "Value": "FlowLogTest", 
                         "Key": "Name"
                     }
                 ], 
@@ -74,76 +106,18 @@
                 "DhcpOptionsId": "dopt-24ff1940", 
                 "CidrBlock": "172.31.0.0/16", 
                 "IsDefault": true
-            }, 
-            {
-                "VpcId": "vpc-e274f499", 
-                "InstanceTenancy": "default", 
-                "Tags": [
-                    {
-                        "Value": "JunkVPC", 
-                        "Key": "Name"
-                    }
-                ], 
-                "CidrBlockAssociationSet": [
-                    {
-                        "AssociationId": "vpc-cidr-assoc-a96ee0c4", 
-                        "CidrBlock": "10.0.64.0/24", 
-                        "CidrBlockState": {
-                            "State": "associated"
-                        }
-                    }
-                ], 
-                "State": "available", 
-                "DhcpOptionsId": "dopt-24ff1940", 
-                "CidrBlock": "10.0.64.0/24", 
-                "IsDefault": false
-            }, 
-            {
-                "VpcId": "vpc-d2447eaa", 
-                "InstanceTenancy": "default", 
-                "Tags": [
-                    {
-                        "Value": "EC2ContainerService-Default", 
-                        "Key": "aws:cloudformation:stack-name"
-                    }, 
-                    {
-                        "Value": "Containers", 
-                        "Key": "Name"
-                    }, 
-                    {
-                        "Value": "Vpc", 
-                        "Key": "aws:cloudformation:logical-id"
-                    }, 
-                    {
-                        "Value": "arn:aws:cloudformation:us-east-1:644160558196:stack/EC2ContainerService-Default/84d2eff0-f917-11e7-b441-50d5ca632656", 
-                        "Key": "aws:cloudformation:stack-id"
-                    }
-                ], 
-                "CidrBlockAssociationSet": [
-                    {
-                        "AssociationId": "vpc-cidr-assoc-a7aa90cd", 
-                        "CidrBlock": "10.0.0.0/16", 
-                        "CidrBlockState": {
-                            "State": "associated"
-                        }
-                    }
-                ], 
-                "State": "available", 
-                "DhcpOptionsId": "dopt-24ff1940", 
-                "CidrBlock": "10.0.0.0/16", 
-                "IsDefault": false
             }
         ], 
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "b8dcd905-3abb-45ae-96f1-e4d16b4d41dc", 
+            "RequestId": "163d16db-040b-4ef9-bb7e-f29285bd63f1", 
             "HTTPHeaders": {
-                "transfer-encoding": "chunked", 
-                "vary": "Accept-Encoding", 
-                "server": "AmazonEC2", 
+                "date": "Fri, 02 Nov 2018 21:48:53 GMT", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "date": "Mon, 16 Apr 2018 14:37:27 GMT"
+                "content-length": "4418", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2"
             }
         }
     }

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.CreateFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.CreateFlowLogs_1.json
@@ -5,17 +5,17 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "18dae9e0-76f7-4cb0-9a98-606857b4f370", 
+            "RequestId": "33afe06e-de8e-4e07-803c-7435f5cbd000", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "content-type": "text/xml;charset=UTF-8", 
                 "vary": "Accept-Encoding", 
-                "date": "Fri, 02 Nov 2018 19:35:49 GMT", 
+                "date": "Fri, 02 Nov 2018 21:48:21 GMT", 
                 "server": "AmazonEC2"
             }
         }, 
         "FlowLogIds": [
-            "fl-04028fd3a164dea49"
+            "fl-061d3f3b816da485e"
         ], 
         "ClientToken": "LeufVjrP/fkZbjxFlNUErFlijDZf1A89z4aCjHIqCxM="
     }

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.CreateFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.CreateFlowLogs_1.json
@@ -1,0 +1,22 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Unsuccessful": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "18dae9e0-76f7-4cb0-9a98-606857b4f370", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "vary": "Accept-Encoding", 
+                "date": "Fri, 02 Nov 2018 19:35:49 GMT", 
+                "server": "AmazonEC2"
+            }
+        }, 
+        "FlowLogIds": [
+            "fl-04028fd3a164dea49"
+        ], 
+        "ClientToken": "LeufVjrP/fkZbjxFlNUErFlijDZf1A89z4aCjHIqCxM="
+    }
+}

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_1.json
@@ -1,0 +1,18 @@
+{
+    "status_code": 200, 
+    "data": {
+        "FlowLogs": [], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "dfdb9039-cf1c-45ea-9d4f-b72bb9f55a9b", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "vary": "Accept-Encoding", 
+                "date": "Fri, 02 Nov 2018 19:35:48 GMT", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_1.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_1.json
@@ -5,12 +5,12 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "dfdb9039-cf1c-45ea-9d4f-b72bb9f55a9b", 
+            "RequestId": "bad4f4f1-afa6-48d1-ac78-2970a939d998", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "content-type": "text/xml;charset=UTF-8", 
                 "vary": "Accept-Encoding", 
-                "date": "Fri, 02 Nov 2018 19:35:48 GMT", 
+                "date": "Fri, 02 Nov 2018 21:48:21 GMT", 
                 "server": "AmazonEC2"
             }
         }

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_2.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_2.json
@@ -6,18 +6,18 @@
                 "LogDestinationType": "s3", 
                 "ResourceId": "vpc-d2d616b5", 
                 "CreationTime": {
-                    "hour": 19, 
+                    "hour": 21, 
                     "__class__": "datetime", 
                     "month": 11, 
-                    "second": 50, 
-                    "microsecond": 244000, 
+                    "second": 21, 
+                    "microsecond": 961000, 
                     "year": 2018, 
                     "day": 2, 
-                    "minute": 35
+                    "minute": 48
                 }, 
                 "TrafficType": "ALL", 
                 "FlowLogStatus": "ACTIVE", 
-                "FlowLogId": "fl-04028fd3a164dea49", 
+                "FlowLogId": "fl-061d3f3b816da485e", 
                 "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role", 
                 "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs/test.log.gz", 
                 "DeliverLogsStatus": "SUCCESS"
@@ -26,12 +26,12 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "927c7e03-8568-45ba-b7c5-85c441392201", 
+            "RequestId": "8b3a9439-620d-440b-8b4a-3634460f9684", 
             "HTTPHeaders": {
                 "transfer-encoding": "chunked", 
                 "content-type": "text/xml;charset=UTF-8", 
                 "vary": "Accept-Encoding", 
-                "date": "Fri, 02 Nov 2018 19:35:49 GMT", 
+                "date": "Fri, 02 Nov 2018 21:48:21 GMT", 
                 "server": "AmazonEC2"
             }
         }

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_2.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeFlowLogs_2.json
@@ -1,0 +1,39 @@
+{
+    "status_code": 200, 
+    "data": {
+        "FlowLogs": [
+            {
+                "LogDestinationType": "s3", 
+                "ResourceId": "vpc-d2d616b5", 
+                "CreationTime": {
+                    "hour": 19, 
+                    "__class__": "datetime", 
+                    "month": 11, 
+                    "second": 50, 
+                    "microsecond": 244000, 
+                    "year": 2018, 
+                    "day": 2, 
+                    "minute": 35
+                }, 
+                "TrafficType": "ALL", 
+                "FlowLogStatus": "ACTIVE", 
+                "FlowLogId": "fl-04028fd3a164dea49", 
+                "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role", 
+                "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs/test.log.gz", 
+                "DeliverLogsStatus": "SUCCESS"
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "927c7e03-8568-45ba-b7c5-85c441392201", 
+            "HTTPHeaders": {
+                "transfer-encoding": "chunked", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "vary": "Accept-Encoding", 
+                "date": "Fri, 02 Nov 2018 19:35:49 GMT", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeVpcs_1.json
@@ -1,0 +1,124 @@
+{
+    "status_code": 200, 
+    "data": {
+        "Vpcs": [
+            {
+                "VpcId": "vpc-f1516b97", 
+                "InstanceTenancy": "default", 
+                "Tags": [
+                    {
+                        "Value": "FancyTestVPC", 
+                        "Key": "Name"
+                    }, 
+                    {
+                        "Value": "tagfanncyvalue", 
+                        "Key": "tagfancykey"
+                    }
+                ], 
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-98ba93f0", 
+                        "CidrBlock": "10.0.42.0/24", 
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ], 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-24ff1940", 
+                "CidrBlock": "10.0.42.0/24", 
+                "IsDefault": false
+            }, 
+            {
+                "VpcId": "vpc-f8c6d983", 
+                "InstanceTenancy": "default", 
+                "Tags": [
+                    {
+                        "Value": "IpV6", 
+                        "Key": "Name"
+                    }
+                ], 
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-c9ff12a5", 
+                        "CidrBlock": "10.0.0.0/16", 
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ], 
+                "Ipv6CidrBlockAssociationSet": [
+                    {
+                        "Ipv6CidrBlock": "2600:1f18:2466:4b00::/56", 
+                        "AssociationId": "vpc-cidr-assoc-caff12a6", 
+                        "Ipv6CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ], 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-24ff1940", 
+                "CidrBlock": "10.0.0.0/16", 
+                "IsDefault": false
+            }, 
+            {
+                "VpcId": "vpc-03005fb9b8740263d", 
+                "InstanceTenancy": "default", 
+                "Tags": [
+                    {
+                        "Value": "testing-vpc", 
+                        "Key": "Name"
+                    }
+                ], 
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-0f6765530d80dc044", 
+                        "CidrBlock": "10.205.0.0/18", 
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ], 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-24ff1940", 
+                "CidrBlock": "10.205.0.0/18", 
+                "IsDefault": false
+            }, 
+            {
+                "VpcId": "vpc-d2d616b5", 
+                "InstanceTenancy": "default", 
+                "Tags": [
+                    {
+                        "Value": "FlowLog", 
+                        "Key": "Name"
+                    }
+                ], 
+                "CidrBlockAssociationSet": [
+                    {
+                        "AssociationId": "vpc-cidr-assoc-33669f5a", 
+                        "CidrBlock": "172.31.0.0/16", 
+                        "CidrBlockState": {
+                            "State": "associated"
+                        }
+                    }
+                ], 
+                "State": "available", 
+                "DhcpOptionsId": "dopt-24ff1940", 
+                "CidrBlock": "172.31.0.0/16", 
+                "IsDefault": true
+            }
+        ], 
+        "ResponseMetadata": {
+            "RetryAttempts": 0, 
+            "HTTPStatusCode": 200, 
+            "RequestId": "c197913b-fd9c-49b9-bf9c-4209c0c22b4c", 
+            "HTTPHeaders": {
+                "date": "Fri, 02 Nov 2018 19:35:48 GMT", 
+                "content-type": "text/xml;charset=UTF-8", 
+                "content-length": "4414", 
+                "vary": "Accept-Encoding", 
+                "server": "AmazonEC2"
+            }
+        }
+    }
+}

--- a/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeVpcs_1.json
+++ b/tests/data/placebo/test_vpc_set_flow_logs_s3/ec2.DescribeVpcs_1.json
@@ -89,7 +89,7 @@
                 "InstanceTenancy": "default", 
                 "Tags": [
                     {
-                        "Value": "FlowLog", 
+                        "Value": "FlowLogTest", 
                         "Key": "Name"
                     }
                 ], 
@@ -111,11 +111,11 @@
         "ResponseMetadata": {
             "RetryAttempts": 0, 
             "HTTPStatusCode": 200, 
-            "RequestId": "c197913b-fd9c-49b9-bf9c-4209c0c22b4c", 
+            "RequestId": "94ac021a-47d5-440d-8c38-4096ad2b4868", 
             "HTTPHeaders": {
-                "date": "Fri, 02 Nov 2018 19:35:48 GMT", 
+                "date": "Fri, 02 Nov 2018 21:48:20 GMT", 
                 "content-type": "text/xml;charset=UTF-8", 
-                "content-length": "4414", 
+                "content-length": "4418", 
                 "vary": "Accept-Encoding", 
                 "server": "AmazonEC2"
             }

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -2255,20 +2255,21 @@ class FlowLogsTest(BaseTest):
         self.assertEqual(logs[0]["ResourceId"], resources[0]["VpcId"])
 
     def test_vpc_set_flow_logs_s3(self):
-        session_factory = self.record_flight_data("test_vpc_set_flow_logs_s3")
+        session_factory = self.replay_flight_data("test_vpc_set_flow_logs_s3")
         p = self.load_policy(
             {
                 "name": "c7n-vpc-flow-logs-s3",
                 "resource": "vpc",
                 "filters": [
-                    {"tag:Name": "FlowLog"}, {"type": "flow-logs", "enabled": False}
+                    {"tag:Name": "FlowLogTest"}, {"type": "flow-logs", "enabled": False}
                 ],
                 "actions": [
                     {
-                        "type": "set-flow-log", 
-                        "LogDestinationType": "s3", 
-                        "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs/test.log.gz", 
-                        "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role",
+                        "type": "set-flow-log",
+                        "LogDestinationType": "s3",
+                        "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs/test.log.gz",
+                        "DeliverLogsPermissionArn":
+                            "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role",
                     }
                 ],
             },
@@ -2290,17 +2291,28 @@ class FlowLogsTest(BaseTest):
         p = self.load_policy(
             {
                 "name": "c7n-delete-vpc-flow-logs",
-                "resource": "vpc",
+                "resource": "aws.vpc",
                 "filters": [
-                    {"tag:Name": "FlowLogTest"}, {"type": "flow-logs", "enabled": True}
+                    {
+                        "tag:Name": "FlowLogTest"
+                    },
+                    {
+                        "type": "flow-logs",
+                        "enabled": True
+                    }
                 ],
-                "actions": [{"type": "set-flow-log", "state": False}],
+                "actions": [
+                    {
+                        "type": "set-flow-log",
+                        "state": False,
+                    }
+                ]
             },
             session_factory=session_factory,
         )
         resources = p.run()
         self.assertEqual(len(resources), 1)
-        self.assertEqual(resources[0]["VpcId"], "vpc-7af45101")
+        self.assertEqual(resources[0]["VpcId"], "vpc-d2d616b5")
         client = session_factory(region="us-east-1").client("ec2")
         logs = client.describe_flow_logs(
             Filters=[{"Name": "resource-id", "Values": [resources[0]["VpcId"]]}]

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -2285,7 +2285,6 @@ class FlowLogsTest(BaseTest):
         ]
         self.assertEqual(logs[0]["ResourceId"], resources[0]["VpcId"])
 
-
     def test_vpc_delete_flow_logs(self):
         session_factory = self.replay_flight_data("test_vpc_delete_flow_logs")
         p = self.load_policy(

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -2254,6 +2254,38 @@ class FlowLogsTest(BaseTest):
         ]
         self.assertEqual(logs[0]["ResourceId"], resources[0]["VpcId"])
 
+    def test_vpc_set_flow_logs_s3(self):
+        session_factory = self.record_flight_data("test_vpc_set_flow_logs_s3")
+        p = self.load_policy(
+            {
+                "name": "c7n-vpc-flow-logs-s3",
+                "resource": "vpc",
+                "filters": [
+                    {"tag:Name": "FlowLog"}, {"type": "flow-logs", "enabled": False}
+                ],
+                "actions": [
+                    {
+                        "type": "set-flow-log", 
+                        "LogDestinationType": "s3", 
+                        "LogDestination": "arn:aws:s3:::c7n-vpc-flow-logs/test.log.gz", 
+                        "DeliverLogsPermissionArn": "arn:aws:iam::644160558196:role/testing-vpc-flow-log-role",
+                    }
+                ],
+            },
+            session_factory=session_factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        self.assertEqual(resources[0]["VpcId"], "vpc-d2d616b5")
+        client = session_factory(region="us-east-1").client("ec2")
+        logs = client.describe_flow_logs(
+            Filters=[{"Name": "resource-id", "Values": [resources[0]["VpcId"]]}]
+        )[
+            "FlowLogs"
+        ]
+        # self.assertEqual(logs[0]["ResourceId"], resources[0]["VpcId"])
+
+
     def test_vpc_delete_flow_logs(self):
         session_factory = self.replay_flight_data("test_vpc_delete_flow_logs")
         p = self.load_policy(

--- a/tests/test_vpc.py
+++ b/tests/test_vpc.py
@@ -2283,7 +2283,7 @@ class FlowLogsTest(BaseTest):
         )[
             "FlowLogs"
         ]
-        # self.assertEqual(logs[0]["ResourceId"], resources[0]["VpcId"])
+        self.assertEqual(logs[0]["ResourceId"], resources[0]["VpcId"])
 
 
     def test_vpc_delete_flow_logs(self):


### PR DESCRIPTION
New options in the set-flow-logs action to allow sending to S3. Schema is updated to require LogDestination, if LogDestinationType is S3. Defaults to cloud-watch-logs