### PR TITLE
Add CloudHSM Clusters (CloudHSMv2) as a resource

### DIFF
--- a/c7n/resources/hsm.py
+++ b/c7n/resources/hsm.py
@@ -13,8 +13,108 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+import functools
+
 from c7n.manager import resources
 from c7n.query import QueryResourceManager
+from c7n.tags import (RemoveTag, Tag, universal_augment)
+from c7n.utils import generate_arn, local_session
+
+
+@resources.register('cloudhsm-cluster')
+class CloudHSMCluster(QueryResourceManager):
+
+    class resource_type(object):
+        service = 'cloudhsmv2'
+        type = 'cluster'
+        resource_type = 'cloudhsm'
+        enum_spec = ('describe_clusters', 'Clusters', None)
+        id = name = 'ClusterId'
+        filter_name = 'Filters'
+        filter_type = 'scalar'
+        dimension = None
+        # universal_taggable = True
+        # Note: resourcegroupstaggingapi still points to hsm-classic
+
+    augment = universal_augment
+    _generate_arn = None
+
+    @property
+    def generate_arn(self):
+        if self._generate_arn is None:
+            self._generate_arn = functools.partial(
+                generate_arn,
+                'cloudhsm',
+                region=self.config.region,
+                account_id=self.account_id,
+                resource_type='cluster',
+                separator='/')
+        return self._generate_arn
+
+
+def tag_function(session_factory, clusters, tags, log):
+    client = local_session(session_factory).client('cloudhsmv2')
+    for c in clusters:
+        id = c['ClusterId']
+        try:
+            client.tag_resource(ResourceId=id, TagList=tags)
+        except Exception as err:
+            log.exception(
+                'Exception tagging cloudhsm cluster %s: %s',
+                c['ClusterId'], err)
+            continue
+
+
+@CloudHSMCluster.action_registry.register('tag')
+class Tag(Tag):
+    """Action to add tag(s) to CloudHSM Cluster(s)
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: cloudhsm
+                resource: aws.cloudhsm-cluster
+                filters:
+                  - "tag:OwnerName": missing
+                actions:
+                  - type: tag
+                    key: OwnerName
+                    value: OwnerName
+    """
+
+    permissions = ('cloudhsmv2:TagResource',)
+
+    def process_resource_set(self, clusters, tags):
+        tag_function(self.manager.session_factory, clusters, tags, self.log)
+
+
+@CloudHSMCluster.action_registry.register('remove-tag')
+class RemoveTag(RemoveTag):
+    """Action to remove tag(s) from CloudHSM Cluster(s)
+
+    :example:
+
+    .. code-block:: yaml
+
+            policies:
+              - name: cloudhsm
+                resource: aws.cloudhsm-cluster
+                filters:
+                  - "tag:OldTagKey": present
+                actions:
+                  - type: remove-tag
+                    tags: [OldTagKey1, OldTagKey2]
+    """
+
+    permissions = ('cloudhsmv2:UntagResource',)
+
+    def process_resource_set(self, clusters, tag_keys):
+        client = local_session(self.manager.session_factory).client('cloudhsmv2')
+        for c in clusters:
+            id = c['ClusterId']
+            client.untag_resource(ResourceId=id, TagKeyList=tag_keys)
 
 
 @resources.register('hsm')

