### PR TITLE
fix c7n-mailer-replay, broken after #3017

### DIFF
--- a/tools/c7n_mailer/README.md
+++ b/tools/c7n_mailer/README.md
@@ -509,7 +509,7 @@ the message file to be base64-encoded, gzipped JSON, just like c7n sends to SQS.
 * With no additional arguments, it will render the template specified by the policy the
   message is for, and actually send mail from the local machine as ``c7n-mailer`` would.
   This only works with SES, not SMTP.
-* With the ``-t`` | ``--template-print`` argument, it will log the email addresses that would
+* With the ``-T`` | ``--template-print`` argument, it will log the email addresses that would
   receive mail, and print the rendered message body template to STDOUT.
 * With the ``-d`` | ``--dry-run`` argument, it will print the actual email body (including headers)
   that would be sent, for each message that would be sent, to STDOUT.

--- a/tools/c7n_mailer/c7n_mailer/replay.py
+++ b/tools/c7n_mailer/c7n_mailer/replay.py
@@ -58,12 +58,12 @@ class MailerTester(object):
                 self.data, self.data['resources'], ['foo@example.com']
             )
             logger.info('Send mail with subject: "%s"', mime['Subject'])
-            print(mime.get_payload())
+            print(mime.get_payload(None, True))
             return
         if dry_run:
             for to_addrs, mimetext_msg in addrs_to_msgs.items():
-                print('-> SEND MESSAGE TO: %s' % to_addrs)
-                print(mimetext_msg)
+                print('-> SEND MESSAGE TO: %s' % '; '.join(to_addrs))
+                print(mimetext_msg.get_payload(None, True))
             return
         # else actually send the message...
         for to_addrs, mimetext_msg in addrs_to_msgs.items():

--- a/tools/c7n_mailer/c7n_mailer/replay.py
+++ b/tools/c7n_mailer/c7n_mailer/replay.py
@@ -77,9 +77,11 @@ def setup_parser():
     parser.add_argument('-d', '--dry-run', dest='dry_run', action='store_true',
                         default=False,
                         help='Log messages that would be sent, but do not send')
-    parser.add_argument('-t', '--template-print', dest='print_only',
+    parser.add_argument('-T', '--template-print', dest='print_only',
                         action='store_true', default=False,
                         help='Just print rendered templates')
+    parser.add_argument('-t', '--templates', default=None, type=str,
+                        help='message templates folder location')
     parser.add_argument('-p', '--plain', dest='plain', action='store_true',
                         default=False,
                         help='Expect MESSAGE_FILE to be a plain string, '
@@ -104,6 +106,18 @@ def main():
     parser = setup_parser()
     options = parser.parse_args()
 
+    module_dir = os.path.dirname(os.path.abspath(__file__))
+    default_templates = [
+        os.path.abspath(os.path.join(module_dir, 'msg-templates')),
+        os.path.abspath(os.path.join(module_dir, '..', 'msg-templates')),
+        os.path.abspath('.')
+    ]
+    templates = options.templates
+    if templates:
+        default_templates.append(
+            os.path.abspath(os.path.expanduser(os.path.expandvars(templates)))
+        )
+
     log_format = '%(asctime)s - %(name)s - %(levelname)s - %(message)s'
     logging.basicConfig(level=logging.DEBUG, format=log_format)
     logging.getLogger('botocore').setLevel(logging.WARNING)
@@ -113,6 +127,7 @@ def main():
 
     jsonschema.validate(config, CONFIG_SCHEMA)
     setup_defaults(config)
+    config['templates_folders'] = default_templates
 
     tester = MailerTester(
         options.MESSAGE_FILE, config, msg_plain=options.plain,


### PR DESCRIPTION
The `c7n-mailer-replay` command was broken by #3017 which added support for custom template directories via a new CLI option on `c7n-mailer`, but didn't replicate that option for replay. This fixes that issue so that c7n-mailer-replay works again. This also decodes the message payload before printing it, since EmailDelivery was switched to utf8 encoding after replay was written.

Before:

```
$ c7n-mailer-replay -c mailer.yml -t -j message.json message.txt
2018-11-16 11:14:39,935 - c7n_mailer.replay - DEBUG - Reading message from: message.txt
2018-11-16 11:14:39,935 - c7n_mailer.replay - DEBUG - Read 1881 byte message
2018-11-16 11:14:39,935 - c7n_mailer.replay - DEBUG - base64-decoding and zlib decompressing message
2018-11-16 11:14:39,936 - c7n_mailer.replay - DEBUG - Loaded message JSON
Traceback (most recent call last):
  File "/home/jantman/GIT/cloud-custodian/bin/c7n-mailer-replay", line 11, in <module>
    load_entry_point('c7n-mailer', 'console_scripts', 'c7n-mailer-replay')()
  File "/home/jantman/GIT/cloud-custodian/tools/c7n_mailer/c7n_mailer/replay.py", line 121, in main
    tester.run(options.dry_run, options.print_only)
  File "/home/jantman/GIT/cloud-custodian/tools/c7n_mailer/c7n_mailer/replay.py", line 54, in run
    addrs_to_msgs = emd.get_to_addrs_email_messages_map(self.data)
  File "/home/jantman/GIT/cloud-custodian/tools/c7n_mailer/c7n_mailer/email_delivery.py", line 245, in get_to_addrs_email_messages_map
    list(to_addrs)
  File "/home/jantman/GIT/cloud-custodian/tools/c7n_mailer/c7n_mailer/email_delivery.py", line 267, in get_mimetext_message
    'template', 'default', self.config['templates_folders'])
KeyError: 'templates_folders'
```

After:
```
$ c7n-mailer-replay -c mailer.yml -T -t cais_c7n/mailer-templates -j message.json message.txt 
2018-11-16 11:20:03,936 - c7n_mailer.replay - DEBUG - Reading message from: message.txt
2018-11-16 11:20:03,937 - c7n_mailer.replay - DEBUG - Read 1881 byte message
2018-11-16 11:20:03,937 - c7n_mailer.replay - DEBUG - base64-decoding and zlib decompressing message
2018-11-16 11:20:03,937 - c7n_mailer.replay - DEBUG - Loaded message JSON
2018-11-16 11:20:04,082 - c7n_mailer.replay - INFO - Would send email to: [(u'foo@example.com', u'bar@example.com')]
2018-11-16 11:20:04,155 - c7n_mailer.replay - INFO - Send mail with subject: "[cloud-custodian] Orphaned cloud-custodian CW Event rules in us-east-1"
<!DOCTYPE html>
<html lang="en">
...
```