### PR TITLE
skip writing api-stats.json as redundant

### DIFF
--- a/c7n/resources/aws.py
+++ b/c7n/resources/aws.py
@@ -299,8 +299,6 @@ class ApiStats(DeltaStats):
             self.ctx.session_factory.set_subscribers(())
         self.ctx.metrics.put_metric(
             "ApiCalls", sum(self.api_calls.values()), "Count")
-        self.ctx.policy._write_file(
-            'api-stats.json', utils.dumps(dict(self.api_calls)))
         self.pop_snapshot()
 
     def __call__(self, s):


### PR DESCRIPTION
since the api call information is also in metadata.json