### PR TITLE
azure - add event advance filtering for event grid subscription

### DIFF
--- a/tools/c7n_azure/c7n_azure/azure_events.py
+++ b/tools/c7n_azure/c7n_azure/azure_events.py
@@ -145,8 +145,9 @@ class AzureEvents(object):
 
 class AzureEventSubscription(object):
 
-    @classmethod
-    def create(cls, destination, name, session=None, event_filter=None):
+    @staticmethod
+    def create(destination, name, session=None, event_filter=None):
+
         s = session or local_session(Session)
         event_filter = event_filter or EventSubscriptionFilter()
 

--- a/tools/c7n_azure/tests/test_policy.py
+++ b/tools/c7n_azure/tests/test_policy.py
@@ -17,10 +17,7 @@ from azure_common import BaseTest
 from c7n_azure.azure_events import AzureEvents
 from c7n_azure.constants import FUNCTION_EVENT_TRIGGER_MODE, FUNCTION_TIME_TRIGGER_MODE
 from c7n_azure.policy import AzureEventGridMode, AzureFunctionMode
-from c7n_azure.session import Session
 from mock import mock
-
-from c7n.utils import local_session
 
 
 # Mock of Azure StorageAccount class
@@ -244,11 +241,12 @@ class AzurePolicyModeTest(BaseTest):
             'resource': 'azure.vm',
             'mode':
                 {'type': FUNCTION_EVENT_TRIGGER_MODE,
-                 'events': ['VmWrite',
-                            {
-                                'resourceProvider': 'Microsoft.Resources/subscriptions/resourceGroups',
-                                'event': 'write'
-                            }]},
+                 'events':
+                     ['VmWrite',
+                        {
+                            'resourceProvider': 'Microsoft.Resources/subscriptions/resourceGroups',
+                            'event': 'write'
+                        }]},
         })
 
         with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
@@ -261,6 +259,7 @@ class AzurePolicyModeTest(BaseTest):
             # verify the advanced filter created
             event_filter = args[3].advanced_filters[0]
             self.assertEqual(event_filter.key, 'Data.OperationName')
-            self.assertEqual(event_filter.values, ['Microsoft.Compute/virtualMachines/write',
-                                                   'Microsoft.Resources/subscriptions/resourceGroups/write'])
+            self.assertEqual(event_filter.values,
+                             ['Microsoft.Compute/virtualMachines/write',
+                              'Microsoft.Resources/subscriptions/resourceGroups/write'])
             self.assertEqual(event_filter.operator_type, 'StringIn')

--- a/tools/c7n_azure/tests/test_policy.py
+++ b/tools/c7n_azure/tests/test_policy.py
@@ -13,10 +13,15 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from collections import namedtuple
+
 from azure_common import BaseTest
 from c7n_azure.azure_events import AzureEvents
 from c7n_azure.constants import FUNCTION_EVENT_TRIGGER_MODE, FUNCTION_TIME_TRIGGER_MODE
 from c7n_azure.policy import AzureEventGridMode, AzureFunctionMode
+from c7n_azure.session import Session
+from c7n_azure.storage_utils import StorageUtilities
+from mock import patch, mock
 
 
 class AzurePolicyModeTest(BaseTest):
@@ -132,7 +137,6 @@ class AzurePolicyModeTest(BaseTest):
         self.assertTrue(params.function_app_name.startswith('test-azure-serverless-mode-'))
 
     def test_init_azure_function_mode_with_resource_ids(self):
-
         ai_id = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups' \
                 '/testrg/providers/microsoft.insights/components/testai'
         sp_id = '/subscriptions/00000000-0000-0000-0000-000000000000/resourceGroups' \
@@ -207,3 +211,56 @@ class AzurePolicyModeTest(BaseTest):
         }
         event_mode = AzureEventGridMode(p)
         self.assertFalse(event_mode._is_subscribed_to_event(event, subscribed_events))
+
+    def test_event_grid_mode_creates_advanced_filtered_subscription(self):
+        p = self.load_policy({
+            'name': 'test-azure-event',
+            'resource': 'azure.vm',
+            'mode':
+                {'type': FUNCTION_EVENT_TRIGGER_MODE,
+                 'events': ['VmWrite']},
+        })
+
+        Account = namedtuple('mockStorage', ['id'])
+        account = Account(id=1)
+
+        with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
+            event_mode = AzureEventGridMode(p)
+            event_mode._create_event_subscription(account, 'some_queue', None)
+
+            name, args, kwargs = mock_create.mock_calls[0]
+
+            # verify the advanced filter created
+            event_filter = args[3].advanced_filters[0]
+            self.assertEqual(event_filter.key, 'Data.OperationName')
+            self.assertEqual(event_filter.values, ['Microsoft.Compute/virtualMachines/write'])
+            self.assertEqual(event_filter.operator_type, 'StringIn')
+
+    def test_event_grid_mode_creates_advanced_filtered_subscription_with_multiple_events(self):
+        p = self.load_policy({
+            'name': 'test-azure-event',
+            'resource': 'azure.vm',
+            'mode':
+                {'type': FUNCTION_EVENT_TRIGGER_MODE,
+                 'events': ['VmWrite',
+                            {
+                                'resourceProvider': 'Microsoft.Resources/subscriptions/resourceGroups',
+                                'event': 'write'
+                            }]},
+        })
+
+        Account = namedtuple('mockStorage', ['id'])
+        account = Account(id=1)
+
+        with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
+            event_mode = AzureEventGridMode(p)
+            event_mode._create_event_subscription(account, 'some_queue', None)
+
+            name, args, kwargs = mock_create.mock_calls[0]
+
+            # verify the advanced filter created
+            event_filter = args[3].advanced_filters[0]
+            self.assertEqual(event_filter.key, 'Data.OperationName')
+            self.assertEqual(event_filter.values, ['Microsoft.Compute/virtualMachines/write',
+                                                   'Microsoft.Resources/subscriptions/resourceGroups/write'])
+            self.assertEqual(event_filter.operator_type, 'StringIn')

