### PR TITLE
tools/omnissm - sanitize tags, handle missing resource on deferred action

### DIFF
--- a/tools/omnissm/pkg/aws/ssm/ssm.go
+++ b/tools/omnissm/pkg/aws/ssm/ssm.go
@@ -77,7 +77,14 @@ type ResourceTags struct {
 func (s *SSM) AddTagsToResource(ctx context.Context, input *ResourceTags) error {
 	awsTags := make([]*ssm.Tag, 0)
 	for k, v := range input.Tags {
+		v = SanitizeTag(v)
+		if v == "" {
+			continue
+		}
 		awsTags = append(awsTags, &ssm.Tag{Key: aws.String(k), Value: aws.String(v)})
+	}
+	if len(awsTags) == 0 {
+		return nil
 	}
 	s.ssmRate.Wait(ctx)
 	_, err := s.SSMAPI.AddTagsToResourceWithContext(ctx, &ssm.AddTagsToResourceInput{

--- a/tools/omnissm/pkg/aws/ssm/utils.go
+++ b/tools/omnissm/pkg/aws/ssm/utils.go
@@ -14,10 +14,25 @@
 
 package ssm
 
-import "strings"
+import (
+	"regexp"
+	"strings"
+)
 
 // IsManagedInstance tests whether the provided EC2 instance identifier is
 // managed.
 func IsManagedInstance(s string) bool {
 	return strings.HasPrefix(s, "mi-")
+}
+
+// original Java regexp for a valid tag: ^([\p{L}\p{Z}\p{N}_.:/=+\-@]*)$
+var invalidTagRegexp = regexp.MustCompile(`[^a-zA-Z0-9\s_.:/=+\-@]`)
+
+func SanitizeTag(t string) string {
+	// special case of key: value# comment is this
+	if i := strings.Index(t, "#"); i != -1 {
+		t = t[:i]
+	}
+	t = strings.TrimSpace(t)
+	return invalidTagRegexp.ReplaceAllString(t, "")
 }

--- a/tools/omnissm/pkg/aws/ssm/utils_test.go
+++ b/tools/omnissm/pkg/aws/ssm/utils_test.go
@@ -1,0 +1,30 @@
+package ssm_test
+
+import (
+	"testing"
+
+	"github.com/capitalone/cloud-custodian/tools/omnissm/pkg/aws/ssm"
+)
+
+func TestSanitizeTag(t *testing.T) {
+	cases := []struct {
+		in, out string
+	}{
+		{"Normal Tag", "Normal Tag"},
+		{"TAG_with-Numbers123", "TAG_with-Numbers123"},
+		{"  extra space ", "extra space"},
+		{"user@emailhost.com", "user@emailhost.com"},
+		{" tag%^wit*h &invalid chars", "tagwith invalid chars"},
+		{"ótag with unicodé", "tag with unicod"},
+		{"value#comment here", "value"},
+		{"value# comment here", "value"},
+		{"Math is ok: 1+1=2", "Math is ok: 1+1=2"},
+	}
+
+	for _, c := range cases {
+		s := ssm.SanitizeTag(c.in)
+		if s != c.out {
+			t.Errorf("Tag sanitization failed. Got '%s' expected '%s'", s, c.out)
+		}
+	}
+}


### PR DESCRIPTION
Sanitize tags added during the enrichment process to conform with (stricter) validation performed by the SSM service. Also handle the case where a deferred action is executed for an instance that has already been deregistered (warn rather than error).