--- a/tests/data/placebo/test_cloudhsm/cloudhsmv2.DescribeClusters_1.json
+++ b/tests/data/placebo/test_cloudhsm/cloudhsmv2.DescribeClusters_1.json
@@ -1,0 +1,60 @@
+{
+    "status_code": 200,
+    "data": {
+        "Clusters": [
+            {
+                "BackupPolicy": "DEFAULT",
+                "ClusterId": "cluster-rhuxbiveqa2",
+                "CreateTimestamp": {
+                    "__class__": "datetime",
+                    "year": 2018,
+                    "month": 8,
+                    "day": 27,
+                    "hour": 16,
+                    "minute": 48,
+                    "second": 30,
+                    "microsecond": 149000
+                },
+                "Hsms": [
+                    {
+                        "AvailabilityZone": "us-east-1d",
+                        "ClusterId": "cluster-rhuxbiveqa2",
+                        "SubnetId": "subnet-e3985acd",
+                        "EniId": "eni-0f7dd690d0f5393da",
+                        "EniIp": "172.31.93.196",
+                        "HsmId": "hsm-mp3i7obxqdb",
+                        "State": "ACTIVE",
+                        "StateMessage": "HSM created."
+                    }
+                ],
+                "HsmType": "hsm1.medium",
+                "SecurityGroup": "sg-0e05677ea7fbd12fd",
+                "State": "ACTIVE",
+                "SubnetMapping": {
+                    "us-east-1a": "subnet-0955c143",
+                    "us-east-1b": "subnet-8e6baad2",
+                    "us-east-1c": "subnet-7a50991d",
+                    "us-east-1d": "subnet-e3985acd",
+                    "us-east-1e": "subnet-806178bf",
+                    "us-east-1f": "subnet-0d168102"
+                },
+                "VpcId": "vpc-02320879",
+                "Certificates": {
+                    "ClusterCertificate": "-----BEGIN CERTIFICATE-----HelloThere-----END CERTIFICATE-----\n"
+                }
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "8bcd4803-e928-11e8-8883-f7796c9f5a01",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 15 Nov 2018 22:48:18 GMT",
+                "x-amzn-requestid": "8bcd4803-e928-11e8-8883-f7796c9f5a01",
+                "content-length": "2017",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_cloudhsm/cloudhsmv2.ListTags_1.json
+++ b/tests/data/placebo/test_cloudhsm/cloudhsmv2.ListTags_1.json
@@ -1,0 +1,23 @@
+{
+    "status_code": 200,
+    "data": {
+        "TagList": [
+            {
+                "Key": "foo",
+                "Value": "bar"
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "8beb7ee1-e928-11e8-9429-d17d579772dc",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "content-type": "application/x-amz-json-1.1",
+                "date": "Thu, 15 Nov 2018 22:48:19 GMT",
+                "x-amzn-requestid": "8beb7ee1-e928-11e8-9429-d17d579772dc",
+                "content-length": "41",
+                "connection": "keep-alive"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/data/placebo/test_cloudhsm/tagging.GetResources_1.json
+++ b/tests/data/placebo/test_cloudhsm/tagging.GetResources_1.json
@@ -1,0 +1,37 @@
+{
+    "status_code": 200,
+    "data": {
+        "PaginationToken": "",
+        "ResourceTagMappingList": [
+            {
+                "ResourceARN": "arn:aws:cloudhsm:us-east-1:12345:cluster/cluster-rhuxbiveqa2",
+                "Tags": [
+                    {
+                        "Key": "foo",
+                        "Value": "bar"
+                    }
+                ]
+            },
+            {
+                "ResourceARN": "arn:aws:cloudhsm:us-east-1:12345:hsm/hsm-mp3i7obxqdb",
+                "Tags": [
+                    {
+                        "Key": "foo",
+                        "Value": "bar"
+                    }
+                ]
+            }
+        ],
+        "ResponseMetadata": {
+            "RequestId": "8bdd9ba5-e928-11e8-baff-67d5e7c0e945",
+            "HTTPStatusCode": 200,
+            "HTTPHeaders": {
+                "x-amzn-requestid": "8bdd9ba5-e928-11e8-baff-67d5e7c0e945",
+                "content-type": "application/x-amz-json-1.1",
+                "content-length": "287",
+                "date": "Thu, 15 Nov 2018 22:48:18 GMT"
+            },
+            "RetryAttempts": 0
+        }
+    }
+}

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -20,5 +20,4 @@ class CloudHSMClusterTest(BaseTest):
         id = resources[0]["ClusterId"]
         tags = client.list_tags(ResourceId=id)
         tag_map = {t["Key"]: t["Value"] for t in tags["TagList"]}
-        print(tag_map)
         self.assertTrue("foo" in tag_map)

--- a/tests/test_hsm.py
+++ b/tests/test_hsm.py
@@ -1,0 +1,24 @@
+from __future__ import absolute_import, division, print_function, unicode_literals
+
+from .common import BaseTest
+
+
+class CloudHSMClusterTest(BaseTest):
+
+    def test_cloudhsm(self):
+        factory = self.replay_flight_data("test_cloudhsm")
+        client = factory().client("cloudhsmv2")
+        p = self.load_policy(
+            {
+                "name": "cloudhsm",
+                "resource": "cloudhsm-cluster",
+            },
+            session_factory=factory,
+        )
+        resources = p.run()
+        self.assertEqual(len(resources), 1)
+        id = resources[0]["ClusterId"]
+        tags = client.list_tags(ResourceId=id)
+        tag_map = {t["Key"]: t["Value"] for t in tags["TagList"]}
+        print(tag_map)
+        self.assertTrue("foo" in tag_map)


### PR DESCRIPTION
This commit adds CloudHSM Clusters as a resource.
Tag-based actions and filters are registered but no other actions yet as they can be costly or detrimental.