### PR TITLE
update validate methods that checked for filter usage.

### DIFF
--- a/c7n/commands.py
+++ b/c7n/commands.py
@@ -75,7 +75,7 @@ def policy_command(f):
                 continue
             except ValueError as e:
                 log.error('problem loading policy file ({}) error: {}'.format(
-                    fp, e.message))
+                    fp, str(e)))
                 errors += 1
                 continue
 

--- a/c7n/filters/core.py
+++ b/c7n/filters/core.py
@@ -178,6 +178,18 @@ class Filter(object):
         """ Bulk process resources and return filtered set."""
         return list(filter(self, resources))
 
+    def get_block_operator(self):
+        block_stack = ['and']
+        for f in self.manager.iter_filters(block_end=True):
+            if f is None:
+                block_stack.pop()
+                continue
+            if f.type in ('and', 'or', 'not'):
+                block_stack.append(f.type)
+            if f == self:
+                break
+        return block_stack[-1]
+
 
 class BooleanGroupFilter(Filter):
 

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -116,11 +116,13 @@ class ResourceManager(object):
         """
         return self.query.resolve(self.resource_type)
 
-    def iter_filters(self):
+    def iter_filters(self, block_end=False):
         queue = deque(self.filters)
         while queue:
             f = queue.popleft()
-            if f.type in ('or', 'and', 'not'):
+            if f and f.type in ('or', 'and', 'not'):
+                if block_end:
+                    queue.appendleft(None)
                 for gf in f.filters:
                     queue.appendleft(gf)
             yield f

--- a/c7n/manager.py
+++ b/c7n/manager.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 from __future__ import absolute_import, division, print_function, unicode_literals
 
+from collections import deque
 import logging
 
 from c7n import cache
@@ -114,3 +115,12 @@ class ResourceManager(object):
         """Returns the resource meta-model.
         """
         return self.query.resolve(self.resource_type)
+
+    def iter_filters(self):
+        queue = deque(self.filters)
+        while queue:
+            f = queue.popleft()
+            if f.type in ('or', 'and', 'not'):
+                for gf in f.filters:
+                    queue.appendleft(gf)
+            yield f

--- a/c7n/resources/apigw.py
+++ b/c7n/resources/apigw.py
@@ -422,7 +422,7 @@ class UpdateRestMethod(BaseAction):
 
     def validate(self):
         found = False
-        for f in self.manager.filters:
+        for f in self.manager.iter_filters():
             if isinstance(f, FilterRestMethod):
                 found = True
                 break

--- a/c7n/resources/appelb.py
+++ b/c7n/resources/appelb.py
@@ -271,7 +271,7 @@ class SetWaf(BaseAction):
 
     def validate(self):
         found = False
-        for f in self.manager.filters:
+        for f in self.manager.iter_filters():
             if isinstance(f, WafEnabled):
                 found = True
                 break
@@ -691,8 +691,7 @@ class AppELBListenerFilter(ValueFilter, AppELBListenerFilterBase):
     def validate(self):
         if not self.data.get('matched'):
             return
-        listeners = [f for f in self.manager.filters
-                     if isinstance(f, self.__class__)]
+        listeners = list(self.manager.iter_filters())
         found = False
         for f in listeners[:listeners.index(self)]:
             if not f.data.get('matched', False):
@@ -755,8 +754,8 @@ class AppELBModifyListenerPolicy(BaseAction):
     permissions = ("elasticloadbalancing:ModifyListener",)
 
     def validate(self):
-        for f in self.manager.data.get('filters', ()):
-            if 'listener' in f.get('type', ()):
+        for f in self.manager.iter_filters():
+            if f.type == 'listener':
                 return self
         raise PolicyValidationError(
             "modify-listener action requires the listener filter %s" % (

--- a/c7n/resources/ebs.py
+++ b/c7n/resources/ebs.py
@@ -775,11 +775,6 @@ class EncryptInstanceVolumes(BaseAction):
         'ec2:DeleteTags')
 
     def validate(self):
-        key = self.data.get('key')
-        if not key:
-            raise ValueError(
-                "action:encrypt-instance-volume "
-                "requires kms keyid/alias specified")
         self.verbose = self.data.get('verbose', False)
         return self
 

--- a/c7n/resources/rds.py
+++ b/c7n/resources/rds.py
@@ -1086,7 +1086,7 @@ class RestoreInstance(BaseAction):
 
     def validate(self):
         found = False
-        for f in self.manager.filters:
+        for f in self.manager.iter_filters():
             if isinstance(f, LatestSnapshot):
                 found = True
         if not found:

--- a/c7n/resources/redshift.py
+++ b/c7n/resources/redshift.py
@@ -850,7 +850,7 @@ class RedshiftSnapshotRevokeAccess(BaseAction):
     schema = type_schema('revoke-access')
 
     def validate(self):
-        for f in self.manager.filters:
+        for f in self.manager.iter_filters():
             if isinstance(f, RedshiftSnapshotCrossAccount):
                 return self
         raise PolicyValidationError(

--- a/c7n/resources/route53.py
+++ b/c7n/resources/route53.py
@@ -287,7 +287,7 @@ class SetQueryLogging(BaseAction):
             # By forcing use of a filter we ensure both getting to right set of
             # resources as well avoiding an extra api call here, as we'll reuse
             # the annotation from the filter for logging config.
-            if not [f for f in self.manager.filters if isinstance(
+            if not [f for f in self.manager.iter_filters() if isinstance(
                     f, IsQueryLoggingEnabled)]:
                 raise ValueError(
                     "set-query-logging when deleting requires "

--- a/c7n/resources/vpc.py
+++ b/c7n/resources/vpc.py
@@ -500,7 +500,7 @@ class SecurityGroupApplyPatch(BaseAction):
                    'ec2:DeleteTags')
 
     def validate(self):
-        diff_filters = [n for n in self.manager.filters if isinstance(
+        diff_filters = [n for n in self.manager.iter_filters() if isinstance(
             n, SecurityGroupDiffFilter)]
         if not len(diff_filters):
             raise PolicyValidationError(

--- a/tests/test_manager.py
+++ b/tests/test_manager.py
@@ -14,6 +14,7 @@
 from __future__ import absolute_import, division, print_function, unicode_literals
 
 from c7n.ctx import ExecutionContext
+from c7n.filters import Filter
 from c7n.resources.ec2 import EC2
 from c7n.tags import Tag
 from .common import BaseTest, instance, Bag, TestConfig as Config
@@ -27,6 +28,51 @@ class TestEC2Manager(BaseTest):
                 {"name": "test-policy", 'provider_name': 'aws'}), config or Config.empty()
         )
         return EC2(ctx, data)
+
+    def test_manager_iter_filters(self):
+        p = self.load_policy({
+            'name': 'xyz',
+            'resource': 'aws.app-elb',
+            'filters': [
+                {'and': [
+                    {'type': 'listener',
+                     'key': 'Protocol',
+                     'value': 'HTTP'},
+                    {'type': 'listener',
+                     'key': 'DefaultActions[*].Type',
+                     'op': 'ni',
+                     'value_type': 'swap',
+                     'value': 'redirect',
+                     'matched': True}]}]})
+        self.assertEqual(
+            [f.type for f in p.resource_manager.iter_filters()],
+            ['and', 'listener', 'listener'])
+
+    def test_filter_get_block_op(self):
+        class F(Filter):
+            type = 'xyz'
+
+        p = self.load_policy({
+            'name': 'xyz',
+            'resource': 'ec2',
+            'filters': [
+                {'and': [{'or': []}]},
+                {'not': []},
+                {'or': []}
+            ]})
+
+        m = p.resource_manager
+        f = F({}, m)
+        m.filters.append(f)
+        self.assertEqual(f.get_block_operator(), 'and')
+
+        f = F({}, m)
+        m.filters[0].filters[0].filters.append(f)
+        self.assertEqual(f.get_block_operator(), 'or')
+
+        f = F({}, m)
+        m.filters[1].filters.append(f)
+        self.assertEqual(f.get_block_operator(), 'not')
 
     def test_get_resource_manager(self):
         p = self.load_policy(


### PR DESCRIPTION
update validate methods that checked for filter usage to be nesting aware, use utility methods on the resource manager for filter iteration, in particular this is needed for those validate methods when used in nested boolean groups to properly consider all other filters.

fixes #3195