### PR TITLE
Correcting DynamoDB backup delete example and warning message

### DIFF
--- a/c7n/resources/dynamodb.py
+++ b/c7n/resources/dynamodb.py
@@ -396,9 +396,11 @@ class DeleteBackup(BaseAction, StatusFilter):
               - name: dynamodb-delete-backup
                 resource: dynamodb-backup
                 filters:
-                  - type: age
-                    days: 28
-                    op: ge
+                  - type: value
+                    key: BackupCreationDateTime
+                    op: greater-than
+                    value_type: age
+                    value: 28
                 actions:
                   - type: delete
     """
@@ -426,7 +428,7 @@ class DeleteBackup(BaseAction, StatusFilter):
                     BackupArn=t['BackupArn'])
             except ClientError as e:
                 if e.response['Error']['Code'] == 'ResourceNotFoundException':
-                    self.log.warning("Could not complete DynamoDB backup table:%s", t)
+                    self.log.warning("Could not complete DynamoDB backup deletion for table:%s", t)
                     continue
                 raise
 


### PR DESCRIPTION
These are just a couple small changes that will hopefully prevent others some confusion. The example for dynamodb-backup delete showed age filters but they are not supported. Additionally, the warning message wasn't clear that it was the backup delete failing (not the actual backup process).

I signed the individual contributor agreement.

Thanks!