### PR TITLE
aws - lambda policy better handling of assume_role/metrics_enabled in exec options

### DIFF
--- a/c7n/handler.py
+++ b/c7n/handler.py
@@ -45,9 +45,6 @@ if 'AWS_EXECUTION_ENV' in os.environ:
 def dispatch_event(event, context):
 
     global account_id
-    if account_id is None:
-        session = boto3.Session()
-        account_id = get_account_id_from_sts(session)
 
     error = event.get('detail', {}).get('errorCode')
     if error:
@@ -58,7 +55,7 @@ def dispatch_event(event, context):
     if event['debug']:
         log.info("Processing event\n %s", format_event(event))
 
-    # policies file should always be valid in lambda so do loading naively
+    # Policies file should always be valid in lambda so do loading naively
     with open('config.json') as f:
         policy_config = json.load(f)
 
@@ -80,7 +77,24 @@ def dispatch_event(event, context):
     # TODO. This enshrines an assumption of a single policy per lambda.
     options_overrides = policy_config[
         'policies'][0].get('mode', {}).get('execution-options', {})
+
+    # if using assume role in lambda ensure that the correct
+    # execution account is captured in options.
+    if 'assume_role' in options_overrides:
+        account_id = options_overrides['assume_role'].split(':')[4]
+    elif account_id is None:
+        session = boto3.Session()
+        account_id = get_account_id_from_sts(session)
+
+    # Historical compatibility with manually set execution options
+    # previously this was a boolean, its now a string value with the
+    # boolean flag triggering a string value of 'aws'
+    if 'metrics_enabled' in options_overrides and isinstance(
+            options_overrides['metrics_enabled'], bool):
+        options_overrides['metrics_enabled'] = 'aws'
+
     options_overrides['account_id'] = account_id
+
     if 'output_dir' not in options_overrides:
         options_overrides['output_dir'] = output_dir
     options = Config.empty(**options_overrides)


### PR DESCRIPTION

with the output refactoring metrics configuration is actually a string to allow specifying provider, but historical usage was a boolean, update usage for metrics_enabled: True to switch to `aws`.

when using assume_role in execution options for a lambda, the account id stored was that of the lambda's role instead of that of the assumed role, this didn't affect execution account target, but may have confused on reporting/notify.