--- a/tools/c7n_azure/tests/test_policy.py
+++ b/tools/c7n_azure/tests/test_policy.py
@@ -23,6 +23,11 @@ from mock import mock
 from c7n.utils import local_session
 
 
+# Mock of Azure StorageAccount class
+class MockStorageAccount(object):
+    id = 1
+
+
 class AzurePolicyModeTest(BaseTest):
     def setUp(self):
         super(AzurePolicyModeTest, self).setUp()
@@ -220,19 +225,18 @@ class AzurePolicyModeTest(BaseTest):
                  'events': ['VmWrite']},
         })
 
-        with mock.patch(self._get_storage_account_namespace()) as storage_account:
-            storage_account.id = 1
-            with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
-                event_mode = AzureEventGridMode(p)
-                event_mode._create_event_subscription(storage_account, 'some_queue', None)
+        with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
+            storage_account = MockStorageAccount()
+            event_mode = AzureEventGridMode(p)
+            event_mode._create_event_subscription(storage_account, 'some_queue', None)
 
-                name, args, kwargs = mock_create.mock_calls[0]
+            name, args, kwargs = mock_create.mock_calls[0]
 
-                # verify the advanced filter created
-                event_filter = args[3].advanced_filters[0]
-                self.assertEqual(event_filter.key, 'Data.OperationName')
-                self.assertEqual(event_filter.values, ['Microsoft.Compute/virtualMachines/write'])
-                self.assertEqual(event_filter.operator_type, 'StringIn')
+            # verify the advanced filter created
+            event_filter = args[3].advanced_filters[0]
+            self.assertEqual(event_filter.key, 'Data.OperationName')
+            self.assertEqual(event_filter.values, ['Microsoft.Compute/virtualMachines/write'])
+            self.assertEqual(event_filter.operator_type, 'StringIn')
 
     def test_event_grid_mode_creates_advanced_filtered_subscription_with_multiple_events(self):
         p = self.load_policy({
@@ -247,25 +251,16 @@ class AzurePolicyModeTest(BaseTest):
                             }]},
         })
 
-        print(self._get_storage_account_namespace())
+        with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
+            storage_account = MockStorageAccount()
+            event_mode = AzureEventGridMode(p)
+            event_mode._create_event_subscription(storage_account, 'some_queue', None)
 
-        with mock.patch(self._get_storage_account_namespace()) as storage_account:
-            storage_account.id = 1
-            with mock.patch('c7n_azure.azure_events.AzureEventSubscription.create') as mock_create:
-                event_mode = AzureEventGridMode(p)
-                event_mode._create_event_subscription(storage_account, 'some_queue', None)
+            name, args, kwargs = mock_create.mock_calls[0]
 
-                name, args, kwargs = mock_create.mock_calls[0]
-
-                # verify the advanced filter created
-                event_filter = args[3].advanced_filters[0]
-                self.assertEqual(event_filter.key, 'Data.OperationName')
-                self.assertEqual(event_filter.values, ['Microsoft.Compute/virtualMachines/write',
-                                                       'Microsoft.Resources/subscriptions/resourceGroups/write'])
-                self.assertEqual(event_filter.operator_type, 'StringIn')
-
-    @staticmethod
-    def _get_storage_account_namespace():
-        client = local_session(Session) \
-            .client('azure.mgmt.storage.StorageManagementClient')
-        return 'azure.mgmt.storage.v' + client.DEFAULT_API_VERSION.replace('-', '_') + '.models.StorageAccount'
+            # verify the advanced filter created
+            event_filter = args[3].advanced_filters[0]
+            self.assertEqual(event_filter.key, 'Data.OperationName')
+            self.assertEqual(event_filter.values, ['Microsoft.Compute/virtualMachines/write',
+                                                   'Microsoft.Resources/subscriptions/resourceGroups/write'])
+            self.assertEqual(event_filter.operator_type, 'StringIn')


### PR DESCRIPTION
Fix #3079 

When the Event Grid Subscription is created, we will create an advanced filters based on the subscribed events in the policy.

@erwelch I chose to keep the additional filtering inside Custodian for now, because although Custodian setup the queue, it is open and I didn't want a policy to attempt to execute on an unexpected event type.