### PR TITLE
fix typo s33:GetAccountPublicAccessBlock

### DIFF
--- a/c7n/resources/account.py
+++ b/c7n/resources/account.py
@@ -1116,7 +1116,7 @@ class SetS3PublicBlock(BaseAction):
         BlockPublicPolicy={'type': 'boolean'},
         RestrictPublicBuckets={'type': 'boolean'})
 
-    permissions = ('s3:PutAccountPublicAccessBlock', 's33:GetAccountPublicAccessBlock')
+    permissions = ('s3:PutAccountPublicAccessBlock', 's3:GetAccountPublicAccessBlock')
 
     def validate(self):
         config = self.data.copy()


### PR DESCRIPTION
It seems this is typo 
https://github.com/capitalone/cloud-custodian/blob/master/c7n/resources/account.py#L1119
s33:GetAccountPublicAccessBlock -> s3:GetAccountPublicAccessBlock