### PR TITLE
aws - correct default cloudwatch metric namespace for emr

### DIFF
--- a/c7n/filters/metrics.py
+++ b/c7n/filters/metrics.py
@@ -90,7 +90,7 @@ class MetricsFilter(Filter):
         'ec2': 'AWS/EC2',
         'elb': 'AWS/ELB',
         'elbv2': 'AWS/ApplicationELB',
-        'emr': 'AWS/EMR',
+        'emr': 'AWS/ElasticMapReduce',
         'es': 'AWS/ES',
         'events': 'AWS/Events',
         'firehose': 'AWS/Firehose',


### PR DESCRIPTION
The Default namespace for EMR Cloudwatch metrics is incorrect in filters/metrics.py

```
# ditto for spot fleet DEFAULT_NAMESPACE = { 'cloudfront': 'AWS/CloudFront', 'cloudsearch': 'AWS/CloudSearch', 'dynamodb': 'AWS/DynamoDB', 'ecs': 'AWS/ECS', 'elasticache': 'AWS/ElastiCache', 'ec2': 'AWS/EC2', 'elb': 'AWS/ELB', 'elbv2': 'AWS/ApplicationELB', 'emr': 'AWS/EMR', 'es': 'AWS/ES', 'events': 'AWS/Events', 'firehose': 'AWS/Firehose', 'kinesis': 'AWS/Kinesis', 'lambda': 'AWS/Lambda', 'logs': 'AWS/Logs', 'redshift': 'AWS/Redshift', 'rds': 'AWS/RDS', 'route53': 'AWS/Route53', 's3': 'AWS/S3', 'sns': 'AWS/SNS', 'sqs': 'AWS/SQS', }

```
emr should be mapped to 'AWS/ElasticMapReduce' rather than 'AWS/EMR'

See
https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/aws-services-cloudwatch-metrics.html