### PR TITLE
always log to blob storage irrespective of -l usage

### DIFF
--- a/tools/c7n_gcp/c7n_gcp/client.py
+++ b/tools/c7n_gcp/c7n_gcp/client.py
@@ -222,7 +222,7 @@ class Session(object):
             version,
             kw.get('developer_key'),
             kw.get('cache_discovery', False),
-            self._http)
+            self._http or _build_http())
 
         return ServiceClient(
             gcp_service=service,


### PR DESCRIPTION
to ensure log collection to cloud blob storage in addition to explicit cloud native log targets.