### PR TITLE
aws - api stats and user agent better handling across policies

### DIFF
--- a/c7n/credentials.py
+++ b/c7n/credentials.py
@@ -55,6 +55,9 @@ class SessionFactory(object):
             session = Session(
                 region_name=region or self.region, profile_name=self.profile)
 
+        return self.update(session)
+
+    def update(self, session):
         session._session.user_agent_name = self.user_agent_name
         session._session.user_agent_version = version
 

--- a/c7n/ctx.py
+++ b/c7n/ctx.py
@@ -26,7 +26,7 @@ from c7n.output import (
     sys_stats_outputs,
     tracer_outputs)
 
-from c7n.utils import reset_session_cache, dumps
+from c7n.utils import reset_session_cache, dumps, local_session
 from c7n.version import version
 
 
@@ -90,6 +90,12 @@ class ExecutionContext(object):
 
         self.api_stats.__enter__()
         self.tracer.__enter__()
+
+        # Api stats and user agent modification by policy require updating
+        # in place the cached session thread local.
+        update_session = getattr(self.session_factory, 'update', None)
+        if update_session:
+            self.session_factory.update(local_session(self.session_factory))
         return self
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):

--- a/c7n/ctx.py
+++ b/c7n/ctx.py
@@ -95,7 +95,7 @@ class ExecutionContext(object):
         # in place the cached session thread local.
         update_session = getattr(self.session_factory, 'update', None)
         if update_session:
-            self.session_factory.update(local_session(self.session_factory))
+            update_session(local_session(self.session_factory))
         return self
 
     def __exit__(self, exc_type=None, exc_value=None, exc_traceback=None):

--- a/c7n/resources/s3.py
+++ b/c7n/resources/s3.py
@@ -57,7 +57,11 @@ from botocore.exceptions import ClientError
 from collections import defaultdict
 from concurrent.futures import as_completed
 from dateutil.parser import parse as parse_date
-from urllib3.exceptions import SSLError
+try:
+    from urllib3.exceptions import SSLError
+except ImportError:
+    from botocore.vendored.requests.packages.urllib3.exceptions import SSLError
+
 
 from c7n.actions import (
     ActionRegistry, BaseAction, PutMetric, RemovePolicyBase)

--- a/tests/test_credentials.py
+++ b/tests/test_credentials.py
@@ -17,6 +17,7 @@ from botocore.exceptions import ClientError
 
 from c7n.credentials import SessionFactory, assumed_session
 from c7n.version import version
+from c7n.utils import local_session
 
 from .common import BaseTest
 
@@ -58,3 +59,16 @@ class Credential(BaseTest):
                 "CloudCustodian(test-policy-name-ua)/%s" % version
             )
         )
+
+    def test_local_session_agent_update(self):
+        factory = SessionFactory('us-east-1')
+        factory.policy_name = "check-ebs"
+        client = local_session(factory).client('ec2')
+        self.assertTrue(
+            'check-ebs' in client._client_config.user_agent)
+
+        factory.policy_name = "check-ec2"
+        factory.update(local_session(factory))
+        client = local_session(factory).client('ec2')
+        self.assertTrue(
+            'check-ec2' in client._client_config.user_agent)


### PR DESCRIPTION

ie. update thread local session cache not just session factory between policy runs.